### PR TITLE
Use interactive mode in Docker command

### DIFF
--- a/modules/guides/pages/getting_started.adoc
+++ b/modules/guides/pages/getting_started.adoc
@@ -71,7 +71,7 @@ For Docker installations:
 
 [,bash]
 ----
-docker run --rm -v $(pwd)/connect.yaml:/connect.yaml docker.redpanda.com/redpandadata/redpanda connect run
+docker run --rm -it -v $(pwd)/connect.yaml:/connect.yaml docker.redpanda.com/redpandadata/redpanda connect run
 ----
 
 Anything you write to stdin will get written unchanged to stdout, cool! Resist the temptation to play with this for hours, there's more stuff to try out.


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2531
Review deadline: 12 June

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)