### PR TITLE
Add enterprise connectors

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -194,6 +194,10 @@ asciidoc:
         name: "LRU"
       - key: "noop"
         name: "Noop"
+    # Defines the connectors that are marked 'enterprise'.
+    enterprise-components:
+      - "splunk_hec"
+      - "snowflake_put"
     # Defines the connectors that are marked 'certified'.
     # This list is a temporary solution until each connector's source code includes the correct support level information. https://github.com/redpanda-data/benthos/pull/21/commits/aba447436e44faf7d4279d3394d82084ea0ed1e1#diff-26839711b0903fcf81e360ea17690bd67eb5e924cbabb62ffe85202c98c2a0a6
     certified-components:
@@ -221,6 +225,8 @@ asciidoc:
         types: ["processor"]
       - name: "cached"
         types: ["processor"]
+      - name: "command"
+        types: ["processor"]
       - name: "compress"
         types: ["processor"]
       - name: "csv"
@@ -229,6 +235,8 @@ asciidoc:
         types: ["processor"]
       - name: "dedupe"
         types: ["processor"]
+      - name: "file"
+        types: ["input","output"]
       - name: "generate"
         types: ["input"]
       - name: "group_by"
@@ -239,6 +247,10 @@ asciidoc:
         types: ["processor"]
       - name: "http_client"
         types: ["input", "output"]
+      - name: "http_server"
+        types: ["input", "output"]
+      - name: "javascript"
+        types: ["processor"]
       - name: "jmespath"
         types: ["processor"]
       - name: "jq"

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.5.0.tgz",
-      "integrity": "sha512-nYWkQMTU8gADF0SLbHm8ZLPNmBS4i8nEIq0wnba9HNVVl1XuXGClOBRtzaOPzQyO/ON5T5MLACRHdMZ16nJGYQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.5.1.tgz",
+      "integrity": "sha512-WBW93YdZhsdrBbbZU4aUYVBohWfXd1GMXmJ65OoCJBjAWuieKabC1QXWM9UqdDGYhFbSjebXwO/0raQW0x56Gg==",
       "dependencies": {
         "@octokit/plugin-retry": "~4.1.3",
         "@octokit/rest": "~19.0.7",


### PR DESCRIPTION
## Description

Requires this to merged first https://github.com/redpanda-data/docs-extensions-and-macros/pull/55

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)