### PR TITLE
Update Kafka Migrator cookbook

### DIFF
--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -15,7 +15,7 @@ Redpanda Connect's Kafka Migrator uses functionality from the following componen
 - xref:components:inputs/schema_registry.adoc[`schema_registry` input]
 - xref:components:outputs/schema_registry.adoc[`schema_registry` output]
 
-For convenience, these components are bundled together into the following xref:configuration:templating.adoc[Redpanda Connect templates]:
+For convenience, these components are bundled together into the following:
 
 - xref:components:inputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` input]
 - xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output]


### PR DESCRIPTION
Remove reference to Redpanda Connect templates since they're irrelevant here because they're bundled directly into the binary.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)