### PR TITLE
Add credentials_json field to GCP Connectors

### DIFF
--- a/modules/components/pages/caches/gcp_cloud_storage.adoc
+++ b/modules/components/pages/caches/gcp_cloud_storage.adoc
@@ -17,6 +17,7 @@ label: ""
 gcp_cloud_storage:
   bucket: "" # No default (required)
   content_type: "" # No default (optional)
+  credentials_json: "" # No default (optional)
 ```
 
 It is not possible to atomically upload cloud storage objects exclusively when the target does not already exist, therefore this cache is not suitable for deduplication.
@@ -37,5 +38,15 @@ Optional field to explicitly set the Content-Type.
 
 
 *Type*: `string`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 // end::single-source[]

--- a/modules/components/pages/inputs/gcp_bigquery_select.adoc
+++ b/modules/components/pages/inputs/gcp_bigquery_select.adoc
@@ -23,6 +23,7 @@ input:
   label: ""
   gcp_bigquery_select:
     project: "" # No default (required)
+    credentials_json: "" # No default (optional)
     table: bigquery-public-data.samples.shakespeare # No default (required)
     columns: [] # No default (required)
     where: type = ? and created_at > ? # No default (optional)
@@ -75,6 +76,16 @@ GCP project where the query job will execute.
 
 
 *Type*: `string`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 
 === `table`

--- a/modules/components/pages/inputs/gcp_cloud_storage.adoc
+++ b/modules/components/pages/inputs/gcp_cloud_storage.adoc
@@ -29,6 +29,7 @@ input:
   gcp_cloud_storage:
     bucket: "" # No default (required)
     prefix: ""
+    credentials_json: "" # No default (optional)
     scanner:
       to_the_end: {}
 ```
@@ -45,6 +46,7 @@ input:
   gcp_cloud_storage:
     bucket: "" # No default (required)
     prefix: ""
+    credentials_json: "" # No default (optional)
     scanner:
       to_the_end: {}
     delete_objects: false
@@ -85,8 +87,17 @@ The name of the bucket from which to download objects.
 
 === `prefix`
 
-An optional path prefix, if set only objects with the prefix are consumed.
+Optional path prefix, if set only objects with the prefix are consumed.
 
+*Type*: `string`
+
+*Default*: `""`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
 
 *Type*: `string`
 

--- a/modules/components/pages/inputs/gcp_pubsub.adoc
+++ b/modules/components/pages/inputs/gcp_pubsub.adoc
@@ -25,6 +25,7 @@ input:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: "" # No default (optional)
     subscription: "" # No default (required)
     endpoint: ""
     sync: false
@@ -43,6 +44,7 @@ input:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: "" # No default (optional)
     subscription: "" # No default (required)
     endpoint: ""
     sync: false
@@ -77,6 +79,16 @@ The project ID of the target subscription.
 
 
 *Type*: `string`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 
 === `subscription`

--- a/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -33,6 +33,7 @@ output:
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
     job_labels: {}
+    credentials_json: "" # No default (optional)
     csv:
       header: []
       field_delimiter: ','
@@ -64,6 +65,7 @@ output:
     max_bad_records: 0
     auto_detect: false
     job_labels: {}
+    credentials_json: "" # No default (optional)
     csv:
       header: []
       field_delimiter: ','
@@ -238,6 +240,17 @@ A list of labels to add to the load job.
 *Type*: `object`
 
 *Default*: `{}`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
 
 === `csv`
 

--- a/modules/components/pages/outputs/gcp_cloud_storage.adoc
+++ b/modules/components/pages/outputs/gcp_cloud_storage.adoc
@@ -32,6 +32,7 @@ output:
     content_type: application/octet-stream
     collision_mode: overwrite
     timeout: 3s
+    credentials_json: "" # No default (optional)
     max_in_flight: 64
     batching:
       count: 0
@@ -57,6 +58,7 @@ output:
     collision_mode: overwrite
     chunk_size: 16777216
     timeout: 3s
+    credentials_json: "" # No default (optional)
     max_in_flight: 64
     batching:
       count: 0
@@ -222,6 +224,16 @@ timeout: 1s
 
 timeout: 500ms
 ```
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `max_in_flight`
 

--- a/modules/components/pages/outputs/gcp_pubsub.adoc
+++ b/modules/components/pages/outputs/gcp_pubsub.adoc
@@ -25,6 +25,7 @@ output:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: "" # No default (optional)
     topic: "" # No default (required)
     endpoint: ""
     max_in_flight: 64
@@ -51,6 +52,7 @@ output:
   label: ""
   gcp_pubsub:
     project: "" # No default (required)
+    credentials_json: "" # No default (optional)
     topic: "" # No default (required)
     endpoint: ""
     ordering_key: "" # No default (optional)
@@ -107,6 +109,16 @@ The project ID of the topic to publish to.
 
 
 *Type*: `string`
+
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 
 === `topic`

--- a/modules/components/pages/processors/gcp_bigquery_select.adoc
+++ b/modules/components/pages/processors/gcp_bigquery_select.adoc
@@ -21,6 +21,7 @@ endif::[]
 label: ""
 gcp_bigquery_select:
   project: "" # No default (required)
+  credentials_json: "" # No default (optional)
   table: bigquery-public-data.samples.shakespeare # No default (required)
   columns: [] # No default (required)
   where: type = ? and created_at > ? # No default (optional)
@@ -74,6 +75,15 @@ GCP project where the query job will execute.
 
 *Type*: `string`
 
+=== `credentials_json`
+
+Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `table`
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2735
Review deadline: 20 September

## Page previews

[gcp_cloud_storage (cache)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/caches/gcp_cloud_storage/)
[gcp_bigquery_select (input)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/inputs/gcp_bigquery_select/)
[gcp_cloud_storage (input)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/inputs/gcp_cloud_storage/)
[gcp_pubsub (input)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/inputs/gcp_pubsub/)
[gcp_bigquery_select (output)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/outputs/gcp_bigquery/)
[gcp_cloud_storage (output)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/outputs/gcp_cloud_storage/)
[gcp_pubsub (output)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/outputs/gcp_pubsub/)
[gcp_bigquery_select (processor)](https://deploy-preview-60--redpanda-connect.netlify.app/redpanda-connect/components/processors/gcp_bigquery_select/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)