### PR TITLE
2636 Incorrect syntax in streams mode and -c flag removed

### DIFF
--- a/modules/configuration/pages/about.adoc
+++ b/modules/configuration/pages/about.adoc
@@ -179,17 +179,17 @@ We can select our chosen resource by changing which file we import, either runni
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -r ./staging/request.yaml -c ./config.yaml
+rpk connect run -r ./staging/request.yaml ./config.yaml
 ----
 
 Or:
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -r ./production/request.yaml -c ./config.yaml
+rpk connect run -r ./production/request.yaml ./config.yaml
 ----
 
-These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" -c ./config.yaml`. You can find out more about configuration resources in the xref:configuration:resources.adoc[resources document].
+These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" ./config.yaml`. You can find out more about configuration resources in the xref:configuration:resources.adoc[resources document].
 
 === Templating
 
@@ -204,13 +204,13 @@ It's possible to have a running instance of {page-component-title} reload config
 [,bash,subs="attributes+"]
 ----
 # Normal mode
-rpk connect run -w -r ./production/request.yaml -c ./config.yaml
+rpk connect run -w -r ./production/request.yaml ./config.yaml
 ----
 
 [,bash,subs="attributes+"]
 ----
 # Streams mode
-rpk connect run -w -r ./production/request.yaml streams ./stream_configs/*.yaml
+rpk connect streams -w -r ./production/request.yaml ./stream_configs/*.yaml
 ----
 
 If a file update results in configuration parsing or linting errors then the change is ignored (with logs informing you of the problem) and the previous configuration will continue to be run (until the issues are fixed).

--- a/modules/configuration/pages/interpolation.adoc
+++ b/modules/configuration/pages/interpolation.adoc
@@ -13,7 +13,7 @@ input:
 
 [,sh,subs="attributes+"]
 ----
-BROKERS="foo:9092,bar:9092" rpk connect run -c ./config.yaml
+BROKERS="foo:9092,bar:9092" rpk connect run ./config.yaml
 ----
 
 If a literal string is required that matches this pattern (`+${foo}+`) you can escape it with double brackets. For example, the string `+${{foo}}+` is read as the literal `+${foo}+`.

--- a/modules/configuration/pages/resources.adoc
+++ b/modules/configuration/pages/resources.adoc
@@ -97,7 +97,7 @@ processor_resources:
         Desires: "are-empty"
 ----
 
-Then when you execute {page-component-title} use the environment variable to choose your resource: `FEATURE_REQUEST=get_foo rpk connect run -c ./your_config.yaml`.
+Then when you execute {page-component-title} use the environment variable to choose your resource: `FEATURE_REQUEST=get_foo rpk connect run ./your_config.yaml`.
 
 === With imports
 
@@ -141,14 +141,14 @@ We can select our chosen resource by changing which file we import, either runni
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -r ./staging/request.yaml -c ./config.yaml
+rpk connect run -r ./staging/request.yaml ./config.yaml
 ----
 
 Or:
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -r ./production/request.yaml -c ./config.yaml
+rpk connect run -r ./production/request.yaml ./config.yaml
 ----
 
-These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" -c ./config.yaml`.
+These flags also support wildcards, which allows you to import an entire directory of resource files like `rpk connect run -r "./staging/*.yaml" ./config.yaml`.

--- a/modules/configuration/pages/secrets.adoc
+++ b/modules/configuration/pages/secrets.adoc
@@ -52,7 +52,7 @@ You could set your credentials to values stored within something like Hashicorp 
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -c ./config.yaml \
+rpk connect run ./config.yaml \
   --set "output.aws_dynamodb.credentials.id=`vault kv get -mount=secret access_key_id`" \
   --set "output.aws_dynamodb.credentials.secret=`vault kv get -mount=secret secret_access_key`"
 ----

--- a/modules/configuration/pages/using_cue.adoc
+++ b/modules/configuration/pages/using_cue.adoc
@@ -109,7 +109,7 @@ We can run this with {page-component-title} to see that it indeed works:
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -c <(cue export --out yaml config.cue)
+rpk connect run <(cue export --out yaml config.cue)
 ----
 
 When you are satisfied with the results, terminate the {page-component-title} process and let's move on to look at some of the nice features that we get with CUE.

--- a/modules/cookbooks/pages/discord_bot.adoc
+++ b/modules/cookbooks/pages/discord_bot.adoc
@@ -35,7 +35,7 @@ If you were to run this config (setting the channel and bot token as env vars in
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -e testing.env -c ./config.yaml
+rpk connect run -e testing.env ./config.yaml
 {"content":"so i like totally just tripped over my own network cables","author":{"id":"1234"}}
 {"content":"like omg that is SO you!!!","author":{"id":"4321"}}
 {"content":"yas totally","author":{"id":"1234"}}

--- a/modules/guides/pages/streams_mode/using_config_files.adoc
+++ b/modules/guides/pages/streams_mode/using_config_files.adoc
@@ -13,7 +13,7 @@ A stream configuration should only include the base stream component fields (`in
 
 [,bash,subs="attributes+"]
 ----
-rpk connect run -r "./resources/prod/*.yaml" streams ./stream_configs/*.yaml
+rpk connect streams -r "./resources/prod/*.yaml" ./stream_configs/*.yaml
 ----
 
 == Walkthrough


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2636
Review deadline: 7 Aug

## Page previews
[Configuration](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/configuration/about/)
[Interpolation](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/configuration/interpolation/)
[Resources](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/configuration/resources/)
[Secrets](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/configuration/secrets/)
[Using CUE](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/configuration/using_cue/)
[Streams mode](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/guides/streams_mode/about/)
[Create a Discord Bot](https://deploy-preview-27--redpanda-connect.netlify.app/redpanda-connect/cookbooks/discord_bot/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)