### PR TITLE
Rename component to Connect

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
     page-header-data:
       order: 3
-      color: '#5720B7'
+      color: '#54478C'
     project-github: redpanda-data/connect
     # Fallback for the latest version of Redpanda
     # This is replaced by the version fetcher extension

--- a/antora.yml
+++ b/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
     page-header-data:
       order: 3
-      color: '#821890'
+      color: '#5720B7'
     project-github: redpanda-data/connect
     # Fallback for the latest version of Redpanda
     # This is replaced by the version fetcher extension

--- a/antora.yml
+++ b/antora.yml
@@ -1,11 +1,14 @@
 name: redpanda-connect
-title: Redpanda Connect
+title: Connect
 version: ~
 start_page: ROOT:about.adoc
 nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    page-header-data:
+      order: 3
+      color: '#821890'
     project-github: redpanda-data/connect
     # Fallback for the latest version of Redpanda
     # This is replaced by the version fetcher extension


### PR DESCRIPTION
## Description

Part of https://github.com/redpanda-data/documentation-private/issues/2587

- Renames the component to 'Connect' so that the UI displays it instead of 'Redpanda Connect'.

- Specifies the order that this component should be displayed in the docs header and the color of the header.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)