### PR TITLE
Document Bloblang `from` statement

### DIFF
--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -361,7 +361,7 @@ root.bar = this.value_two.apply("things")
 
 Within a map the keyword `root` refers to a newly created document that will replace the target of the map, and `this` refers to the original value of the target. The argument of `apply` is a string, which allows you to dynamically resolve the mapping to apply.
 
-== Import maps
+== Import maps or Mappings
 
 It's possible to import maps defined in a file with an `import` statement:
 
@@ -373,7 +373,14 @@ root.foo = this.value_one.apply("things")
 root.bar = this.value_two.apply("things")
 ----
 
-Imports from a Bloblang mapping within a {page-component-title} config are relative to the process running the config. Imports from an imported file are relative to the file that is importing it.
+Additionally, you can use the `from` statement to import an entire mapping:
+
+[source,coffeescript]
+----
+from "./mapping.blobl"
+----
+
+The files referenced by both `import` and `from` in a Bloblang mapping within a {page-component-title} config are relative to the process running the config. Imports from an imported file are relative to the file that is importing it.
 
 == Filtering
 


### PR DESCRIPTION
## Description

Document the Bloblang `from` statement which can be used to import an entire mapping from a file.

This is a rebase of https://github.com/redpanda-data/connect/pull/2586.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)