### PR TITLE
#2533 RP Connect redirects

### DIFF
--- a/modules/ROOT/pages/about.adoc
+++ b/modules/ROOT/pages/about.adoc
@@ -1,4 +1,5 @@
 = Introduction to {page-component-title}
+:page-aliases: guides:delivery_guarantee.adoc, redpanda:current:reference:connect.adoc
 
 {page-component-title} is a declarative data streaming service that solves a wide range of data engineering problems with simple, chained, stateless xref:components:processors/about.adoc[processing steps]. It implements transaction based resiliency with back pressure, so when connecting to at-least-once sources and sinks it's able to guarantee at-least-once delivery without needing to persist messages during transit.
 

--- a/modules/ROOT/pages/about.adoc
+++ b/modules/ROOT/pages/about.adoc
@@ -1,5 +1,5 @@
 = Introduction to {page-component-title}
-:page-aliases: guides:delivery_guarantee.adoc, redpanda:current:reference:connect.adoc
+:page-aliases: guides:delivery_guarantee.adoc
 
 {page-component-title} is a declarative data streaming service that solves a wide range of data engineering problems with simple, chained, stateless xref:components:processors/about.adoc[processing steps]. It implements transaction based resiliency with back pressure, so when connecting to at-least-once sources and sinks it's able to guarantee at-least-once delivery without needing to persist messages during transit.
 

--- a/modules/components/pages/about.adoc
+++ b/modules/components/pages/about.adoc
@@ -1,5 +1,6 @@
 = Components
 :description: Learn about components.
+:page-aliases: ROOT:components.adoc, components:conditions.adoc 
 
 Every {page-component-title} pipeline has at least one xref:components:inputs/about.adoc[input], an optional xref:components:buffers/about.adoc[buffer], an xref:components:outputs/about.adoc[output] and any number of xref:components:processors/about.adoc[processors]:
 

--- a/modules/components/pages/buffers/about.adoc
+++ b/modules/components/pages/buffers/about.adoc
@@ -1,4 +1,5 @@
 = Buffers
+:page-aliases: components:buffers.adoc
 
 {page-component-title} uses a transaction model internally for guaranteeing delivery of messages, this means that a message from an input is not acknowledged (or its offset committed, etc) until that message has been processed and either intentionally deleted or successfully delivered to all outputs. This transaction model makes {page-component-title} safe to deploy in scenarios where data loss is unacceptable. However, sometimes it's useful to customize the way in which messages are delivered, and this is where buffers come in.
 

--- a/modules/components/pages/inputs/about.adoc
+++ b/modules/components/pages/inputs/about.adoc
@@ -1,4 +1,5 @@
 = Inputs
+:page-aliases: components:inputs.adoc, components:inputs:bloblang.adoc
 
 
 An input is a source of data piped through an array of optional xref:components:processors/about.adoc[processors]:
@@ -64,4 +65,3 @@ It's possible to generate data with {page-component-title} using the xref:compon
 == Categories
 
 components_by_category::[input]
-

--- a/modules/components/pages/inputs/about.adoc
+++ b/modules/components/pages/inputs/about.adoc
@@ -1,6 +1,5 @@
 = Inputs
-:page-aliases: components:inputs.adoc, components:inputs:bloblang.adoc
-
+:page-aliases: components:inputs.adoc
 
 An input is a source of data piped through an array of optional xref:components:processors/about.adoc[processors]:
 

--- a/modules/components/pages/outputs/about.adoc
+++ b/modules/components/pages/outputs/about.adoc
@@ -1,5 +1,5 @@
 = Outputs
-
+:page-aliases: components:outputs.adoc
 
 An output is a sink where we wish to send our consumed data after applying an optional array of xref:components:processors/about.adoc[processors]. Only one output is configured at the root of a {page-component-title} config. However, the output can be a xref:components:outputs/broker.adoc[broker] which combines multiple outputs under a chosen brokering pattern, or a xref:components:outputs/switch.adoc[switch] which is used to multiplex against different outputs.
 

--- a/modules/configuration/pages/about.adoc
+++ b/modules/configuration/pages/about.adoc
@@ -1,5 +1,6 @@
 = Configuration
 :description: Learn about configuration
+:page-aliases: ROOT:configuration.adoc
 
 {page-component-title} pipelines are configured in a YAML file that consists of a number of root sections, arranged like so:
 

--- a/modules/configuration/pages/resources.adoc
+++ b/modules/configuration/pages/resources.adoc
@@ -1,4 +1,5 @@
 = Resources
+:page-aliases: redpanda:current:guides:resources.adoc
 
 Resources are components within {page-component-title} that are declared with a unique label and can be referenced any number of times within a configuration. Only one instance of each named resource is created, but it is safe to use it in multiple places as they can be shared without consequence.
 

--- a/modules/configuration/pages/resources.adoc
+++ b/modules/configuration/pages/resources.adoc
@@ -1,5 +1,4 @@
 = Resources
-:page-aliases: redpanda:current:guides:resources.adoc
 
 Resources are components within {page-component-title} that are declared with a unique label and can be referenced any number of times within a configuration. Only one instance of each named resource is created, but it is safe to use it in multiple places as they can be shared without consequence.
 

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -1,5 +1,6 @@
 = Bloblang
 :description: Learn what Bloblang is and how to use the native mapping language.
+:page-aliases: guides:plugins.adoc
 
 
 Bloblang, or blobl for short, is a language designed for mapping data of a wide variety of forms. It's a safe, fast, and powerful way to perform document mapping within {page-component-title}. It also has a https://pkg.go.dev/github.com/{project-github}/v4/public/bloblang[Go API for writing your own functions and methods^] as plugins.

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -1,6 +1,6 @@
 = Bloblang
 :description: Learn what Bloblang is and how to use the native mapping language.
-:page-aliases: guides:plugins.adoc, guides:bloblang.adoc, components:processors:conditional.adoc
+:page-aliases: guides:plugins.adoc, guides:bloblang.adoc
 
 
 Bloblang, or blobl for short, is a language designed for mapping data of a wide variety of forms. It's a safe, fast, and powerful way to perform document mapping within {page-component-title}. It also has a https://pkg.go.dev/github.com/{project-github}/v4/public/bloblang[Go API for writing your own functions and methods^] as plugins.

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -1,6 +1,6 @@
 = Bloblang
 :description: Learn what Bloblang is and how to use the native mapping language.
-:page-aliases: guides:plugins.adoc
+:page-aliases: guides:plugins.adoc, guides:bloblang.adoc
 
 
 Bloblang, or blobl for short, is a language designed for mapping data of a wide variety of forms. It's a safe, fast, and powerful way to perform document mapping within {page-component-title}. It also has a https://pkg.go.dev/github.com/{project-github}/v4/public/bloblang[Go API for writing your own functions and methods^] as plugins.

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -1,6 +1,6 @@
 = Bloblang
 :description: Learn what Bloblang is and how to use the native mapping language.
-:page-aliases: guides:plugins.adoc, guides:bloblang.adoc
+:page-aliases: guides:plugins.adoc, guides:bloblang.adoc, components:processors:conditional.adoc
 
 
 Bloblang, or blobl for short, is a language designed for mapping data of a wide variety of forms. It's a safe, fast, and powerful way to perform document mapping within {page-component-title}. It also has a https://pkg.go.dev/github.com/{project-github}/v4/public/bloblang[Go API for writing your own functions and methods^] as plugins.

--- a/modules/guides/pages/getting_started.adoc
+++ b/modules/guides/pages/getting_started.adoc
@@ -1,5 +1,6 @@
 = Get Started
 :description: Getting started with {page-component-title}.
+:page-aliases: getting_started:overview.adoc
 
 This topic explains how to get started with {page-component-title}.
 

--- a/modules/guides/pages/getting_started.adoc
+++ b/modules/guides/pages/getting_started.adoc
@@ -1,6 +1,6 @@
 = Get Started
 :description: Getting started with {page-component-title}.
-:page-aliases: getting_started:overview.adoc
+:page-aliases: getting_started:overview.adoc, ROOT:install.adoc
 
 This topic explains how to get started with {page-component-title}.
 

--- a/modules/guides/pages/index.adoc
+++ b/modules/guides/pages/index.adoc
@@ -1,2 +1,3 @@
 = Guides
 :page-layout: index
+:page-aliases: about.adoc

--- a/modules/guides/pages/streams_mode/about.adoc
+++ b/modules/guides/pages/streams_mode/about.adoc
@@ -1,6 +1,6 @@
 = Streams Mode
 :description: Get an overview of streams mode in Redpanda Connect, detailing its features, use cases, and setup instructions.
-
+:page-aliases: guides:streams_mode.adoc
 
 A {page-component-title} stream consists of four components; an input, an optional buffer, processor pipelines and an output. Under normal use a {page-component-title} instance is a single stream, and these components are configured within the service config file.
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2553
Review deadline: 15 July

URLs that never existed have been excluded

## Page previews

[Homepage](https://deploy-preview-19--redpanda-connect.netlify.app//redpanda-connect/about/)

## Redirects added
```
https://docs.redpanda.com/redpanda-connect/components/ > /components/about
https://docs.redpanda.com/redpanda-connect/components/conditions/ > /components/about
https://docs.redpanda.com/redpanda-connect/components/buffers/ > /components/buffers/about
https://docs.redpanda.com/redpanda-connect/components/outputs/ > /components/outputs/about
https://docs.redpanda.com/redpanda-connect/components/inputs > /components/inputs/about
https://docs.redpanda.com/redpanda-connect/getting_started/overview > /guides/getting_started/
https://docs.redpanda.com/redpanda-connect/guides/bloblang/ > /guides/bloblang/about/
https://docs.redpanda.com/redpanda-connect/guides/about > /guides/
https://docs.redpanda.com/redpanda-connect/guides/streams_mode > /guides/streams_mode/about/
https://docs.redpanda.com/redpanda-connect/guides/delivery_guarantee > /about/
https://docs.redpanda.com/redpanda-connect/configuration > /configuration/about/
https://docs.redpanda.com/redpanda-connect/install/ > /guides/getting_started/
```

Redirects for autogenerated pages are in another PR: https://github.com/redpanda-data/docs-site/pull/67

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)