### PR TITLE
Point S3 input documentation to scanner instead of codec

### DIFF
--- a/modules/components/pages/inputs/aws_s3.adoc
+++ b/modules/components/pages/inputs/aws_s3.adoc
@@ -92,7 +92,7 @@ When using SQS please make sure you have sensible values for `sqs.max_messages` 
 
 == Download large files
 
-When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. In order to do this a <<codec, `codec`>> can be specified that determines how to break the input into smaller individual messages.
+When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. In order to do this a <<scanner, `scanner`>> can be specified that determines how to break the input into smaller individual messages.
 
 == Credentials
 

--- a/modules/components/pages/inputs/aws_s3.adoc
+++ b/modules/components/pages/inputs/aws_s3.adoc
@@ -92,7 +92,7 @@ When using SQS please make sure you have sensible values for `sqs.max_messages` 
 
 == Download large files
 
-When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. In order to do this a <<scanner, `scanner`>> can be specified that determines how to break the input into smaller individual messages.
+When downloading large files it's often necessary to process it in streamed parts in order to avoid loading the entire file in memory at a given time. To do this, a <<scanner, `scanner`>> can be specified, which determines how to break the input into smaller individual messages.
 
 == Credentials
 


### PR DESCRIPTION
## Description

Fix originally applied in https://github.com/redpanda-data/connect/pull/2603

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)