### PR TITLE
Fix `rpk connect` commands

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,7 +6,6 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    rpk-command: rpk connect run
     project-github: redpanda-data/connect
     # Fallback for the version of Redpanda
     # used for things like rpk download URLs

--- a/modules/configuration/pages/about.adoc
+++ b/modules/configuration/pages/about.adoc
@@ -242,7 +242,7 @@ If, for example, we wanted to generate a config with a websocket input, a Kafka 
 rpk connect create websocket/mapping/kafka
 ----
 
-TIP: To see which components {page-component-title} offers, use `rpk connect run list`.
+TIP: To see which components {page-component-title} offers, use `rpk connect list`.
 
 All of these generated configuration examples also include other useful config sections such as `metrics`, `logging`, etc with sensible defaults.
 

--- a/modules/configuration/pages/about.adoc
+++ b/modules/configuration/pages/about.adoc
@@ -178,17 +178,17 @@ We can select our chosen resource by changing which file we import, either runni
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r ./staging/request.yaml -c ./config.yaml
+rpk connect run -r ./staging/request.yaml -c ./config.yaml
 ----
 
 Or:
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r ./production/request.yaml -c ./config.yaml
+rpk connect run -r ./production/request.yaml -c ./config.yaml
 ----
 
-These flags also support wildcards, which allows you to import an entire directory of resource files like `{rpk-command} -r "./staging/*.yaml" -c ./config.yaml`. You can find out more about configuration resources in the xref:configuration:resources.adoc[resources document].
+These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" -c ./config.yaml`. You can find out more about configuration resources in the xref:configuration:resources.adoc[resources document].
 
 === Templating
 
@@ -203,13 +203,13 @@ It's possible to have a running instance of {page-component-title} reload config
 [,bash,subs="attributes+"]
 ----
 # Normal mode
-{rpk-command} -w -r ./production/request.yaml -c ./config.yaml
+rpk connect run -w -r ./production/request.yaml -c ./config.yaml
 ----
 
 [,bash,subs="attributes+"]
 ----
 # Streams mode
-{rpk-command} -w -r ./production/request.yaml streams ./stream_configs/*.yaml
+rpk connect run -w -r ./production/request.yaml streams ./stream_configs/*.yaml
 ----
 
 If a file update results in configuration parsing or linting errors then the change is ignored (with logs informing you of the problem) and the previous configuration will continue to be run (until the issues are fixed).
@@ -239,14 +239,14 @@ If, for example, we wanted to generate a config with a websocket input, a Kafka 
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} create websocket/mapping/kafka
+rpk connect create websocket/mapping/kafka
 ----
 
-TIP: To see which components {page-component-title} offers, use `{rpk-command} list`.
+TIP: To see which components {page-component-title} offers, use `rpk connect run list`.
 
 All of these generated configuration examples also include other useful config sections such as `metrics`, `logging`, etc with sensible defaults.
 
-For more information read the output from `{rpk-command} create --help`.
+For more information read the output from `rpk connect create --help`.
 
 == Help with debugging
 
@@ -271,11 +271,11 @@ We can catch this error before attempting to run the config:
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} lint ./foo.yaml
+rpk connect lint ./foo.yaml
 ./foo.yaml: line 3: field yourl not recognized
 ----
 
-For more information read the output from `{rpk-command} lint --help`.
+For more information read the output from `rpk connect lint --help`.
 
 === Echoing
 
@@ -283,7 +283,7 @@ Echoing is where {page-component-title} can print back your configuration _after
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -c ./your-config.yaml echo
+rpk connect run -c ./your-config.yaml echo
 ----
 
 You can check the output of the above command to see if certain sections are missing or fields are incorrect, which allows you to pinpoint typos in the config.

--- a/modules/configuration/pages/interpolation.adoc
+++ b/modules/configuration/pages/interpolation.adoc
@@ -13,7 +13,7 @@ input:
 
 [,sh,subs="attributes+"]
 ----
-BROKERS="foo:9092,bar:9092" {rpk-command} -c ./config.yaml
+BROKERS="foo:9092,bar:9092" rpk connect run -c ./config.yaml
 ----
 
 If a literal string is required that matches this pattern (`+${foo}+`) you can escape it with double brackets. For example, the string `+${{foo}}+` is read as the literal `+${foo}+`.

--- a/modules/configuration/pages/resources.adoc
+++ b/modules/configuration/pages/resources.adoc
@@ -97,7 +97,7 @@ processor_resources:
         Desires: "are-empty"
 ----
 
-Then when you execute {page-component-title} use the environment variable to choose your resource: `FEATURE_REQUEST=get_foo {rpk-command} -c ./your_config.yaml`.
+Then when you execute {page-component-title} use the environment variable to choose your resource: `FEATURE_REQUEST=get_foo rpk connect run -c ./your_config.yaml`.
 
 === With imports
 
@@ -141,14 +141,14 @@ We can select our chosen resource by changing which file we import, either runni
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r ./staging/request.yaml -c ./config.yaml
+rpk connect run -r ./staging/request.yaml -c ./config.yaml
 ----
 
 Or:
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r ./production/request.yaml -c ./config.yaml
+rpk connect run -r ./production/request.yaml -c ./config.yaml
 ----
 
-These flags also support wildcards, which allows you to import an entire directory of resource files like `{rpk-command} -r "./staging/*.yaml" -c ./config.yaml`.
+These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" -c ./config.yaml`.

--- a/modules/configuration/pages/secrets.adoc
+++ b/modules/configuration/pages/secrets.adoc
@@ -34,7 +34,7 @@ And we wanted to set the value of `super_secret` to a value stored within someth
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -c ./config.yaml \
+rpk connect run -c ./config.yaml \
   --set "thing.super_secret=`vault kv get -mount=secret thing_secret`"
 ----
 
@@ -44,4 +44,4 @@ Using this method we can inject the secret into the config without "leaking" it 
 
 There are a few ways in which configs parsed by {page-component-title} can be exported back out of the service. In all of these cases {page-component-title} will attempt to scrub any field values within the config that are known secrets (any field marked as a secret in the docs).
 
-However, if you're embedding secrets within a config outside of the value of secret fields, maybe as part of a Bloblang mapping, then care should be made to avoid exposing the resulting config. This specifically means you should not enable xref:components:http/about.adoc#debug-endpoints[debug HTTP endpoints] when the port is exposed, and don't use the `{rpk-command} echo` subcommand on configs containing secrets unless you're printing to a secure pipe.
+However, if you're embedding secrets within a config outside of the value of secret fields, maybe as part of a Bloblang mapping, then care should be made to avoid exposing the resulting config. This specifically means you should not enable xref:components:http/about.adoc#debug-endpoints[debug HTTP endpoints] when the port is exposed, and don't use the `rpk connect run echo` subcommand on configs containing secrets unless you're printing to a secure pipe.

--- a/modules/configuration/pages/templating.adoc
+++ b/modules/configuration/pages/templating.adoc
@@ -291,7 +291,7 @@ metrics_mapping: |-
 
 === `tests`
 
-Optional unit test definitions for the template that verify certain configurations produce valid configs. These tests are executed with the command `rpk connect run template lint`.
+Optional unit test definitions for the template that verify certain configurations produce valid configs. These tests are executed with the command `rpk connect template lint`.
 
 
 *Type*: list of `object`

--- a/modules/configuration/pages/templating.adoc
+++ b/modules/configuration/pages/templating.adoc
@@ -19,7 +19,7 @@ A template is defined in a YAML file that can be imported when {page-component-t
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -t "./templates/*.yaml" -c ./config.yaml
+rpk connect run -t "./templates/*.yaml" -c ./config.yaml
 ----
 
 The template describes the type of the component and configuration fields that can be used to customize it, followed by a xref:guides:bloblang/about.adoc[Bloblang mapping] that translates an object containing those fields into a {page-component-title} config structure. This allows you to use logic to generate more complex configurations:
@@ -291,7 +291,7 @@ metrics_mapping: |-
 
 === `tests`
 
-Optional unit test definitions for the template that verify certain configurations produce valid configs. These tests are executed with the command `{rpk-command} template lint`.
+Optional unit test definitions for the template that verify certain configurations produce valid configs. These tests are executed with the command `rpk connect run template lint`.
 
 
 *Type*: list of `object`

--- a/modules/configuration/pages/unit_testing.adoc
+++ b/modules/configuration/pages/unit_testing.adoc
@@ -11,7 +11,7 @@
      internal/config/test/docs.adoc
 ////
 
-The {page-component-title} service offers a command `{rpk-command} test` for running unit tests on sections of a configuration file. This makes it easy to protect your config files from regressions over time.
+The {page-component-title} service offers a command `rpk connect run test` for running unit tests on sections of a configuration file. This makes it easy to protect your config files from regressions over time.
 
 == Writing a test
 
@@ -105,7 +105,7 @@ tests:
         - json_equals: {"Cities": "Bellevue, Olympia, Seattle"}
 ```
 
-And execute this test the same way we execute other {page-component-title} tests (`{rpk-command} test ./dir/cities_test.yaml`, `{rpk-command} test ./dir/...`, etc).
+And execute this test the same way we execute other {page-component-title} tests (`rpk connect run test ./dir/cities_test.yaml`, `rpk connect run test ./dir/...`, etc).
 
 === Fragmented tests
 
@@ -233,12 +233,12 @@ Checks that both the message and the condition are valid JSON documents, and tha
 
 == Running tests
 
-Executing tests for a specific config can be done by pointing the subcommand `test` at either the config to be tested or its test definition, e.g. `{rpk-command} test ./config.yaml` and `{rpk-command} test ./config_benthos_test.yaml` are equivalent.
+Executing tests for a specific config can be done by pointing the subcommand `test` at either the config to be tested or its test definition, e.g. `rpk connect run test ./config.yaml` and `rpk connect run test ./config_benthos_test.yaml` are equivalent.
 
-The `test` subcommand also supports wildcard patterns e.g. `{rpk-command} test ./foo/*.yaml` will execute all tests within matching files. In order to walk a directory tree and execute all tests found you can use the shortcut `./...`, e.g. `{rpk-command} test ./...` will execute all tests found in the current directory, any child directories, and so on.
+The `test` subcommand also supports wildcard patterns e.g. `rpk connect run test ./foo/*.yaml` will execute all tests within matching files. In order to walk a directory tree and execute all tests found you can use the shortcut `./...`, e.g. `rpk connect run test ./...` will execute all tests found in the current directory, any child directories, and so on.
 
 If you want to allow components to write logs at a provided level to stdout when running the tests, you can use
-`{rpk-command} test --log <level>`. Please consult the {logger-url}[logger docs] for further details.
+`rpk connect run test --log <level>`. Please consult the {logger-url}[logger docs] for further details.
 
 == Mocking processors
 

--- a/modules/configuration/pages/unit_testing.adoc
+++ b/modules/configuration/pages/unit_testing.adoc
@@ -11,7 +11,7 @@
      internal/config/test/docs.adoc
 ////
 
-The {page-component-title} service offers a command `rpk connect run test` for running unit tests on sections of a configuration file. This makes it easy to protect your config files from regressions over time.
+The {page-component-title} service offers a command `rpk connect test` for running unit tests on sections of a configuration file. This makes it easy to protect your config files from regressions over time.
 
 == Writing a test
 
@@ -105,7 +105,7 @@ tests:
         - json_equals: {"Cities": "Bellevue, Olympia, Seattle"}
 ```
 
-And execute this test the same way we execute other {page-component-title} tests (`rpk connect run test ./dir/cities_test.yaml`, `rpk connect run test ./dir/...`, etc).
+And execute this test the same way we execute other {page-component-title} tests (`rpk connect test ./dir/cities_test.yaml`, `rpk connect test ./dir/...`, etc).
 
 === Fragmented tests
 
@@ -233,12 +233,12 @@ Checks that both the message and the condition are valid JSON documents, and tha
 
 == Running tests
 
-Executing tests for a specific config can be done by pointing the subcommand `test` at either the config to be tested or its test definition, e.g. `rpk connect run test ./config.yaml` and `rpk connect run test ./config_benthos_test.yaml` are equivalent.
+Executing tests for a specific config can be done by pointing the subcommand `test` at either the config to be tested or its test definition, e.g. `rpk connect test ./config.yaml` and `rpk connect test ./config_benthos_test.yaml` are equivalent.
 
-The `test` subcommand also supports wildcard patterns e.g. `rpk connect run test ./foo/*.yaml` will execute all tests within matching files. In order to walk a directory tree and execute all tests found you can use the shortcut `./...`, e.g. `rpk connect run test ./...` will execute all tests found in the current directory, any child directories, and so on.
+The `test` subcommand also supports wildcard patterns e.g. `rpk connect test ./foo/*.yaml` will execute all tests within matching files. In order to walk a directory tree and execute all tests found you can use the shortcut `./...`, e.g. `rpk connect test ./...` will execute all tests found in the current directory, any child directories, and so on.
 
 If you want to allow components to write logs at a provided level to stdout when running the tests, you can use
-`rpk connect run test --log <level>`. Please consult the {logger-url}[logger docs] for further details.
+`rpk connect test --log <level>`. Please consult the {logger-url}[logger docs] for further details.
 
 == Mocking processors
 

--- a/modules/configuration/pages/using_cue.adoc
+++ b/modules/configuration/pages/using_cue.adoc
@@ -27,12 +27,12 @@ ____
 CUE modules must start with a hostname. This will typically be the URL of your repository. For example: `cue mod init github.com/redpanda-data/hello-cue`.
 ____
 
-The `rpk connect run list` command will generate a CUE package containing the types we'll need to build our configuration. Let's write this package into our project:
+The `rpk connect list` command will generate a CUE package containing the types we'll need to build our configuration. Let's write this package into our project:
 
 [,bash,subs="attributes+"]
 ----
 mkdir benthos
-rpk connect run list --format cue > benthos/schema.cue
+rpk connect list --format cue > benthos/schema.cue
 ----
 
 At this point, you should now have the following directory structure:

--- a/modules/configuration/pages/using_cue.adoc
+++ b/modules/configuration/pages/using_cue.adoc
@@ -27,12 +27,12 @@ ____
 CUE modules must start with a hostname. This will typically be the URL of your repository. For example: `cue mod init github.com/redpanda-data/hello-cue`.
 ____
 
-The `{rpk-command} list` command will generate a CUE package containing the types we'll need to build our configuration. Let's write this package into our project:
+The `rpk connect run list` command will generate a CUE package containing the types we'll need to build our configuration. Let's write this package into our project:
 
 [,bash,subs="attributes+"]
 ----
 mkdir benthos
-{rpk-command} list --format cue > benthos/schema.cue
+rpk connect run list --format cue > benthos/schema.cue
 ----
 
 At this point, you should now have the following directory structure:
@@ -109,7 +109,7 @@ We can run this with {page-component-title} to see that it indeed works:
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -c <(cue export --out yaml config.cue)
+rpk connect run -c <(cue export --out yaml config.cue)
 ----
 
 When you are satisfied with the results, terminate the {page-component-title} process and let's move on to look at some of the nice features that we get with CUE.

--- a/modules/cookbooks/pages/discord_bot.adoc
+++ b/modules/cookbooks/pages/discord_bot.adoc
@@ -35,7 +35,7 @@ If you were to run this config (setting the channel and bot token as env vars in
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -e testing.env -c ./config.yaml
+rpk connect run -e testing.env -c ./config.yaml
 {"content":"so i like totally just tripped over my own network cables","author":{"id":"1234"}}
 {"content":"like omg that is SO you!!!","author":{"id":"4321"}}
 {"content":"yas totally","author":{"id":"1234"}}

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -10,7 +10,7 @@ You can also execute Bloblang mappings on the command-line with the `blobl` subc
 
 [,shell]
 ----
-cat data.jsonl | rpk connect run blobl 'foo.(bar | baz).buz'
+cat data.jsonl | rpk connect blobl 'foo.(bar | baz).buz'
 ----
 
 This document outlines the core features of the Bloblang language, but if you're totally new to Bloblang then it's worth following xref:guides:bloblang/walkthrough.adoc[the walkthrough first].
@@ -432,8 +432,8 @@ It's possible to execute unit tests for your Bloblang mappings using the standar
 
 == Troubleshooting
 
-. I'm seeing `unable to reference message as structured (with 'this')` when I try to run mappings with `rpk connect run blobl`.
+. I'm seeing `unable to reference message as structured (with 'this')` when I try to run mappings with `rpk connect blobl`.
 
-That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents _do not_ contain line breaks as `rpk connect run blobl` will parse each line individually.
+That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents _do not_ contain line breaks as `rpk connect blobl` will parse each line individually.
 
 Why? That's a good question. Bloblang supports non-JSON formats too, so it can't delimit documents with a streaming JSON parser like tools such as `jq`, so instead it uses line breaks to determine the boundaries of each message.

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -10,7 +10,7 @@ You can also execute Bloblang mappings on the command-line with the `blobl` subc
 
 [,shell]
 ----
-cat data.jsonl | {rpk-command} blobl 'foo.(bar | baz).buz'
+cat data.jsonl | rpk connect run blobl 'foo.(bar | baz).buz'
 ----
 
 This document outlines the core features of the Bloblang language, but if you're totally new to Bloblang then it's worth following xref:guides:bloblang/walkthrough.adoc[the walkthrough first].
@@ -432,8 +432,8 @@ It's possible to execute unit tests for your Bloblang mappings using the standar
 
 == Troubleshooting
 
-. I'm seeing `unable to reference message as structured (with 'this')` when I try to run mappings with `{rpk-command} blobl`.
+. I'm seeing `unable to reference message as structured (with 'this')` when I try to run mappings with `rpk connect run blobl`.
 
-That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents _do not_ contain line breaks as `{rpk-command} blobl` will parse each line individually.
+That particular error message means the mapping is failing to parse what's being fed in as a JSON document. Make sure that the data you are feeding in is valid JSON, and also that the documents _do not_ contain line breaks as `rpk connect run blobl` will parse each line individually.
 
 Why? That's a good question. Bloblang supports non-JSON formats too, so it can't delimit documents with a streaming JSON parser like tools such as `jq`, so instead it uses line breaks to determine the boundaries of each message.

--- a/modules/guides/pages/bloblang/walkthrough.adoc
+++ b/modules/guides/pages/bloblang/walkthrough.adoc
@@ -4,7 +4,7 @@
 
 Bloblang is the most advanced mapping language that you'll learn from this walkthrough (probably). It is designed for readability, the power to shape even the most outrageous input documents, and to easily make erratic schemas bend to your will. Bloblang is the native mapping language of {page-component-title}, but it has been designed as a general purpose technology ready to be adopted by other tools.
 
-In this walkthrough you'll learn how to make new friends by mapping their documents, and lose old friends as they grow jealous and bitter of your mapping abilities. There are a few ways to execute Bloblang but the way we'll do it in this guide is to pull a {page-component-title} docker image and run the command `{rpk-command} blobl server`, which opens up an interactive Bloblang editor:
+In this walkthrough you'll learn how to make new friends by mapping their documents, and lose old friends as they grow jealous and bitter of your mapping abilities. There are a few ways to execute Bloblang but the way we'll do it in this guide is to pull a {page-component-title} docker image and run the command `rpk connect run blobl server`, which opens up an interactive Bloblang editor:
 
 [source,sh,subs="attributes+"]
 ----
@@ -759,7 +759,7 @@ tests:
 
 As you can see we've defined a single test, where we point to our mapping file which will be executed in our test. We then specify an input message which is a reduced version of the document we tried out before, and finally we specify output predicates, which is a JSON comparison against the output document.
 
-We can execute these tests with `{rpk-command} test ./naughty_man_test.yaml`, {page-component-title} will also automatically find our tests if you simply run `{rpk-command} test ./...`. You should see an output something like:
+We can execute these tests with `rpk connect run test ./naughty_man_test.yaml`, {page-component-title} will also automatically find our tests if you simply run `rpk connect run test ./...`. You should see an output something like:
 
 [source,text]
 ----

--- a/modules/guides/pages/bloblang/walkthrough.adoc
+++ b/modules/guides/pages/bloblang/walkthrough.adoc
@@ -4,7 +4,7 @@
 
 Bloblang is the most advanced mapping language that you'll learn from this walkthrough (probably). It is designed for readability, the power to shape even the most outrageous input documents, and to easily make erratic schemas bend to your will. Bloblang is the native mapping language of {page-component-title}, but it has been designed as a general purpose technology ready to be adopted by other tools.
 
-In this walkthrough you'll learn how to make new friends by mapping their documents, and lose old friends as they grow jealous and bitter of your mapping abilities. There are a few ways to execute Bloblang but the way we'll do it in this guide is to pull a {page-component-title} docker image and run the command `rpk connect run blobl server`, which opens up an interactive Bloblang editor:
+In this walkthrough you'll learn how to make new friends by mapping their documents, and lose old friends as they grow jealous and bitter of your mapping abilities. There are a few ways to execute Bloblang but the way we'll do it in this guide is to pull a {page-component-title} docker image and run the command `rpk connect blobl server`, which opens up an interactive Bloblang editor:
 
 [source,sh,subs="attributes+"]
 ----
@@ -759,7 +759,7 @@ tests:
 
 As you can see we've defined a single test, where we point to our mapping file which will be executed in our test. We then specify an input message which is a reduced version of the document we tried out before, and finally we specify output predicates, which is a JSON comparison against the output document.
 
-We can execute these tests with `rpk connect run test ./naughty_man_test.yaml`, {page-component-title} will also automatically find our tests if you simply run `rpk connect run test ./...`. You should see an output something like:
+We can execute these tests with `rpk connect test ./naughty_man_test.yaml`, {page-component-title} will also automatically find our tests if you simply run `rpk connect test ./...`. You should see an output something like:
 
 [source,text]
 ----

--- a/modules/guides/pages/getting_started.adoc
+++ b/modules/guides/pages/getting_started.adoc
@@ -64,7 +64,7 @@ Eventually we'll want to configure a more useful xref:components:inputs/about.ad
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} connect.yaml
+rpk connect run connect.yaml
 ----
 
 For Docker installations:
@@ -120,7 +120,7 @@ Try running that config with some sample documents:
 [,bash,subs="attributes+"]
 ----
 echo '{"id":"1","names":["celine","dion"]}
-{"id":"2","names":["chad","robert","kroeger"]}' | {rpk-command} connect.yaml
+{"id":"2","names":["chad","robert","kroeger"]}' | rpk connect run connect.yaml
 ----
 
 For Docker installations:

--- a/modules/guides/pages/streams_mode/about.adoc
+++ b/modules/guides/pages/streams_mode/about.adoc
@@ -17,7 +17,7 @@ You can import resources either in the general configuration, or using the `-r`/
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r "./prod/*.yaml" -c ./config.yaml streams
+rpk connect run -r "./prod/*.yaml" -c ./config.yaml streams
 ----
 
 == HTTP endpoints
@@ -36,7 +36,7 @@ output:
   sync_response: {}
 ----
 
-Will register an endpoint `/meow`, which will be prefixed with the name `foo` to become `/foo/meow`. This behavior is intended to make a clearer distinction between endpoints registered by different streams, and prevent collisions of those endpoints. However, you can disable this behavior by setting the flag `--prefix-stream-endpoints` to `false` (`{rpk-command} streams --prefix-stream-endpoints=false ./streams/*.yaml`).
+Will register an endpoint `/meow`, which will be prefixed with the name `foo` to become `/foo/meow`. This behavior is intended to make a clearer distinction between endpoints registered by different streams, and prevent collisions of those endpoints. However, you can disable this behavior by setting the flag `--prefix-stream-endpoints` to `false` (`rpk connect run streams --prefix-stream-endpoints=false ./streams/*.yaml`).
 
 == Resources
 

--- a/modules/guides/pages/streams_mode/about.adoc
+++ b/modules/guides/pages/streams_mode/about.adoc
@@ -36,7 +36,7 @@ output:
   sync_response: {}
 ----
 
-Will register an endpoint `/meow`, which will be prefixed with the name `foo` to become `/foo/meow`. This behavior is intended to make a clearer distinction between endpoints registered by different streams, and prevent collisions of those endpoints. However, you can disable this behavior by setting the flag `--prefix-stream-endpoints` to `false` (`rpk connect run streams --prefix-stream-endpoints=false ./streams/*.yaml`).
+Will register an endpoint `/meow`, which will be prefixed with the name `foo` to become `/foo/meow`. This behavior is intended to make a clearer distinction between endpoints registered by different streams, and prevent collisions of those endpoints. However, you can disable this behavior by setting the flag `--prefix-stream-endpoints` to `false` (`rpk connect streams --prefix-stream-endpoints=false ./streams/*.yaml`).
 
 == Resources
 

--- a/modules/guides/pages/streams_mode/using_config_files.adoc
+++ b/modules/guides/pages/streams_mode/using_config_files.adoc
@@ -4,7 +4,7 @@ When running {page-component-title} in `streams` mode it's possible to create st
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} streams ./foo.yaml ./configs/*.yaml
+rpk connect run streams ./foo.yaml ./configs/*.yaml
 ----
 
 == Resources
@@ -13,7 +13,7 @@ A stream configuration should only include the base stream component fields (`in
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} -r "./resources/prod/*.yaml" streams ./stream_configs/*.yaml
+rpk connect run -r "./resources/prod/*.yaml" streams ./stream_configs/*.yaml
 ----
 
 == Walkthrough
@@ -57,7 +57,7 @@ Run {page-component-title} in streams mode, pointing to our directory of streams
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} streams ./streams/*.yaml
+rpk connect run streams ./streams/*.yaml
 ----
 
 On a separate terminal you can query the set of streams loaded:

--- a/modules/guides/pages/streams_mode/using_config_files.adoc
+++ b/modules/guides/pages/streams_mode/using_config_files.adoc
@@ -4,7 +4,7 @@ When running {page-component-title} in `streams` mode it's possible to create st
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run streams ./foo.yaml ./configs/*.yaml
+rpk connect streams ./foo.yaml ./configs/*.yaml
 ----
 
 == Resources
@@ -57,7 +57,7 @@ Run {page-component-title} in streams mode, pointing to our directory of streams
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run streams ./streams/*.yaml
+rpk connect streams ./streams/*.yaml
 ----
 
 On a separate terminal you can query the set of streams loaded:

--- a/modules/guides/pages/streams_mode/using_rest_api.adoc
+++ b/modules/guides/pages/streams_mode/using_rest_api.adoc
@@ -10,7 +10,7 @@ Start by running {page-component-title} in streams mode:
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run streams
+rpk connect streams
 ----
 
 On a separate terminal we can add our first stream `foo` by ``POST``ing a JSON or YAML config to the `/streams/foo` endpoint:

--- a/modules/guides/pages/streams_mode/using_rest_api.adoc
+++ b/modules/guides/pages/streams_mode/using_rest_api.adoc
@@ -10,7 +10,7 @@ Start by running {page-component-title} in streams mode:
 
 [,bash,subs="attributes+"]
 ----
-{rpk-command} streams
+rpk connect run streams
 ----
 
 On a separate terminal we can add our first stream `foo` by ``POST``ing a JSON or YAML config to the `/streams/foo` endpoint:


### PR DESCRIPTION
## Description

Fixes #8

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)