### PR TITLE
Add Kafka Migrator cookbook

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -314,7 +314,7 @@
 ** xref:cookbooks:filtering.adoc[]
 ** xref:cookbooks:joining_streams.adoc[]
 ** xref:cookbooks:rag.adoc[]
-
+** xref:cookbooks:kafka_migrator.adoc[]
 
 
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -4,7 +4,7 @@
 
 Author: https://www.linkedin.com/in/mtodor[Mihai Todor^]
 
-:description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using _just one command_. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+:description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -11,7 +11,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
 - xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output]
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input]
-- xref:components:outputs/schema_registry.adoc[`schema_registry` output].
+- xref:components:outputs/schema_registry.adoc[`schema_registry` output]
 
 For convenience, these components are bundled together into the:
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -154,7 +154,7 @@ output:
     partition: ${! random_int(min:0, max:1) }
 ----
 
-Now run this command to start the pipeline, and leave it running:
+Now, run this command to start the pipeline, and leave it running:
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -218,9 +218,9 @@ Now, use the following Kafka Migrator Bundle configuration. Please refer to the 
 
 NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See the xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 
+.`kafka_migrator_bundle.yaml`
 [source,yaml]
 ----
-# kafka_migrator_bundle.yaml
 
 input:
   kafka_migrator_bundle:

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -99,7 +99,7 @@ services:
 $ docker-compose -f docker-compose.yml up --force-recreate -V
 ----
 
-NOTE: You used an `init` container above to create 2 topics, `foo` and `bar`, each with 2 partitions and an associated ACL.
+NOTE: This command uses an `init` container to create two topics, `foo` and `bar`, each with two partitions and an associated ACL.
 
 == Create schemas
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -261,7 +261,7 @@ redpanda-connect run kafka_migrator_bundle.yaml
 
 == Check the status of migrated topics
 
-You can use the Redpanda https://docs.redpanda.com/current/get-started/rpk[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
+You can use the Redpanda xref:ROOT:get-started:rpk/index.adoc[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
 
 NOTE: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -8,7 +8,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 
 - xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input]
 - xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
-- xref:components:inputs/kafka_franz.adoc[`kafka_franz` input],
+- xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
 - xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output],
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input],
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output].

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -6,7 +6,7 @@
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 
-- xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input],
+- xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input]
 - xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output],
 - xref:components:inputs/kafka_franz.adoc[`kafka_franz` input],
 - xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output],

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -7,7 +7,7 @@
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 
 - xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input]
-- xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output],
+- xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
 - xref:components:inputs/kafka_franz.adoc[`kafka_franz` input],
 - xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output],
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input],

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -218,7 +218,7 @@ NOTE: Changing topic configurations, such as partition count, isn't currently su
 
 Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output] docs for details.
 
-NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
+NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See the xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 
 [source,yaml]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -7,16 +7,18 @@ Author: https://www.linkedin.com/in/mtodor[Mihai Todor^]
 :description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using _just one command_. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
-* xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input],
-* xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
-* xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
-* xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output]
-* xref:components:inputs/schema_registry.adoc[`schema_registry` input]
-* xref:components:outputs/schema_registry.adoc[`schema_registry` output].
+
+- xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input],
+- xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output],
+- xref:components:inputs/kafka_franz.adoc[`kafka_franz` input],
+- xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output],
+- xref:components:inputs/schema_registry.adoc[`schema_registry` input],
+- xref:components:outputs/schema_registry.adoc[`schema_registry` output].
 
 For convenience, these components are bundled together into the:
-* xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and
-* xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] templates.
+
+- xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and
+- xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] templates.
 
 This cookbook shows how to use the bundled components.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -283,7 +283,7 @@ User:redpanda  *     TOPIC          foo            LITERAL                READ  
 
 == Check metrics to monitor progress
 
-Redpanda Connect provides a comprehensive suite of metrics in various formats, which you can use to monitor its performance in your observability stack. Besides the xref:components:metrics/about.adoc#metric-names[standard Redpanda Connect metrics], the `kafka_migrator` input also emits an `input_kafka_migrator_lag` metric for monitoring the migration progress of each topic and partition (for example in Prometheus format).
+Redpanda Connect provides a comprehensive suite of metrics in various formats, such as Prometheus, which you can use to monitor its performance in your observability stack. Besides the xref:components:metrics/about.adoc#metric-names[standard Redpanda Connect metrics], the `kafka_migrator` input also emits an `input_kafka_migrator_lag` metric for monitoring the migration progress of each topic and partition.
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -15,7 +15,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input]
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output]
 
-For convenience, these components are bundled together into the following xref:configuration:pages/templating.adoc[Redpanda Connect templates]:
+For convenience, these components are bundled together into the following xref:configuration:templating.adoc[Redpanda Connect templates]:
 
 - xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input]
 - xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output]

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -263,7 +263,7 @@ $ redpanda-connect run kafka_migrator_bundle.yaml
 
 == Check the status of migrated topics
 
-Now you can use the Redpanda https://docs.redpanda.com/current/get-started/rpk[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. If you don't have it installed already, please follow the instructions https://docs.redpanda.com/current/get-started/rpk-install[here^].
+You can use the Redpanda https://docs.redpanda.com/current/get-started/rpk[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
 
 Note: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -218,7 +218,7 @@ NOTE: Changing topic configurations, such as partition count, isn't currently su
 
 Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output] docs for details.
 
-Note: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. Please refer to xref:components:outputs/kafka_migrator.adoc#max_in_flight[its documentation] for details.
+NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 
 [source,yaml]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -10,7 +10,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
 - xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
 - xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output]
-- xref:components:inputs/schema_registry.adoc[`schema_registry` input],
+- xref:components:inputs/schema_registry.adoc[`schema_registry` input]
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output].
 
 For convenience, these components are bundled together into the:

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -4,6 +4,8 @@
 
 :description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
+Move your workloads from any Kafka system to Redpanda using a single command. Kafka Migrator lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 
 - xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input]

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -1,8 +1,8 @@
 = Kafka Migrator
 
-// tag::single-source[]
-
 :description: Move your workloads from any Kafka system to Redpanda using a single command. Kafka Migrator lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+
+// tag::single-source[]
 
 With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -103,7 +103,7 @@ services:
 $ docker-compose -f docker-compose.yml up --force-recreate -V
 ----
 
-Note: We used an `init` container above to create 2 topics, `foo` and `bar`, each with 2 partitions and an associated ACL.
+NOTE: You used an `init` container above to create 2 topics, `foo` and `bar`, each with 2 partitions and an associated ACL.
 
 == Create schemas
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -1,0 +1,352 @@
+= Kafka Migrator
+
+// tag::single-source[]
+
+Author: https://www.linkedin.com/in/mtodor[Mihai Todor^]
+
+:description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using _just one command_. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+
+Redpanda Connect's Kafka Migrator uses functionality from the following components:
+* xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input],
+* xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
+* xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
+* xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output]
+* xref:components:inputs/schema_registry.adoc[`schema_registry` input]
+* xref:components:outputs/schema_registry.adoc[`schema_registry` output].
+
+For convenience, these components are bundled together into the:
+* xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and
+* xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] templates.
+
+This cookbook shows how to use the bundled components.
+
+== Create the Docker containers
+
+First, we will need two clusters and, for simplicity, we can run two Redpanda Docker containers via https://docs.docker.com/compose[Docker Compose^]:
+
+First, you’ll need two clusters. To keep it simple, you can run the https://hub.docker.com/r/bitnami/kafka[Bitnami Kafka^] and https://hub.docker.com/r/bitnami/schema-registry[Schema Registry^] Docker containers for the source cluster and a https://hub.docker.com/r/redpandadata/redpanda[Redpanda Docker container^] for the destination cluster via https://docs.docker.com/compose[Docker Compose^].
+
+[source,yaml]
+----
+# docker-compose.yml
+
+services:
+  source:
+    image: bitnami/kafka
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@localhost:9093
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_DOCKER:PLAINTEXT
+      KAFKA_CFG_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_DOCKER://0.0.0.0:19092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_DOCKER://source:19092
+      KAFKA_CFG_AUTHORIZER_CLASS_NAME: "org.apache.kafka.metadata.authorizer.StandardAuthorizer"
+      KAFKA_CFG_SUPER_USERS: User:redpanda;User:ANONYMOUS
+    ports:
+      - 9092:9092
+      - 19092:19092
+    healthcheck:
+      test: [ "CMD", "kafka-topics.sh", "--bootstrap-server=localhost:9092", "--list" ]
+      start_period: 5s
+      interval: 3s
+
+  init_source:
+    image: bitnami/kafka
+    working_dir: /opt/bitnami/kafka/bin
+    entrypoint: /bin/bash
+    depends_on:
+      source:
+        condition: service_healthy
+    command: >
+      -c "kafka-topics.sh --create --if-not-exists --topic foo --replication-factor=1 --partitions=2 --bootstrap-server source:19092 &&
+          kafka-topics.sh --create --if-not-exists --topic bar --replication-factor=1 --partitions=2 --bootstrap-server source:19092 &&
+          echo 'Created topics:' &&
+          kafka-topics.sh --list --exclude-internal --bootstrap-server source:19092 &&
+          kafka-acls.sh --bootstrap-server source:19092 --add --allow-principal User:redpanda --operation Read --topic foo &&
+          kafka-acls.sh --bootstrap-server source:19092 --add --deny-principal User:redpanda --operation Read --topic bar
+          echo 'Created ACLs:' &&
+          kafka-acls.sh --bootstrap-server source:19092 --list"
+
+  source_schema_registry:
+    image: bitnami/schema-registry
+    environment:
+      SCHEMA_REGISTRY_KAFKA_BROKERS: PLAINTEXT://source:19092
+    ports:
+      - 8081:8081
+    depends_on:
+      source:
+        condition: service_healthy
+
+  destination:
+    image: redpandadata/redpanda
+    command:
+      - redpanda
+      - start
+      - --node-id 0
+      - --mode dev-container
+      - --set rpk.additional_start_flags=[--reactor-backend=epoll]
+      - --set redpanda.auto_create_topics_enabled=false
+      - --kafka-addr 0.0.0.0:9093
+      - --advertise-kafka-addr localhost:9093
+      - --schema-registry-addr 0.0.0.0:8081
+    ports:
+      - 8082:8081
+      - 9093:9093
+      - 9645:9644
+----
+
+[source,console]
+----
+$ docker-compose -f docker-compose.yml up --force-recreate -V
+----
+
+Note: We used an `init` container above to create 2 topics, `foo` and `bar`, each with 2 partitions and an associated ACL.
+
+== Create schemas
+
+Once the demo clusters are up and running, use https://curl.se[curl^] to create a schema for each topic in the `source` cluster.
+
+[source,console]
+----
+$ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Foo\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/foo/versions
+$ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Bar\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/bar/versions
+----
+
+== Generate messages
+
+Let's simulate an application with a producer and consumer actively publishing and reading messages on the `source` cluster. You can use Redpanda Connect to generate some Avro-encoded messages and push them to the two topics from the `source` cluster.
+
+[source,yaml]
+----
+# generate_data.yaml
+
+http:
+  enabled: false
+
+input:
+  sequence:
+    inputs:
+      - generate:
+          mapping: |
+            let msg = counter()
+            root.data = $msg
+
+            meta kafka_topic = match $msg % 2 {
+              0 => "foo"
+              1 => "bar"
+            }
+          interval: 1s
+          count: 0
+          batch_size: 1
+
+        processors:
+          - schema_registry_encode:
+              url: "http://localhost:8081"
+              subject: ${! metadata("kafka_topic") }
+              avro_raw_json: true
+
+output:
+  kafka_franz:
+    seed_brokers: [ "localhost:9092" ]
+    topic: ${! @kafka_topic }
+    partitioner: manual
+    partition: ${! random_int(min:0, max:1) }
+----
+
+Now run this command to start the pipeline, and leave it running:
+
+[source,console]
+----
+$ redpanda-connect run generate_data.yaml
+----
+
+Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
+
+[source,yaml]
+----
+# read_data_source.yaml
+
+http:
+  enabled: false
+
+input:
+  kafka_franz:
+    seed_brokers: [ "localhost:9092" ]
+    topics:
+      - '^[^_]' # Skip topics which start with `_`
+    regexp_topics: true
+    start_from_oldest: true
+    consumer_group: foobar
+
+  processors:
+    - schema_registry_decode:
+        url: "http://localhost:8081"
+        avro_raw_json: true
+
+output:
+  stdout: {}
+  processors:
+    - mapping: |
+        root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
+----
+
+Run launch the `source` consumer pipeline, and leave it running:
+
+[source,console]
+----
+$ redpanda-connect run read_data_source.yaml
+----
+
+At this point, the `source` cluster should have some data in both `foo` and `bar` topics and the consumer should be printing the messages it reads from these topics to `stdout`.
+
+== Configure and start Kafka Migrator
+
+At this point, you can start the new Kafka Migrator Bundle, which will do the following:
+
+- On startup, it reads all the schemas from the `source` cluster Schema Registry through the REST API and pushes them to the destination cluster Schema Registry using the same API. It needs to preserve the schema IDs, so the `destination` cluster *must not have any schemas in it*.
+- Once the schemas have been imported, Kafka Migrator begins the migration of all the selected topics from the `source` cluster, and any associated ACLs. After it finishes creating all the topics and ACLs that don't exist in the `destination` cluster, it begins the migration of messages and performs consumer group offsets remapping.
+- If any new topics are created in the `source` cluster while Kafka Migrator is running, they are only migrated to the `destination` cluster if messages are written to them.
+
+ACL migration for topics adheres to the following principles:
+
+- `ALLOW WRITE` ACLs for topics are not migrated
+- `ALLOW ALL` ACLs for topics are downgraded to `ALLOW READ`
+- Group ACLs are not migrated
+
+Note: Changing topic configurations, such as partition count, isn't currently supported.
+
+Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output^] docs for details.
+
+Note: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. Please refer to xref:components:outputs/kafka_migrator.adoc#max_in_flight[its documentation^] for details.
+
+[source,yaml]
+----
+# kafka_migrator_bundle.yaml
+
+input:
+  kafka_migrator_bundle:
+    kafka_migrator:
+      seed_brokers: [ "localhost:9092" ]
+      topics:
+        - '^[^_]' # Skip internal topics which start with `_`
+      regexp_topics: true
+      consumer_group: migrator_bundle
+      start_from_oldest: true
+
+    schema_registry:
+      url: http://localhost:8081
+      include_deleted: true
+      subject_filter: ""
+
+output:
+  kafka_migrator_bundle:
+    kafka_migrator:
+      seed_brokers: [ "localhost:9093" ]
+      max_in_flight: 1
+
+    schema_registry:
+      url: http://localhost:8082
+
+metrics:
+  prometheus: {}
+  mapping: |
+    meta label = if this == "input_kafka_migrator_lag" { "source" }
+----
+
+Now launch the Kafka Migrator Bundle pipeline, and leave it running:
+
+[source,console]
+----
+$ redpanda-connect run kafka_migrator_bundle.yaml
+----
+
+== Check the status of migrated topics
+
+Now you can use the Redpanda https://docs.redpanda.com/current/get-started/rpk[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. If you don't have it installed already, please follow the instructions https://docs.redpanda.com/current/get-started/rpk-install[here^].
+
+Note: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
+
+[source,console]
+----
+$ rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 topic list
+NAME      PARTITIONS  REPLICAS
+_schemas  1           1
+bar       2           1
+foo       2           1
+
+$ rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 security acl list
+PRINCIPAL      HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
+User:redpanda  *     TOPIC          bar            LITERAL                READ       DENY
+User:redpanda  *     TOPIC          foo            LITERAL                READ       ALLOW
+----
+
+== Check metrics to monitor progress
+
+Redpanda Connect provides a comprehensive suite of metrics in various formats, which you can use to monitor its performance in your observability stack. Besides the xref:components:metrics/about.adoc#metric-names[standard Redpanda Connect metrics], the `kafka_migrator` input also emits an `input_kafka_migrator_lag` metric for monitoring the migration progress of each topic and partition (for example in Prometheus format).
+
+[source,console]
+----
+$ curl http://localhost:4195/metrics
+...
+# HELP input_kafka_migrator_lag Benthos Gauge metric
+# TYPE input_kafka_migrator_lag gauge
+input_kafka_migrator_lag{label="source",partition="0",path="root.input.sequence.broker.inputs.0",topic="__consumer_offsets"} 0
+input_kafka_migrator_lag{label="source",partition="0",path="root.input.sequence.broker.inputs.0",topic="bar"} 0
+input_kafka_migrator_lag{label="source",partition="0",path="root.input.sequence.broker.inputs.0",topic="foo"} 0
+input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.broker.inputs.0",topic="__consumer_offsets"} 0
+input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.broker.inputs.0",topic="bar"} 1
+input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.broker.inputs.0",topic="foo"} 0
+...
+----
+
+== Read from the migrated topics
+
+Finally, stop the `read_data_source.yaml` consumer you started previously and, afterwards, start a similar consumer for the `destination` cluster. Before starting the consumer up on the `destination` cluster, make sure you give the migrator bundle some time to replicate the translated offset.
+
+[source,yaml]
+----
+# read_data_destination.yaml
+
+http:
+  enabled: false
+
+input:
+  kafka_franz:
+    seed_brokers: [ "localhost:9093" ]
+    topics:
+      - '^[^_]' # Skip topics which start with `_`
+    regexp_topics: true
+    start_from_oldest: true
+    consumer_group: foobar
+
+  processors:
+    - schema_registry_decode:
+        url: "http://localhost:8082"
+        avro_raw_json: true
+
+output:
+  stdout: {}
+  processors:
+    - mapping: |
+        root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
+----
+
+Now launch the `destination` consumer pipeline, and leave it running:
+
+[source,console]
+----
+$ redpanda-connect run read_data_sink.yaml
+----
+
+It's worth clarifying that the `source` cluster consumer uses the same `foobar` consumer group. As you can see, this consumer resumes reading messages from where the `source` consumer left off.
+
+And you're all done!
+
+Due to the mechanics of the Kafka protocol, Kafka Migrator needs to perform offset remapping when migrating consumer group offsets to the `destination` cluster. While more sophisticated approaches are possible, Redpanda chose to use a simple timestamp-based approach. So, for each migrated offset, the `destination` cluster is queried to find the latest offset before the received offset timestamp. Kafka Migrator then writes this offset as the `destination` consumer group offset for the corresponding topic and partition pair.
+
+Although the timestamp-based approach doesn't guarantee exactly-once delivery, it minimises the likelihood of message duplication and avoids the need for complex and error-prone offset remapping logic.
+
+The content from this cookbook was first introduced on the https://www.redpanda.com/blog/kafka-migrator-redpanda-connect[Redpanda Blog^].
+
+// end::single-source[]

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -302,7 +302,7 @@ input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.
 
 == Read from the migrated topics
 
-Finally, stop the `read_data_source.yaml` consumer you started previously and, afterwards, start a similar consumer for the `destination` cluster. Before starting the consumer up on the `destination` cluster, make sure you give the migrator bundle some time to replicate the translated offset.
+Stop the `read_data_source.yaml` consumer you started earlier and, afterwards, start a similar consumer for the `destination` cluster. Before starting the consumer up on the `destination` cluster, make sure you give the migrator bundle some time to replicate the translated offset.
 
 [source,yaml]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -302,9 +302,9 @@ input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.
 
 Stop the `read_data_source.yaml` consumer you started earlier and, afterwards, start a similar consumer for the `destination` cluster. Before starting the consumer up on the `destination` cluster, make sure you give the migrator bundle some time to replicate the translated offset.
 
+.`read_data_destination.yaml`
 [source,yaml]
 ----
-# read_data_destination.yaml
 
 http:
   enabled: false

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -24,9 +24,9 @@ This cookbook shows how to use the bundled components.
 
 First, you’ll need two clusters. To keep it simple, you can run the https://hub.docker.com/r/bitnami/kafka[Bitnami Kafka^] and https://hub.docker.com/r/bitnami/schema-registry[Schema Registry^] Docker containers for the source cluster and a https://hub.docker.com/r/redpandadata/redpanda[Redpanda Docker container^] for the destination cluster via https://docs.docker.com/compose[Docker Compose^].
 
+.`docker-compose.yml`
 [source,yaml]
 ----
-# docker-compose.yml
 
 services:
   source:

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -2,7 +2,6 @@
 
 // tag::single-source[]
 
-
 :description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -254,7 +254,7 @@ metrics:
     meta label = if this == "input_kafka_migrator_lag" { "source" }
 ----
 
-Now launch the Kafka Migrator Bundle pipeline, and leave it running:
+Launch the Kafka Migrator Bundle pipeline, and leave it running:
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -13,10 +13,10 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input]
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output]
 
-For convenience, these components are bundled together into the:
+For convenience, these components are bundled together into the following xref:configuration:pages/templating.adoc[Redpanda Connect templates]:
 
-- xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and
-- xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] templates.
+- xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input]
+- xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output]
 
 This cookbook shows how to use the bundled components.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -480,7 +480,7 @@ redpanda-connect run kafka_migrator_bundle.yaml
 
 == Check the status of migrated topics
 
-You can use the Redpanda xref:ROOT:get-started:rpk/index.adoc[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
+You can use the Redpanda xref:ROOT:get-started:rpk/index.adoc[`rpk` CLI tool] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
 
 NOTE: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -214,7 +214,7 @@ ACL migration for topics adheres to the following principles:
 - `ALLOW ALL` ACLs for topics are downgraded to `ALLOW READ`
 - Group ACLs are not migrated
 
-Note: Changing topic configurations, such as partition count, isn't currently supported.
+NOTE: Changing topic configurations, such as partition count, isn't currently supported.
 
 Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output] docs for details.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -377,7 +377,7 @@ ACL migration for topics adheres to the following principles:
 
 NOTE: Changing topic configurations, such as partition count, isn't currently supported.
 
-Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output] docs for details.
+Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] docs for details.
 
 NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See the xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -352,7 +352,7 @@ output:
 
 endif::[]
 
-Run launch the `source` consumer pipeline, and leave it running:
+Launch the `source` consumer pipeline, and leave it running:
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -103,7 +103,7 @@ NOTE: This command uses an `init` container to create two topics, `foo` and `bar
 
 == Create schemas
 
-Once the demo clusters are up and running, use https://curl.se[curl^] to create a schema for each topic in the `source` cluster.
+When the demo clusters are up and running, use https://curl.se[curl^] to create a schema for each topic in the `source` cluster.
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -198,7 +198,7 @@ Run launch the `source` consumer pipeline, and leave it running:
 $ redpanda-connect run read_data_source.yaml
 ----
 
-At this point, the `source` cluster should have some data in both `foo` and `bar` topics and the consumer should be printing the messages it reads from these topics to `stdout`.
+At this point, the `source` cluster should have some data in both `foo` and `bar` topics, and the consumer should print the messages it reads from these topics to `stdout`.
 
 == Configure and start Kafka Migrator
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -20,14 +20,15 @@ For convenience, these components are bundled together into the:
 
 This cookbook shows how to use the bundled components.
 
+ifndef::env-cloud[]
+
 == Create the Docker containers
 
-First, you’ll need two clusters. To keep it simple, you can run the https://hub.docker.com/r/bitnami/kafka[Bitnami Kafka^] and https://hub.docker.com/r/bitnami/schema-registry[Schema Registry^] Docker containers for the source cluster and a https://hub.docker.com/r/redpandadata/redpanda[Redpanda Docker container^] for the destination cluster via https://docs.docker.com/compose[Docker Compose^].
+First, you'll need two clusters. To keep it simple, you can run the https://hub.docker.com/r/bitnami/kafka[Bitnami Kafka^] and https://hub.docker.com/r/bitnami/schema-registry[Schema Registry^] Docker containers for the source cluster and a https://hub.docker.com/r/redpandadata/redpanda[Redpanda Docker container^] for the destination cluster via https://docs.docker.com/compose[Docker Compose^].
 
 .`docker-compose.yml`
 [source,yaml]
 ----
-
 services:
   source:
     image: bitnami/kafka
@@ -57,10 +58,10 @@ services:
       source:
         condition: service_healthy
     command: >
-      -c "kafka-topics.sh --create --if-not-exists --topic foo --replication-factor=1 --partitions=2 --bootstrap-server source:19092 &&
-          kafka-topics.sh --create --if-not-exists --topic bar --replication-factor=1 --partitions=2 --bootstrap-server source:19092 &&
+      -c "kafka-topics.sh --bootstrap-server source:19092 --create --if-not-exists --topic foo --replication-factor=1 --partitions=2 &&
+          kafka-topics.sh --bootstrap-server source:19092 --create --if-not-exists --topic bar --replication-factor=1 --partitions=2 &&
           echo 'Created topics:' &&
-          kafka-topics.sh --list --exclude-internal --bootstrap-server source:19092 &&
+          kafka-topics.sh --bootstrap-server source:19092 --list --exclude-internal &&
           kafka-acls.sh --bootstrap-server source:19092 --add --allow-principal User:redpanda --operation Read --topic foo &&
           kafka-acls.sh --bootstrap-server source:19092 --add --deny-principal User:redpanda --operation Read --topic bar
           echo 'Created ACLs:' &&
@@ -101,24 +102,91 @@ docker-compose -f docker-compose.yml up --force-recreate -V
 
 NOTE: This command uses an `init` container to create two topics, `foo` and `bar`, each with two partitions and an associated ACL.
 
+endif::[]
+
+ifdef::env-cloud[]
+
+== Create a Kafka cluster and a Redpanda Cloud cluster
+
+First, you'll need to provision two clusters, a Kafka one called `source` and a Redpanda Cloud one called `destination`. We'll use the following sample connection details throughout the rest of this cookbook:
+
+`source`
+----
+broker:          source.cloud.kafka.com:9092
+schema registry: https://schema-registry-source.cloud.kafka.com:30081
+username:        kafka
+password:        testpass
+----
+
+`destination`
+----
+broker:          destination.cloud.redpanda.com:9092
+schema registry: https://schema-registry-destination.cloud.redpanda.com:30081
+username:        redpanda
+password:        testpass
+----
+
+Then you'll have to create two topics in the `source` Kafka cluster, `foo` and `bar`, and an ACL for each topic:
+
+[source,console]
+----
+cat > ./config.properties <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-256
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="kafka" password="testpass";
+EOF
+
+kafka-topics.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --create --if-not-exists --topic foo --replication-factor=3 --partitions=2
+
+kafka-topics.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --create --if-not-exists --topic bar --replication-factor=3 --partitions=2
+
+kafka-topics.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --list --exclude-internal
+
+kafka-acls.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --add --allow-principal User:redpanda --operation Read --topic foo
+
+kafka-acls.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --add --deny-principal User:redpanda --operation Read --topic bar
+
+kafka-acls.sh --bootstrap-server source.cloud.kafka.com:9092 --command-config config.properties --list
+----
+
+endif::[]
+
 == Create schemas
 
 When the demo clusters are up and running, use https://curl.se[curl^] to create a schema for each topic in the `source` cluster.
 
+ifndef::env-cloud[]
+
 [source,console]
 ----
 curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Foo\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/foo/versions
+
 curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Bar\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/bar/versions
 ----
+
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,console]
+----
+curl -X POST -u "kafka:testpass" -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Foo\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' https://schema-registry-source.cloud.kafka.com:30081/subjects/foo/versions
+
+curl -X POST -u "kafka:testpass" -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Bar\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' https://schema-registry-source.cloud.kafka.com:30081/subjects/bar/versions
+----
+
+endif::[]
 
 == Generate messages
 
 Let's simulate an application with a producer and consumer actively publishing and reading messages on the `source` cluster. You can use Redpanda Connect to generate some Avro-encoded messages and push them to the two topics from the `source` cluster.
 
 .`generate_data.yaml`
+
+ifndef::env-cloud[]
+
 [source,yaml]
 ----
-
 http:
   enabled: false
 
@@ -152,6 +220,57 @@ output:
     partition: ${! random_int(min:0, max:1) }
 ----
 
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,yaml]
+----
+http:
+  enabled: false
+
+input:
+  sequence:
+    inputs:
+      - generate:
+          mapping: |
+            let msg = counter()
+            root.data = $msg
+
+            meta kafka_topic = match $msg % 2 {
+              0 => "foo"
+              1 => "bar"
+            }
+          interval: 1s
+          count: 0
+          batch_size: 1
+
+        processors:
+          - schema_registry_encode:
+              url: "https://schema-registry-source.cloud.kafka.com:30081"
+              subject: ${! metadata("kafka_topic") }
+              avro_raw_json: true
+              basic_auth:
+                enabled: true
+                username: kafka
+                password: testpass
+
+output:
+  kafka_franz:
+    seed_brokers: [ "source.cloud.kafka.com:9092" ]
+    topic: ${! @kafka_topic }
+    partitioner: manual
+    partition: ${! random_int(min:0, max:1) }
+    tls:
+      enabled: true
+    sasl:
+      - mechanism: SCRAM-SHA-256
+        username: kafka
+        password: testpass
+----
+
+endif::[]
+
 Now, run this command to start the pipeline, and leave it running:
 
 [source,console]
@@ -162,9 +281,11 @@ redpanda-connect run generate_data.yaml
 Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
 
 .`read_data_source.yaml`
+
+ifndef::env-cloud[]
+
 [source,yaml]
 ----
-
 http:
   enabled: false
 
@@ -188,6 +309,48 @@ output:
     - mapping: |
         root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
 ----
+
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,yaml]
+----
+http:
+  enabled: false
+
+input:
+  kafka_franz:
+    seed_brokers: [ "source.cloud.kafka.com:9092" ]
+    topics:
+      - '^[^_]' # Skip topics which start with `_`
+    regexp_topics: true
+    start_from_oldest: true
+    consumer_group: foobar
+    tls:
+      enabled: true
+    sasl:
+      - mechanism: SCRAM-SHA-256
+        username: kafka
+        password: testpass
+
+  processors:
+    - schema_registry_decode:
+        url: "https://schema-registry-source.cloud.kafka.com:30081"
+        avro_raw_json: true
+        basic_auth:
+          enabled: true
+          username: kafka
+          password: testpass
+
+output:
+  stdout: {}
+  processors:
+    - mapping: |
+        root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
+----
+
+endif::[]
 
 Run launch the `source` consumer pipeline, and leave it running:
 
@@ -219,9 +382,11 @@ Now, use the following Kafka Migrator Bundle configuration. Please refer to the 
 NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See the xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 
 .`kafka_migrator_bundle.yaml`
+
+ifndef::env-cloud[]
+
 [source,yaml]
 ----
-
 input:
   kafka_migrator_bundle:
     kafka_migrator:
@@ -252,6 +417,60 @@ metrics:
     meta label = if this == "input_kafka_migrator_lag" { "source" }
 ----
 
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,yaml]
+----
+input:
+  kafka_migrator_bundle:
+    kafka_migrator:
+      seed_brokers: [ "source.cloud.kafka.com:9092" ]
+      topics:
+        - '^[^_]' # Skip internal topics which start with `_`
+      regexp_topics: true
+      consumer_group: migrator_bundle
+      start_from_oldest: true
+      sasl:
+        - mechanism: SCRAM-SHA-256
+          username: kafka
+          password: testpass
+
+    schema_registry:
+      url: "https://schema-registry-source.cloud.kafka.com:30081"
+      include_deleted: true
+      subject_filter: ""
+      basic_auth:
+        enabled: true
+        username: kafka
+        password: testpass
+
+output:
+  kafka_migrator_bundle:
+    kafka_migrator:
+      seed_brokers: [ "destination.cloud.redpanda.com:9092" ]
+      max_in_flight: 1
+      sasl:
+        - mechanism: SCRAM-SHA-256
+          username: redpanda
+          password: testpass
+
+    schema_registry:
+      url: https://schema-registry-destination.cloud.redpanda.com:30081
+      basic_auth:
+        enabled: true
+        username: redpanda
+        password: testpass
+
+metrics:
+  prometheus: {}
+  mapping: |
+    meta label = if this == "input_kafka_migrator_lag" { "source" }
+----
+
+endif::[]
+
 Launch the Kafka Migrator Bundle pipeline, and leave it running:
 
 [source,console]
@@ -265,19 +484,41 @@ You can use the Redpanda xref:ROOT:get-started:rpk/index.adoc[`rpk` CLI tool^] t
 
 NOTE: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
 
+ifndef::env-cloud[]
+
 [source,console]
 ----
-rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 topic list
+rpk -X brokers=localhost:9093 topic list
 NAME      PARTITIONS  REPLICAS
 _schemas  1           1
 bar       2           1
 foo       2           1
 
-rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 security acl list
+rpk -X brokers=localhost:9093 security acl list
 PRINCIPAL      HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
 User:redpanda  *     TOPIC          bar            LITERAL                READ       DENY
 User:redpanda  *     TOPIC          foo            LITERAL                READ       ALLOW
 ----
+
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,console]
+----
+rpk -X brokers=destination.cloud.redpanda.com:9092 -X tls.enabled=true -X sasl.mechanism=SCRAM-SHA-256 -X user=redpanda -X pass=testpass topic list
+NAME      PARTITIONS  REPLICAS
+_schemas  1           1
+bar       2           1
+foo       2           1
+
+rpk -X brokers=destination.cloud.redpanda.com:9092 -X tls.enabled=true -X sasl.mechanism=SCRAM-SHA-256 -X user=redpanda -X pass=testpass security acl list
+PRINCIPAL      HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
+User:redpanda  *     TOPIC          bar            LITERAL                READ       DENY
+User:redpanda  *     TOPIC          foo            LITERAL                READ       ALLOW
+----
+
+endif::[]
 
 == Check metrics to monitor progress
 
@@ -303,9 +544,11 @@ input_kafka_migrator_lag{label="source",partition="1",path="root.input.sequence.
 Stop the `read_data_source.yaml` consumer you started earlier and, afterwards, start a similar consumer for the `destination` cluster. Before starting the consumer up on the `destination` cluster, make sure you give the migrator bundle some time to replicate the translated offset.
 
 .`read_data_destination.yaml`
+
+ifndef::env-cloud[]
+
 [source,yaml]
 ----
-
 http:
   enabled: false
 
@@ -329,6 +572,46 @@ output:
     - mapping: |
         root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
 ----
+
+endif::[]
+
+ifdef::env-cloud[]
+
+[source,yaml]
+----
+http:
+  enabled: false
+
+input:
+  kafka_franz:
+    seed_brokers: [ "destination.cloud.redpanda.com:9092" ]
+    topics:
+      - '^[^_]' # Skip topics which start with `_`
+    regexp_topics: true
+    start_from_oldest: true
+    consumer_group: foobar
+    sasl:
+      - mechanism: SCRAM-SHA-256
+        username: redpanda
+        password: testpass
+
+  processors:
+    - schema_registry_decode:
+        url: "https://schema-registry-destination.cloud.redpanda.com:30081"
+        avro_raw_json: true
+        basic_auth:
+          enabled: true
+          username: redpanda
+          password: testpass
+
+output:
+  stdout: {}
+  processors:
+    - mapping: |
+        root = this.merge({"count": counter(), "topic": @kafka_topic, "partition": @kafka_partition})
+----
+
+endif::[]
 
 Now launch the `destination` consumer pipeline, and leave it running:
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -278,7 +278,7 @@ Now, run this command to start the pipeline, and leave it running:
 redpanda-connect run generate_data.yaml
 ----
 
-Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
+Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `destination` cluster.
 
 .`read_data_source.yaml`
 
@@ -617,7 +617,7 @@ Now launch the `destination` consumer pipeline, and leave it running:
 
 [source,console]
 ----
-redpanda-connect run read_data_sink.yaml
+redpanda-connect run read_data_destination.yaml
 ----
 
 It's worth clarifying that the `source` cluster consumer uses the same `foobar` consumer group. As you can see, this consumer resumes reading messages from where the `source` consumer left off.

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -202,7 +202,7 @@ At this point, the `source` cluster should have some data in both `foo` and `bar
 
 == Configure and start Kafka Migrator
 
-At this point, you can start the new Kafka Migrator Bundle, which will do the following:
+You're ready to start the new Kafka Migrator Bundle, which will do the following:
 
 - On startup, it reads all the schemas from the `source` cluster Schema Registry through the REST API and pushes them to the destination cluster Schema Registry using the same API. It needs to preserve the schema IDs, so the `destination` cluster *must not have any schemas in it*.
 - Once the schemas have been imported, Kafka Migrator begins the migration of all the selected topics from the `source` cluster, and any associated ACLs. After it finishes creating all the topics and ACLs that don't exist in the `destination` cluster, it begins the migration of messages and performs consumer group offsets remapping.

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -218,9 +218,9 @@ ACL migration for topics adheres to the following principles:
 
 Note: Changing topic configurations, such as partition count, isn't currently supported.
 
-Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output^] docs for details.
+Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle input] and xref:components:outputs/kafka_migrator_bundle.adoc[Kafka Migrator Bundle output] docs for details.
 
-Note: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. Please refer to xref:components:outputs/kafka_migrator.adoc#max_in_flight[its documentation^] for details.
+Note: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. Please refer to xref:components:outputs/kafka_migrator.adoc#max_in_flight[its documentation] for details.
 
 [source,yaml]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -24,8 +24,6 @@ This cookbook shows how to use the bundled components.
 
 == Create the Docker containers
 
-First, we will need two clusters and, for simplicity, we can run two Redpanda Docker containers via https://docs.docker.com/compose[Docker Compose^]:
-
 First, you’ll need two clusters. To keep it simple, you can run the https://hub.docker.com/r/bitnami/kafka[Bitnami Kafka^] and https://hub.docker.com/r/bitnami/schema-registry[Schema Registry^] Docker containers for the source cluster and a https://hub.docker.com/r/redpandadata/redpanda[Redpanda Docker container^] for the destination cluster via https://docs.docker.com/compose[Docker Compose^].
 
 [source,yaml]

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -377,7 +377,7 @@ ACL migration for topics adheres to the following principles:
 
 NOTE: Changing topic configurations, such as partition count, isn't currently supported.
 
-Now, use the following Kafka Migrator Bundle configuration. Please refer to the xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] docs for details.
+Now, use the following Kafka Migrator Bundle configuration. See the xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input] and xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output] docs for details.
 
 NOTE: The `max_in_flight: 1` setting is required to preserve message ordering at the partition level. See the xref:components:outputs/kafka_migrator.adoc#max_in_flight[`kafka_migrator` output documentation] for more details.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -2,7 +2,6 @@
 
 // tag::single-source[]
 
-Author: https://www.linkedin.com/in/mtodor[Mihai Todor^]
 
 :description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -285,7 +285,7 @@ Redpanda Connect provides a comprehensive suite of metrics in various formats, s
 
 [source,console]
 ----
-$ curl http://localhost:4195/metrics
+curl http://localhost:4195/metrics
 ...
 # HELP input_kafka_migrator_lag Benthos Gauge metric
 # TYPE input_kafka_migrator_lag gauge

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -161,7 +161,7 @@ Now, run this command to start the pipeline, and leave it running:
 $ redpanda-connect run generate_data.yaml
 ----
 
-Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
+Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
 
 [source,yaml]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -115,9 +115,9 @@ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{
 
 Let's simulate an application with a producer and consumer actively publishing and reading messages on the `source` cluster. You can use Redpanda Connect to generate some Avro-encoded messages and push them to the two topics from the `source` cluster.
 
+.`generate_data.yaml`
 [source,yaml]
 ----
-# generate_data.yaml
 
 http:
   enabled: false

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -96,7 +96,7 @@ services:
 
 [source,console]
 ----
-$ docker-compose -f docker-compose.yml up --force-recreate -V
+docker-compose -f docker-compose.yml up --force-recreate -V
 ----
 
 NOTE: This command uses an `init` container to create two topics, `foo` and `bar`, each with two partitions and an associated ACL.
@@ -107,8 +107,8 @@ When the demo clusters are up and running, use https://curl.se[curl^] to create 
 
 [source,console]
 ----
-$ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Foo\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/foo/versions
-$ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Bar\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/bar/versions
+curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Foo\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/foo/versions
+curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"name\": \"Bar\", \"type\": \"record\", \"fields\": [{\"name\": \"data\", \"type\": \"int\"}]}"}' http://localhost:8081/subjects/bar/versions
 ----
 
 == Generate messages
@@ -156,7 +156,7 @@ Now, run this command to start the pipeline, and leave it running:
 
 [source,console]
 ----
-$ redpanda-connect run generate_data.yaml
+redpanda-connect run generate_data.yaml
 ----
 
 Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
@@ -193,7 +193,7 @@ Run launch the `source` consumer pipeline, and leave it running:
 
 [source,console]
 ----
-$ redpanda-connect run read_data_source.yaml
+redpanda-connect run read_data_source.yaml
 ----
 
 At this point, the `source` cluster should have some data in both `foo` and `bar` topics, and the consumer should print the messages it reads from these topics to `stdout`.
@@ -256,7 +256,7 @@ Launch the Kafka Migrator Bundle pipeline, and leave it running:
 
 [source,console]
 ----
-$ redpanda-connect run kafka_migrator_bundle.yaml
+redpanda-connect run kafka_migrator_bundle.yaml
 ----
 
 == Check the status of migrated topics
@@ -267,13 +267,13 @@ NOTE: For now, users need to be migrated manually. However, this step is not req
 
 [source,console]
 ----
-$ rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 topic list
+rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 topic list
 NAME      PARTITIONS  REPLICAS
 _schemas  1           1
 bar       2           1
 foo       2           1
 
-$ rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 security acl list
+rpk -X brokers=localhost:9093 -X admin.hosts=localhost:9645 security acl list
 PRINCIPAL      HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
 User:redpanda  *     TOPIC          bar            LITERAL                READ       DENY
 User:redpanda  *     TOPIC          foo            LITERAL                READ       ALLOW
@@ -334,7 +334,7 @@ Now launch the `destination` consumer pipeline, and leave it running:
 
 [source,console]
 ----
-$ redpanda-connect run read_data_sink.yaml
+redpanda-connect run read_data_sink.yaml
 ----
 
 It's worth clarifying that the `source` cluster consumer uses the same `foobar` consumer group. As you can see, this consumer resumes reading messages from where the `source` consumer left off.

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -9,7 +9,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:inputs/kafka_migrator.adoc[`kafka_migrator` input]
 - xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output]
 - xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
-- xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output],
+- xref:components:outputs/kafka_migrator_offsets.adoc[`kafka_migrator_offsets` output]
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input],
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output].
 

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -161,9 +161,9 @@ redpanda-connect run generate_data.yaml
 
 Next, add a Redpanda Connect consumer, which reads messages from the `source` cluster topics, and leave it running. This consumer uses the `foobar` consumer group, which will be reused in a later step when consuming from the `sink` cluster.
 
+.`read_data_source.yaml`
 [source,yaml]
 ----
-# read_data_source.yaml
 
 http:
   enabled: false

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -265,7 +265,7 @@ $ redpanda-connect run kafka_migrator_bundle.yaml
 
 You can use the Redpanda https://docs.redpanda.com/current/get-started/rpk[`rpk` CLI tool^] to check which topics and ACLs have been migrated to the `destination` cluster. You can quickly xref:ROOT:get-started:rpk-install.adoc[install `rpk`] if you don't already have it.
 
-Note: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
+NOTE: For now, users need to be migrated manually. However, this step is not required for the current demo. Similarly, roles are specific to Redpanda and, for now, will also require manual migration if the `source` cluster is based on Redpanda.
 
 [source,console]
 ----

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -2,9 +2,9 @@
 
 // tag::single-source[]
 
-:description: With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+:description: Move your workloads from any Kafka system to Redpanda using a single command. Kafka Migrator lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
-Move your workloads from any Kafka system to Redpanda using a single command. Kafka Migrator lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 


### PR DESCRIPTION
## Description

Add a cookbook to demo the new Kafka Migrator feature: https://github.com/redpanda-data/connect/pull/2789

TODO:
- [ ] Add a link to the blog post after it gets released.

Review deadline: September 9th

## Page previews

https://deploy-preview-36--redpanda-docs-preview.netlify.app/current/modules/cookbooks/pages/kafka_migrator

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)