### PR TITLE
Use Apache Kafka in the Kafka Migrator cookbook.

### DIFF
--- a/modules/components/pages/inputs/kafka_migrator.adoc
+++ b/modules/components/pages/inputs/kafka_migrator.adoc
@@ -9,7 +9,7 @@
 
 component_type_dropdown::[]
 
-Use this connector in conjunction with the xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output] to migrate topics between Kafka brokers. The `kafka_migrator` input uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
+Use this connector in conjunction with the xref:components:outputs/kafka_migrator.adoc[`kafka_migrator` output] to migrate topics between Apache Kafka brokers. The `kafka_migrator` input uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
 
 ifndef::env-cloud[]
@@ -79,8 +79,8 @@ input:
 The `kafka_migrator` input:
 
 * Reads a batch of messages from a Kafka broker.
-* Attempts to create all selected topics along with their associated ACLs in the broker that the output points to, identified by the label specified in `output_resource`. 
-* Waits for the `kafka_migrator` output to acknowledge the writes before updating the Kafka consumer group offset. 
+* Attempts to create all selected topics along with their associated ACLs in the broker that the output points to, identified by the label specified in `output_resource`.
+* Waits for the `kafka_migrator` output to acknowledge the writes before updating the Kafka consumer group offset.
 
 Specify a consumer group for this input to consume one or more topics and automatically balance the topic partitions across any other connected clients with the same consumer group. Otherwise, topics are consumed in their entirety or with explicit partitions.
 
@@ -129,7 +129,7 @@ seed_brokers:
 
 === `topics`
 
-A list of topics to consume from. Use commas to separated multiple topics in a single element. 
+A list of topics to consume from. Use commas to separated multiple topics in a single element.
 
 When a `consumer_group` is specified, partitions are automatically distributed across consumers of a topic. Otherwise, all partitions are consumed.
 
@@ -212,7 +212,7 @@ The maximum number of messages that can accumulate in each batch.
 
 === `auto_replay_nacks`
 
-Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure. 
+Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.
 
 Set `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data is discarded immediately upon consumption and mutation.
 

--- a/modules/components/pages/inputs/kafka_migrator_bundle.adoc
+++ b/modules/components/pages/inputs/kafka_migrator_bundle.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-The `kafka_migrator_bundle` input reads messages and schemas from a Kafka or Redpanda cluster. Use this input in conjunction with the xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output].
+The `kafka_migrator_bundle` input reads messages and schemas from an Apache Kafka or Redpanda cluster. Use this input in conjunction with the xref:components:outputs/kafka_migrator_bundle.adoc[`kafka_migrator_bundle` output].
 
 ```yml
 # Config fields, showing default values

--- a/modules/components/pages/outputs/kafka_migrator.adoc
+++ b/modules/components/pages/outputs/kafka_migrator.adoc
@@ -9,7 +9,7 @@
 
 component_type_dropdown::[]
 
-Writes a batch of messages to a Kafka broker and waits for acknowledgement before propagating them back to the input.
+Writes a batch of messages to an Apache Kafka broker and waits for acknowledgement before propagating them back to the input.
 
 Use this connector in conjunction with the xref:components:inputs/kakfa_migrator[`kafka_migrator` input] to migrate topics between Kafka brokers. The `kafka_migrator` output uses the the https://github.com/twmb/franz-go[Franz Kafka client library^].
 

--- a/modules/components/pages/outputs/kafka_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/kafka_migrator_bundle.adoc
@@ -10,7 +10,7 @@
 
 component_type_dropdown::[]
 
-Writes messages and schemas to a Kafka or Redpanda cluster. Use this output in conjunction with the `kafka_migrator_bundle` input.
+Writes messages and schemas to an Apache Kafka or Redpanda cluster. Use this output in conjunction with the `kafka_migrator_bundle` input.
 
 
 ```yml

--- a/modules/cookbooks/pages/kafka_migrator.adoc
+++ b/modules/cookbooks/pages/kafka_migrator.adoc
@@ -4,7 +4,7 @@
 
 // tag::single-source[]
 
-With Kafka Migrator, you can move your workloads from any Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
+With Kafka Migrator, you can move your workloads from any Apache Kafka system to Redpanda using a single command. It lets you migrate Kafka messages, schemas, and ACLs quickly and efficiently.
 
 Redpanda Connect's Kafka Migrator uses functionality from the following components:
 


### PR DESCRIPTION
This was raised as a requirement from the Apache Kafka team for copyright reasons:

https://redpandadata.slack.com/archives/C076AV2M5MH/p1726670549775749

AS: I have checked with David Foley and no trademark symbol is required.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 20 September

## Page previews

https://deploy-preview-59--redpanda-connect.netlify.app/redpanda-connect/cookbooks/kafka_migrator/
https://deploy-preview-59--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka_migrator/
https://deploy-preview-59--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka_migrator_bundle/
https://deploy-preview-59--redpanda-connect.netlify.app/redpanda-connect/components/outputs/kafka_migrator/
https://deploy-preview-59--redpanda-connect.netlify.app/redpanda-connect/components/outputs/kafka_migrator_bundle/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)