### PR TITLE
Add Docker to get started

### DIFF
--- a/modules/guides/pages/getting_started.adoc
+++ b/modules/guides/pages/getting_started.adoc
@@ -21,14 +21,29 @@ include::ROOT:get-started:partial$install-rpk-linux.adoc[]
 
 include::ROOT:get-started:partial$install-rpk-macos.adoc[]
 
+=== Docker
+
+To use `rpk` in Docker, you can use the Redpanda Docker image, which includes both Redpanda and `rpk` as part of the installation.
+
+[source,bash]
+----
+docker pull docker.redpanda.com/redpandadata/redpanda
+----
+
 == Run
 
 A {page-component-title} stream pipeline is configured with a single xref:configuration:about.adoc[config file], you can generate a fresh one with:
 
-
 [,bash,subs="attributes+"]
 ----
 rpk connect create > connect.yaml
+----
+
+For Docker installations:
+
+[,bash]
+----
+docker run --rm docker.redpanda.com/redpandadata/redpanda connect create > ./connect.yaml
 ----
 
 The main sections that make up a config are `input`, `pipeline` and `output`. When you generate a fresh config it'll simply pipe `stdin` to `stdout` like this:
@@ -50,6 +65,13 @@ Eventually we'll want to configure a more useful xref:components:inputs/about.ad
 [,bash,subs="attributes+"]
 ----
 {rpk-command} connect.yaml
+----
+
+For Docker installations:
+
+[,bash]
+----
+docker run --rm -v $(pwd)/connect.yaml:/connect.yaml docker.redpanda.com/redpandadata/redpanda connect run
 ----
 
 Anything you write to stdin will get written unchanged to stdout, cool! Resist the temptation to play with this for hours, there's more stuff to try out.
@@ -99,6 +121,14 @@ Try running that config with some sample documents:
 ----
 echo '{"id":"1","names":["celine","dion"]}
 {"id":"2","names":["chad","robert","kroeger"]}' | {rpk-command} connect.yaml
+----
+
+For Docker installations:
+
+[,bash]
+----
+echo '{"id":"1","names":["celine","dion"]}
+{"id":"2","names":["chad","robert","kroeger"]}' | docker run --rm -i -v $(pwd)/connect.yaml:/connect.yaml docker.redpanda.com/redpandadata/redpanda connect run
 ----
 
 You should see this output in the logs:


### PR DESCRIPTION
Users can pull the Redpanda Docker image, which comes with `rpk` in order to run Redpanda Connect with `rpk connect`.