### PR TITLE
Mark AI processors as enterprise

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -206,6 +206,14 @@ asciidoc:
     enterprise-components:
       - "splunk_hec"
       - "snowflake_put"
+      - "openai_chat_completion"
+      - "openai_embeddings"
+      - "openai_image_generation"
+      - "openai_speech"
+      - "openai_transcription"
+      - "openai_translation"
+      - "ollama_chat"
+      - "ollama_embeddings"
     # Defines the connectors that are marked 'certified'.
     # This list is a temporary solution until each connector's source code includes the correct support level information. https://github.com/redpanda-data/benthos/pull/21/commits/aba447436e44faf7d4279d3394d82084ea0ed1e1#diff-26839711b0903fcf81e360ea17690bd67eb5e924cbabb62ffe85202c98c2a0a6
     certified-components:


### PR DESCRIPTION
## Description

Marks the various new AI processors as enterprise licensed.

## Page previews

???

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
