### PR TITLE
gha: fix configure-aws-credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
-          aws-secret-access-key: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |


### PR DESCRIPTION
## Description

fixes: https://redpandadata.atlassian.net/browse/PESDLC-1737

follow-up to PR #25 to address [error](https://github.com/redpanda-data/rp-connect-docs/actions/runs/10229979034/job/28304348004#step:2:56) on action run after merge to `main`:
> Error: Credentials could not be loaded, please check your action inputs

## Page previews

N/A

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)