### PR TITLE
DOC-600 Field level changes for release v.4.31 to v.4.37.0

### DIFF
--- a/modules/components/pages/inputs/kafka_franz.adoc
+++ b/modules/components/pages/inputs/kafka_franz.adoc
@@ -69,6 +69,7 @@ input:
       period: ""
       check: ""
       processors: [] # No default (optional)
+    metadata_max_age: 5m
 ```
 
 --
@@ -214,7 +215,7 @@ The period of time between each commit of the current partition offsets. Offsets
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
 
 === `start_from_oldest`
 
@@ -676,5 +677,15 @@ processors:
   - archive:
       format: json_array
 ```
+
+=== `metadata_max_age`
+
+The maximum period of time after which metadata is refreshed.
+
+*Type*: `string`
+
+*Default*: `5m`
+
+
 
 // end::single-source[]

--- a/modules/components/pages/inputs/nats.adoc
+++ b/modules/components/pages/inputs/nats.adoc
@@ -28,6 +28,7 @@ input:
     subject: foo.bar.baz # No default (required)
     queue: "" # No default (optional)
     auto_replay_nacks: true
+    send_ack: true
 ```
 
 --
@@ -44,6 +45,7 @@ input:
     subject: foo.bar.baz # No default (required)
     queue: "" # No default (optional)
     auto_replay_nacks: true
+    send_ack: true
     nak_delay: 1m # No default (optional)
     prefetch_count: 524288
     tls:
@@ -88,7 +90,7 @@ NATS component, so that monitoring tools between NATS and Redpanda Connect can s
 
 == Authentication
 
-There are several components within Redpanda Connect which uses NATS services. You will find that each of these components
+There are several components within Redpanda Connect which use NATS services. You will find that each of these components
 support optional advanced authentication parameters for https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth[NKeys^]
 and https://docs.nats.io/using-nats/developer/connecting/creds[User Credentials^].
 
@@ -168,6 +170,14 @@ An optional queue group to consume as.
 
 Whether messages that are rejected (nacked) at the output level should be automatically replayed indefinitely, eventually resulting in back pressure if the cause of the rejections is persistent. If set to `false` these messages will instead be deleted. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data can be discarded immediately upon consumption and mutation.
 
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `send_ack`
+
+Whether an automatic acknowledgment is sent as a reply to each message. When enabled, these replies are sent only when data has been delivered to all outputs.
 
 *Type*: `bool`
 

--- a/modules/components/pages/inputs/nats.adoc
+++ b/modules/components/pages/inputs/nats.adoc
@@ -90,8 +90,8 @@ NATS component, so that monitoring tools between NATS and Redpanda Connect can s
 
 == Authentication
 
-There are several components within Redpanda Connect which use NATS services. You will find that each of these components
-support optional advanced authentication parameters for https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth[NKeys^]
+Several components in Redpanda Connect use NATS services. Each of these components
+supports optional advanced authentication parameters for https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth[NKeys^]
 and https://docs.nats.io/using-nats/developer/connecting/creds[User Credentials^].
 
 See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-depth tutorial^].

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -189,7 +189,7 @@ An optional consumer group. When specified, the partitions of specified topics a
 
 === `output_resource`
 
-The label of the `redpanda_migrator` output in which the currently selected topics need to be created before attempting to read messages.
+The label of the xref:components:outputs/redpanda_migrator.adoc[`redpanda_migrator` output] in which the currently selected topics need to be created before attempting to read messages.
 
 
 *Type*: `string`
@@ -198,7 +198,7 @@ The label of the `redpanda_migrator` output in which the currently selected topi
 
 === `replication_factor_override`
 
-Indicate whether to override the replication factor of the input topics when creating copies of them. You must specify the new replication factor in the <<replication-factor, `replication_factor` field>>.
+Indicate whether to override the replication factor of the input topics when creating copies of them on the output cluster. You must specify the new replication factor in the <<replication-factor, `replication_factor` field>>.
 
 *Type*: `bool`
 
@@ -728,7 +728,7 @@ The period of time between each topic lag refresh cycle.
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. Reducing this value increases the frequency with which newly created topics are identified. 
 
 *Type*: `string`
 

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -73,6 +73,9 @@ input:
       processors: [] # No default (optional)
     topic_lag_refresh_period: 5s
     output_resource: redpanda_migrator_output
+    replication_factor_override: true
+    replication_factor: 3
+    metadata_max_age: 5m
 ```
 
 --
@@ -192,7 +195,7 @@ An identifier for the client connection.
 
 *Type*: `string`
 
-*Default*: `"benthos"`
+*Default*: `benthos`
 
 === `rack_id`
 
@@ -230,7 +233,7 @@ The period of time between each commit of the current partition offsets. Offsets
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
 
 === `start_from_oldest`
 
@@ -696,7 +699,7 @@ The period of time between each topic lag refresh cycle.
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
 
 === `output_resource`
 
@@ -705,6 +708,32 @@ The label of the `redpanda_migrator` output in which the currently selected topi
 
 *Type*: `string`
 
-*Default*: `"redpanda_migrator_output"`
+*Default*: `redpanda_migrator_output`
+
+=== `replication_factor_override`
+
+Use the value specified in the `replication_factor` field when creating topics.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `replication_factor`
+
+Replication factor for created topics. This is only used when `replication_factor_override` is set to `true`.
+
+*Type*: `int`
+
+*Default*: `3`
+
+
+=== `metadata_max_age`
+
+The maximum period of time after which metadata is refreshed.
+
+*Type*: `string`
+
+*Default*: `5m`
+
 
 // end::single-source[]

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -49,6 +49,9 @@ input:
     seed_brokers: [] # No default (required)
     topics: [] # No default (required)
     regexp_topics: false
+    output_resource: redpanda_migrator_output
+    replication_factor_override: true
+    replication_factor: 3
     consumer_group: "" # No default (optional)
     client_id: benthos
     rack_id: ""
@@ -72,9 +75,6 @@ input:
       check: ""
       processors: [] # No default (optional)
     topic_lag_refresh_period: 5s
-    output_resource: redpanda_migrator_output
-    replication_factor_override: true
-    replication_factor: 3
     metadata_max_age: 5m
 ```
 
@@ -187,6 +187,31 @@ An optional consumer group. When specified, the partitions of specified topics a
 
 *Type*: `string`
 
+=== `output_resource`
+
+The label of the `redpanda_migrator` output in which the currently selected topics need to be created before attempting to read messages.
+
+
+*Type*: `string`
+
+*Default*: `redpanda_migrator_output`
+
+=== `replication_factor_override`
+
+Indicate whether to override the replication factor of the input topics when creating copies of them. You must specify the new replication factor in the <<replication-factor, `replication_factor` field>>.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+[[replication-factor]]
+=== `replication_factor`
+
+Replication factor for created topics. This is only used when `replication_factor_override` is set to `true`.
+
+*Type*: `int`
+
+*Default*: `3`
 
 === `client_id`
 
@@ -700,32 +725,6 @@ The period of time between each topic lag refresh cycle.
 *Type*: `string`
 
 *Default*: `5s`
-
-=== `output_resource`
-
-The label of the `redpanda_migrator` output in which the currently selected topics need to be created before attempting to read messages.
-
-
-*Type*: `string`
-
-*Default*: `redpanda_migrator_output`
-
-=== `replication_factor_override`
-
-Use the value specified in the `replication_factor` field when creating topics.
-
-*Type*: `bool`
-
-*Default*: `true`
-
-=== `replication_factor`
-
-Replication factor for created topics. This is only used when `replication_factor_override` is set to `true`.
-
-*Type*: `int`
-
-*Default*: `3`
-
 
 === `metadata_max_age`
 

--- a/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
@@ -14,13 +14,15 @@ component_type_dropdown::[]
 
 The `redpanda_migrator_bundle` input reads messages and schemas from an Apache Kafka or Redpanda cluster. Use this input in conjunction with the xref:components:outputs/redpanda_migrator_bundle.adoc[`redpanda_migrator_bundle` output].
 
+
+
 ```yml
 # Config fields, showing default values
 input:
   label: ""
   redpanda_migrator_bundle:
     redpanda_migrator: {} # No default (required)
-    schema_registry: {} # No default (required)
+    schema_registry: {} # No default (optional)
     migrate_schemas_before_data: true
 ```
 

--- a/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator_bundle.adoc
@@ -14,7 +14,9 @@ component_type_dropdown::[]
 
 The `redpanda_migrator_bundle` input reads messages and schemas from an Apache Kafka or Redpanda cluster. Use this input in conjunction with the xref:components:outputs/redpanda_migrator_bundle.adoc[`redpanda_migrator_bundle` output].
 
-
+ifndef::env-cloud[]
+Introduced in version 4.37.0.
+endif::[]
 
 ```yml
 # Config fields, showing default values

--- a/modules/components/pages/inputs/schema_registry.adoc
+++ b/modules/components/pages/inputs/schema_registry.adoc
@@ -44,6 +44,7 @@ input:
     url: "" # No default (required)
     include_deleted: false
     subject_filter: ""
+    fetch_in_order: true
     tls:
       enabled: false
       skip_cert_verify: false
@@ -52,6 +53,22 @@ input:
       root_cas_file: ""
       client_certs: []
     auto_replay_nacks: true
+    oauth:
+      enabled: false
+      consumer_key: ""
+      consumer_secret: ""
+      access_token: ""
+      access_token_secret: ""
+    basic_auth:
+      enabled: false
+      username: ""
+      password: ""
+    jwt:
+      enabled: false
+      private_key_file: ""
+      signing_method: ""
+      claims: {}
+      headers: {}
 ```
 
 --
@@ -111,6 +128,18 @@ Include only subjects which match the regular expression filter, or leave this f
 
 *Default*: `""`
 
+=== `fetch_in_order`
+
+Fetch all schemas from the schema registry service and sort them by ID. Set this value to `true` if you use schema references: schemas that refer to other schemas.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+ifndef::env-cloud[]
+Requires version 3.37.0 or newer
+endif::[]
+
 === `tls`
 
 Override system defaults with custom TLS settings.
@@ -130,7 +159,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -154,15 +183,7 @@ endif::[]
 
 Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
 
 *Type*: `string`
 
@@ -226,17 +247,7 @@ The plain text certificate to use.
 
 The plain text certificate key to use.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
-
-
 
 *Type*: `string`
 
@@ -266,17 +277,7 @@ A plain text password for when the private key is password encrypted in PKCS#1 o
 
 Because the obsolete `pbeWithMD5AndDES-CBC` algorithm does not authenticate the ciphertext, it is vulnerable to padding Oracle attacks that can let an attacker recover the plaintext.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
-
-
 
 *Type*: `string`
 
@@ -300,5 +301,133 @@ Set `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto r
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `oauth`
+
+Configure OAuth version 1.0 to give this component authorized access to your schema registry.
+
+*Type*: `object`
+
+=== `oauth.enabled`
+
+Whether to use OAuth version 1 in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `oauth.consumer_key`
+
+The value used to identify this component or client to your schema registry.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.consumer_secret`
+
+The secret used to establish ownership of the consumer key.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.access_token`
+
+The value this component can use to gain access to the data in the schema registry.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.access_token_secret`
+
+The secret that establishes ownership of the `oauth.access_token`.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `basic_auth`
+
+Configure basic authentication for requests from this component to your schema registry.
+
+*Type*: `object`
+
+=== `basic_auth.enabled`
+
+Whether to use basic authentication in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `basic_auth.username`
+
+The username of the account credentials to authenticate as.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `basic_auth.password`
+
+The password of the account credentials to authenticate with.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt`
+
+BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from your schema registry to this component.
+
+*Type*: `object`
+
+=== `jwt.enabled`
+
+Whether to use JWT authentication in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `jwt.private_key_file`
+
+A file in PEM format encoded via PKCS1 or PKCS8 as private key.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt.signing_method`
+
+The method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt.claims`
+
+Values used to pass the identity of the authenticated entity to the service provider. In this case, between this component and the schema registry.
+
+*Type*: `object`
+
+*Default*: `{}`
+
+=== `jwt.headers`
+
+The key/value pairs that identify the type of token and signing algorithm.
+
+*Type*: `object`
+
+*Default*: `{}`
 
 // end::single-source[]

--- a/modules/components/pages/inputs/schema_registry.adoc
+++ b/modules/components/pages/inputs/schema_registry.adoc
@@ -130,7 +130,7 @@ Include only subjects which match the regular expression filter, or leave this f
 
 === `fetch_in_order`
 
-Fetch all schemas from the schema registry service and sort them by ID. Set this value to `true` if you use schema references: schemas that refer to other schemas.
+Indicate whether to fetch all schemas from the schema registry service and sort them by ID. Set this value to `true` if you use schemas that refer to other schemas (schema references).
 
 *Type*: `bool`
 
@@ -400,7 +400,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file in PEM format encoded via PKCS1 or PKCS8 as private key.
+A PEM-encoded file containing a private key that is formatted using either PKCS1 or PKCS8 standards.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/aws_s3.adoc
+++ b/modules/components/pages/outputs/aws_s3.adoc
@@ -59,6 +59,7 @@ output:
     cache_control: ""
     content_disposition: ""
     content_language: ""
+    content_md5: ""
     website_redirect_location: ""
     metadata:
       exclude_prefixes: []
@@ -242,9 +243,15 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `content_language`
 
-The content language to set for each object.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+The content language to set for each object. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
+*Type*: `string`
+
+*Default*: `""`
+
+=== `content_md5`
+
+The https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#checking-object-integrity-md5[content MD5^] to set for each object. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -28,6 +28,7 @@ output:
   label: ""
   gcp_bigquery:
     project: ""
+    job_project: ""
     dataset: "" # No default (required)
     table: "" # No default (required)
     format: NEWLINE_DELIMITED_JSON
@@ -55,6 +56,7 @@ output:
   label: ""
   gcp_bigquery:
     project: ""
+    job_project: ""
     dataset: "" # No default (required)
     table: "" # No default (required)
     format: NEWLINE_DELIMITED_JSON
@@ -174,7 +176,6 @@ The format of each incoming message.
 Options:
 `NEWLINE_DELIMITED_JSON`
 , `CSV`
-.
 
 === `max_in_flight`
 

--- a/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Sends messages as new rows to a Google Cloud BigQuery table.
+Inserts message data as new rows in a Google Cloud BigQuery table.
 
 ifndef::env-cloud[]
 Introduced in version 3.55.0.
@@ -23,7 +23,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   gcp_bigquery:
@@ -50,7 +50,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   gcp_bigquery:
@@ -86,16 +86,16 @@ output:
 
 == Credentials
 
-By default Redpanda Connect will use a shared credentials file when connecting to GCP services. You can find out more in xref:guides:cloud/gcp.adoc[].
+By default, Redpanda Connect uses a xref:guides:cloud/gcp.adoc[shared credentials file] when connecting to GCP services.
 
 == Format
 
-This output currently supports only CSV and NEWLINE_DELIMITED_JSON formats. Learn more about how to use GCP BigQuery with them here:
+The `gcp_bigquery` output currently supports only `CSV` and `NEWLINE_DELIMITED_JSON` formats. To learn more about how to use BigQuery with these formats, see the following documentation:
 
 - https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json[`NEWLINE_DELIMITED_JSON`^]
 - https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-csv[`CSV`^]
 
-Each message may contain multiple elements separated by newlines. For example a single message containing:
+Each message may contain multiple elements separated by newlines. For example, a single message containing:
 
 ```json
 {"key": "1"}
@@ -118,20 +118,29 @@ The same is true for the CSV format.
 
 === CSV
 
-For the CSV format when the field `csv.header` is specified a header row will be inserted as the first line of each message batch. If this field is not provided then the first message of each message batch must include a header line.
+When the field `csv.header` is specified for the `CSV` format, a header row is inserted as the first line of each message batch. If this field is not provided, then the first message of each message batch must include a header line.
 
 == Performance
 
-This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+The `gcp_bigquery` output benefits from sending multiple messages in parallel for improved performance. You can tune the maximum number of in-flight messages (or message batches) with the field `max_in_flight`.
 
-This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. You can find out more xref:configuration:batching.adoc[in this doc].
+This output also sends messages as a batch for improved performance. Redpanda Connect can form batches at both the input and output level. For more information, see xref:configuration:batching.adoc[].
 
 == Fields
 
 === `project`
 
-The project ID of the dataset to insert data to. If not set, it will be inferred from the credentials or read from the GOOGLE_CLOUD_PROJECT environment variable.
+Specify the project ID of the dataset to insert data into. If not set, the project ID is inferred from the project linked to the service account or read from the `GOOGLE_CLOUD_PROJECT` environment variable.
 
+
+*Type*: `string`
+
+*Default*: `""`
+
+
+=== `job_project`
+
+Specify the project ID in which jobs are executed. If not set, the `project` value is used.
 
 *Type*: `string`
 
@@ -147,7 +156,7 @@ The BigQuery Dataset ID.
 
 === `table`
 
-The table to insert messages to.
+The table to insert messages into.
 
 
 *Type*: `string`
@@ -160,7 +169,7 @@ The format of each incoming message.
 
 *Type*: `string`
 
-*Default*: `"NEWLINE_DELIMITED_JSON"`
+*Default*: `NEWLINE_DELIMITED_JSON`
 
 Options:
 `NEWLINE_DELIMITED_JSON`
@@ -169,7 +178,7 @@ Options:
 
 === `max_in_flight`
 
-The maximum number of message batches to have in flight at a given time. Increase this to improve throughput.
+The maximum number of message batches to have in flight at a given time. Increase this value to improve throughput.
 
 
 *Type*: `int`
@@ -193,12 +202,15 @@ Options:
 
 === `create_disposition`
 
-Specifies the circumstances under which destination table will be created. If CREATE_IF_NEEDED is used the GCP BigQuery will create the table if it does not already exist and tables are created atomically on successful completion of a job. The CREATE_NEVER option ensures the table must already exist and will not be automatically created.
+Specifies the circumstances under which a destination table is created. 
+
+* Use `CREATE_IF_NEEDED` to create the destination table if it does not already exist. Tables are created atomically on successful completion of a job. 
+* Use `CREATE_NEVER` if the destination table must already exist.
 
 
 *Type*: `string`
 
-*Default*: `"CREATE_IF_NEEDED"`
+*Default*: `CREATE_IF_NEEDED`
 
 Options:
 `CREATE_IF_NEEDED`
@@ -207,7 +219,12 @@ Options:
 
 === `ignore_unknown_values`
 
-Causes values not matching the schema to be tolerated. Unknown values are ignored. For CSV this ignores extra values at the end of a line. For JSON this ignores named values that do not match any column name. If this field is set to false (the default value), records containing unknown values are treated as bad records. The max_bad_records field can be used to customize how bad records are handled.
+Set this value to `true` to ignore values that do not match the schema:
+
+* For the `CSV` format, extra values at the end of a line are ignored. 
+* For the `NEWLINE_DELIMITED_JSON` format, values that do not match any column name are ignored. 
+
+By default, this value is set to `false`, and records containing unknown values are treated as bad records. Use the `max_bad_records` field to customize how bad records are handled.
 
 
 *Type*: `bool`
@@ -216,7 +233,7 @@ Causes values not matching the schema to be tolerated. Unknown values are ignore
 
 === `max_bad_records`
 
-The maximum number of bad records that will be ignored when reading data.
+The maximum number of bad records that are ignored when reading data.
 
 
 *Type*: `int`
@@ -225,8 +242,11 @@ The maximum number of bad records that will be ignored when reading data.
 
 === `auto_detect`
 
-Indicates if we should automatically infer the options and schema for CSV and JSON sources. If the table doesn't exist and this field is set to `false` the output may not be able to insert data and will throw insertion error. Be careful using this field since it delegates to the GCP BigQuery service the schema detection and values like `"no"` may be treated as booleans for the CSV format.
+Whether this component automatically infers the options and schema for `CSV` and `NEWLINE_DELIMITED_JSON` sources. 
 
+If this value is set to `false` and the destination table doesn't exist, the output may throw an insertion error as it is unable to insert data. 
+
+CAUTION: This field delegates schema detection to the GCP BigQuery service. For the `CSV` format, values like `"no"` may be treated as booleans.
 
 *Type*: `bool`
 
@@ -236,14 +256,13 @@ Indicates if we should automatically infer the options and schema for CSV and JS
 
 A list of labels to add to the load job.
 
-
 *Type*: `object`
 
 *Default*: `{}`
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Sets the  https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^] (optional).
 
 include::components:partial$secret_warning.adoc[]
 
@@ -254,7 +273,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `csv`
 
-Specify how CSV data should be interpretted.
+Specify how CSV data is interpreted.
 
 
 *Type*: `object`
@@ -262,7 +281,7 @@ Specify how CSV data should be interpretted.
 
 === `csv.header`
 
-A list of values to use as header for each batch of messages. If not specified the first line of each message will be used as header.
+A list of values to use as the header for each batch of messages. If not specified, the first line of each message is used as the header.
 
 
 *Type*: `array`
@@ -271,7 +290,7 @@ A list of values to use as header for each batch of messages. If not specified t
 
 === `csv.field_delimiter`
 
-The separator for fields in a CSV file, used when reading or exporting data.
+The separator for fields in a CSV file. The output uses this value when reading or exporting data.
 
 
 *Type*: `string`
@@ -280,8 +299,7 @@ The separator for fields in a CSV file, used when reading or exporting data.
 
 === `csv.allow_jagged_rows`
 
-Causes missing trailing optional columns to be tolerated when reading CSV data. Missing values are treated as nulls.
-
+Set to `true` to treat optional missing trailing columns as nulls in CSV data.
 
 *Type*: `bool`
 
@@ -289,7 +307,7 @@ Causes missing trailing optional columns to be tolerated when reading CSV data. 
 
 === `csv.allow_quoted_newlines`
 
-Sets whether quoted data sections containing newlines are allowed when reading CSV data.
+Whether quoted data sections containing new lines are allowed when reading CSV data.
 
 
 *Type*: `bool`
@@ -298,7 +316,7 @@ Sets whether quoted data sections containing newlines are allowed when reading C
 
 === `csv.encoding`
 
-Encoding is the character encoding of data to be read.
+The character encoding of CSV data.
 
 
 *Type*: `string`
@@ -312,7 +330,7 @@ Options:
 
 === `csv.skip_leading_rows`
 
-The number of rows at the top of a CSV file that BigQuery will skip when reading data. The default value is 1 since Redpanda Connect will add the specified header in the first line of each batch sent to BigQuery.
+The number of rows at the top of a CSV file that BigQuery will skip when reading data. The default value is `1`, which allows Redpanda Connect to add the specified header in the first line of each batch sent to BigQuery.
 
 
 *Type*: `int`
@@ -321,7 +339,7 @@ The number of rows at the top of a CSV file that BigQuery will skip when reading
 
 === `batching`
 
-Allows you to configure a xref:configuration:batching.adoc[batching policy].
+Configure a xref:configuration:batching.adoc[batching policy].
 
 
 *Type*: `object`
@@ -347,7 +365,7 @@ batching:
 
 === `batching.count`
 
-A number of messages at which the batch should be flushed. If `0` disables count based batching.
+The number of messages after which the batch is flushed. Set to `0` to disable count-based batching.
 
 
 *Type*: `int`
@@ -356,7 +374,7 @@ A number of messages at which the batch should be flushed. If `0` disables count
 
 === `batching.byte_size`
 
-An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
+The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 
 *Type*: `int`
@@ -365,7 +383,7 @@ An amount of bytes at which the batch should be flushed. If `0` disables size ba
 
 === `batching.period`
 
-A period in which an incomplete batch should be flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 
 *Type*: `string`
@@ -384,7 +402,7 @@ period: 500ms
 
 === `batching.check`
 
-A xref:guides:bloblang/about.adoc[Bloblang query] that should return a boolean value indicating whether a message should end a batch.
+A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch.
 
 
 *Type*: `string`
@@ -399,8 +417,7 @@ check: this.type == "end_of_transaction"
 
 === `batching.processors`
 
-A list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
-
+For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches.
 
 *Type*: `array`
 

--- a/modules/components/pages/outputs/gcp_bigquery.adoc
+++ b/modules/components/pages/outputs/gcp_bigquery.adoc
@@ -234,7 +234,7 @@ By default, this value is set to `false`, and records containing unknown values 
 
 === `max_bad_records`
 
-The maximum number of bad records that are ignored when reading data.
+The maximum number of bad records to ignore when reading data and <<ignore_unknown_values, `ignore_unknown_values`>> is set to `true`.
 
 
 *Type*: `int`
@@ -245,9 +245,9 @@ The maximum number of bad records that are ignored when reading data.
 
 Whether this component automatically infers the options and schema for `CSV` and `NEWLINE_DELIMITED_JSON` sources. 
 
-If this value is set to `false` and the destination table doesn't exist, the output may throw an insertion error as it is unable to insert data. 
+If this value is set to `false` and the destination table doesn't exist, the output throws an insertion error as it is unable to insert data. 
 
-CAUTION: This field delegates schema detection to the GCP BigQuery service. For the `CSV` format, values like `"no"` may be treated as booleans.
+CAUTION: This field delegates schema detection to the GCP BigQuery service. For the `CSV` format, values like `no` may be treated as booleans.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/nats.adoc
+++ b/modules/components/pages/outputs/nats.adoc
@@ -82,8 +82,8 @@ NATS component, so that monitoring tools between NATS and Redpanda Connect can s
 
 == Authentication
 
-There are several components within Redpanda Connect which uses NATS services. You will find that each of these components
-support optional advanced authentication parameters for https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth[NKeys^]
+Several components in Redpanda Connect use NATS services. Each of these components
+supports optional advanced authentication parameters for https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth[NKeys^]
 and https://docs.nats.io/using-nats/developer/connecting/creds[User Credentials^].
 
 See an https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt[in-depth tutorial^].

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -830,7 +830,6 @@ The label of the `redpanda_migrator` input from which to read the configurations
 
 Use the value specified in the `replication_factor` field when creating topics.
 
-
 *Type*: `bool`
 
 *Default*: `true`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -218,7 +218,7 @@ partition: ${! meta("partition") }
 
 === `input_resource`
 
-The label of the `redpanda_migrator` input from which to read the configurations of topics and ACLs for creation.
+The label of the xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] from which to read the configurations of topics and ACLs for creation.
 
 
 *Type*: `string`
@@ -228,7 +228,7 @@ The label of the `redpanda_migrator` input from which to read the configurations
 
 === `replication_factor_override`
 
-Indicate whether to override the replication factor of the input topics when creating copies of them. The new replication factor must be specified in the <<replication-factor, `replication_factor` field>>.
+Indicate whether to override the replication factor of the input topics when creating copies of them on the output cluster. The new replication factor must be specified in the <<replication-factor, `replication_factor` field>>.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -60,6 +60,9 @@ output:
     key: "" # No default (optional)
     partitioner: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
+    input_resource: redpanda_migrator_input
+    replication_factor_override: true
+    replication_factor: 3
     client_id: benthos
     rack_id: ""
     idempotent_write: true
@@ -86,9 +89,6 @@ output:
       client_certs: []
     sasl: [] # No default (optional)
     timestamp: ${! timestamp_unix() } # No default (optional)
-    input_resource: redpanda_migrator_input
-    replication_factor_override: true
-    replication_factor: 3
 ```
 
 --
@@ -215,6 +215,36 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 partition: ${! meta("partition") }
 ```
 
+
+=== `input_resource`
+
+The label of the `redpanda_migrator` input from which to read the configurations of topics and ACLs for creation.
+
+
+*Type*: `string`
+
+*Default*: `"redpanda_migrator_input"`
+
+
+=== `replication_factor_override`
+
+Indicate whether to override the replication factor of the input topics when creating copies of them. The new replication factor must be specified in the <<replication-factor, `replication_factor` field>>.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+
+[[replication-factor]]
+=== `replication_factor`
+
+Replication factor for created topics. This is only used when `replication_factor_override` is set to `true`.
+
+
+*Type*: `int`
+
+*Default*: `3`
+
 === `client_id`
 
 An identifier for the client connection.
@@ -303,7 +333,7 @@ The maximum number of batches to send in parallel at any given time.
 
 === `timeout`
 
-The maximum period of time to wait for message sends before abandoning the request and retrying
+The maximum period of time to wait for message sends before abandoning the request and retrying.
 
 
 *Type*: `string`
@@ -816,32 +846,6 @@ timestamp: ${! timestamp_unix() }
 timestamp: ${! metadata("kafka_timestamp_unix") }
 ```
 
-=== `input_resource`
 
-The label of the `redpanda_migrator` input from which to read the configurations of topics and ACLs for creation.
-
-
-*Type*: `string`
-
-*Default*: `"redpanda_migrator_input"`
-
-
-=== `replication_factor_override`
-
-Use the value specified in the `replication_factor` field when creating topics.
-
-*Type*: `bool`
-
-*Default*: `true`
-
-
-=== `replication_factor`
-
-Replication factor for created topics. This is only used when `replication_factor_override` is set to `true`.
-
-
-*Type*: `int`
-
-*Default*: `3`
 
 // end::single-source[]

--- a/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
@@ -21,8 +21,8 @@ Writes messages and schemas to an Apache Kafka or Redpanda cluster. Use this out
 output:
   label: ""
   redpanda_migrator_bundle:
-    redpanda_migrator: {} # No default (optional)
-    schema_registry: {} # No default (required)
+    redpanda_migrator: {} # No default (required)
+    schema_registry: {} # No default (optional)
 ```
 
 == Fields

--- a/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
@@ -15,6 +15,10 @@ component_type_dropdown::[]
 
 Writes messages and schemas to an Apache Kafka or Redpanda cluster. Use this output in conjunction with the xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator_bundle` input].
 
+ifndef::env-cloud[]
+Introduced in version 4.37.0.
+endif::[]
+
 
 ```yml
 # Config fields, showing default values

--- a/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
@@ -21,7 +21,7 @@ Writes messages and schemas to an Apache Kafka or Redpanda cluster. Use this out
 output:
   label: ""
   redpanda_migrator_bundle:
-    redpanda_migrator: {} # No default (required)
+    redpanda_migrator: {} # No default (optional)
     schema_registry: {} # No default (required)
 ```
 

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -53,6 +53,22 @@ output:
       root_cas_file: ""
       client_certs: []
     max_in_flight: 64
+    oauth:
+      enabled: false
+      consumer_key: ""
+      consumer_secret: ""
+      access_token: ""
+      access_token_secret: ""
+    basic_auth:
+      enabled: false
+      username: ""
+      password: ""
+    jwt:
+      enabled: false
+      private_key_file: ""
+      signing_method: ""
+      claims: {}
+      headers: {}
 ```
 
 --
@@ -147,18 +163,7 @@ endif::[]
 
 Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
-
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
-
-
 
 *Type*: `string`
 
@@ -221,15 +226,7 @@ The plain text certificate to use.
 
 The plain text certificate key to use.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
 
 *Type*: `string`
 
@@ -259,15 +256,7 @@ A plain text password for when the private key is password encrypted in PKCS#1 o
 
 Because the obsolete `pbeWithMD5AndDES-CBC` algorithm does not authenticate the ciphertext, it is vulnerable to padding Oracle attacks that can let an attacker recover the plaintext.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
 
 *Type*: `string`
 
@@ -285,9 +274,136 @@ password: ${KEY_PASSWORD}
 
 The maximum number of messages to have in flight at a given time. Increase this number to improve throughput.
 
-
 *Type*: `int`
 
 *Default*: `64`
+
+=== `oauth`
+
+Configure OAuth version 1.0 to give this component authorized access to your schema registry.
+
+*Type*: `object`
+
+=== `oauth.enabled`
+
+Whether to use OAuth version 1 in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `oauth.consumer_key`
+
+The value used to identify this component or client to your schema registry.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.consumer_secret`
+
+The secret used to establish ownership of the consumer key.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.access_token`
+
+The value this component can use to gain access to the schema registry.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `oauth.access_token_secret`
+
+The secret that establishes ownership of the `oauth.access_token`.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `basic_auth`
+
+Configure basic authentication for requests from this component to your schema registry.
+
+*Type*: `object`
+
+=== `basic_auth.enabled`
+
+Whether to use basic authentication in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `basic_auth.username`
+
+The username of the account credentials to authenticate as.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `basic_auth.password`
+
+The password of the account credentials to authenticate with.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt`
+
+BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from this component to your schema registry.
+
+*Type*: `object`
+
+=== `jwt.enabled`
+
+Whether to use JWT authentication in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `jwt.private_key_file`
+
+A file in PEM format encoded via PKCS1 or PKCS8 as private key.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt.signing_method`
+
+The method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `jwt.claims`
+
+Values used to pass the identity of the authenticated entity to the service provider. In this case, between this component and the schema registry.
+
+*Type*: `object`
+
+*Default*: `{}`
+
+=== `jwt.headers`
+
+The key/value pairs that identify the type of token and signing algorithm.
+
+*Type*: `object`
+
+*Default*: `{}`
 
 // end::single-source[]

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -376,7 +376,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file in PEM format encoded via PKCS1 or PKCS8 as private key.
+A PEM-encoded file containing a private key that is formatted using either PKCS1 or PKCS8 standards.
 
 *Type*: `string`
 

--- a/modules/components/pages/processors/aws_bedrock_chat.adoc
+++ b/modules/components/pages/processors/aws_bedrock_chat.adoc
@@ -154,17 +154,7 @@ The ID of credentials to use.
 
 The secret for the credentials you want to use.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
-
-
 
 *Type*: `string`
 

--- a/modules/components/pages/processors/gcp_vertex_ai_chat.adoc
+++ b/modules/components/pages/processors/gcp_vertex_ai_chat.adoc
@@ -82,17 +82,7 @@ The GCP project ID to use.
 
 An optional field to set a Google Service Account Credentials JSON.
 
-ifndef::env-cloud[]
-[CAUTION]
-====
-This field contains sensitive information that usually shouldn't be added to a config directly, read our xref:configuration:secrets.adoc[secrets page for more info].
-====
-endif::[]
-ifdef::env-cloud[]
 include::components:partial$secret_warning.adoc[]
-endif::[]
-
-
 
 *Type*: `string`
 

--- a/modules/components/partials/feature_stability_caution.adoc
+++ b/modules/components/partials/feature_stability_caution.adoc
@@ -1,12 +1,12 @@
 ifndef::env-cloud[]
 [CAUTION]
 ====
-Breaking changes to this method may occur outside of major version releases only if a fundamental issue is identified.
+This method is in beta and may be subject breaking changes outside of major releases if issues or improvements are identified.
 ====
 endif::[]
 ifdef::env-cloud[]
 [CAUTION]
 ====
-Breaking changes to this method may occur if a fundamental issue is identified.
+This method is in beta and may be subject to breaking changes if issues or improvements are identified.
 ====
 endif::[]

--- a/modules/components/partials/feature_stability_caution.adoc
+++ b/modules/components/partials/feature_stability_caution.adoc
@@ -1,0 +1,12 @@
+ifndef::env-cloud[]
+[CAUTION]
+====
+This field contains sensitive information that usually shouldn't be added to a configuration directly. For more information, see xref:configuration:secrets.adoc[Secrets].
+====
+endif::[]
+ifdef::env-cloud[]
+[CAUTION]
+====
+This field contains sensitive information. Review your xref:redpanda-cloud:security:authorization/cloud-authorization.adoc[cluster security] before adding it to your configuration.
+====
+endif::[]

--- a/modules/components/partials/feature_stability_caution.adoc
+++ b/modules/components/partials/feature_stability_caution.adoc
@@ -1,12 +1,12 @@
 ifndef::env-cloud[]
 [CAUTION]
 ====
-This method is mostly stable. However, breaking changes could still be made to it outside of major version releases if a fundamental problem is found.
+Breaking changes to this method may occur outside of major version releases only if a fundamental issue is identified.
 ====
 endif::[]
 ifdef::env-cloud[]
 [CAUTION]
 ====
-This method is mostly stable. However, breaking changes could still be made to it if a fundamental problem is found.
+Breaking changes to this method may occur if a fundamental issue is identified.
 ====
 endif::[]

--- a/modules/components/partials/feature_stability_caution.adoc
+++ b/modules/components/partials/feature_stability_caution.adoc
@@ -1,12 +1,12 @@
 ifndef::env-cloud[]
 [CAUTION]
 ====
-This field contains sensitive information that usually shouldn't be added to a configuration directly. For more information, see xref:configuration:secrets.adoc[Secrets].
+This method is mostly stable. However, breaking changes could still be made to it outside of major version releases if a fundamental problem is found.
 ====
 endif::[]
 ifdef::env-cloud[]
 [CAUTION]
 ====
-This field contains sensitive information. Review your xref:redpanda-cloud:security:authorization/cloud-authorization.adoc[cluster security] before adding it to your configuration.
+This method is mostly stable. However, breaking changes could still be made to it if a fundamental problem is found.
 ====
 endif::[]

--- a/modules/guides/pages/bloblang/methods.adoc
+++ b/modules/guides/pages/bloblang/methods.adoc
@@ -528,12 +528,14 @@ root.the_rest = this.value.slice(0, -4)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Creates a "slug" from a given string. Wraps the github.com/gosimple/slug package. See its https://pkg.go.dev/github.com/gosimple/slug[docs^] for more information.
 
+ifndef::env-cloud[]
 Introduced in version 4.2.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -628,8 +630,9 @@ root.description = this.description.trim()
 
 Remove the provided leading prefix substring from a string. If the string does not have the prefix substring, it is returned unchanged.
 
+ifndef::env-cloud[]
 Introduced in version 4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -650,8 +653,9 @@ root.description = this.description.trim_prefix("foobar_")
 
 Remove the provided trailing suffix substring from a string. If the string does not have the suffix substring, it is returned unchanged.
 
+ifndef::env-cloud[]
 Introduced in version 4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -1398,8 +1402,9 @@ root.delay_for_s = this.delay_for.parse_duration() / 1000000000
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Attempts to parse a string using ISO-8601 rules as a duration and returns an integer of nanoseconds. A duration string is represented by the format "P[n]Y[n]M[n]DT[n]H[n]M[n]S" or "P[n]W". In these representations, the "[n]" is replaced by the value for each of the date and time elements that follow the "[n]". For example, "P3Y6M4DT12H30M5S" represents a duration of "three years, six months, four days, twelve hours, thirty minutes, and five seconds". The last field of the format allows fractions with one decimal place, so "P3.5S" will return 3500000000ns. Any additional decimals will be truncated.
 
 ==== Examples
@@ -1436,8 +1441,9 @@ root.delay_for_s = this.delay_for.parse_duration_iso8601() / 1000000000
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Parse parameter string as ISO 8601 period and add it to value with high precision for units larger than an hour.
 
 ==== Parameters
@@ -1448,8 +1454,9 @@ Parse parameter string as ISO 8601 period and add it to value with high precisio
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Attempts to format a timestamp value as a string according to a specified format, or RFC 3339 by default. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format.
 
 The output format is defined by showing how the reference time, defined to be Mon Jan 2 15:04:05 -0700 MST 2006, would be displayed if it were the value. For an alternative way to specify formats check out the <<ts_strftime, `ts_strftime`>> method.
@@ -1500,8 +1507,9 @@ root.something_at = this.created_at.ts_format("2006-Jan-02 15:04:05.999999", "UT
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Attempts to parse a string as a timestamp following a specified format and outputs a timestamp, which can then be fed into methods such as <<ts_format, `ts_format`>>.
 
 The input format is defined by showing how the reference time, defined to be Mon Jan 2 15:04:05 -0700 MST 2006, would be displayed if it were the value. For an alternative way to specify formats check out the <<ts_strptime, `ts_strptime`>> method.
@@ -1524,12 +1532,14 @@ root.doc.timestamp = this.doc.timestamp.ts_parse("2006-Jan-02")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Returns the result of rounding a timestamp to the nearest multiple of the argument duration (nanoseconds). The rounding behavior for halfway values is to round up. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
+ifndef::env-cloud[]
 Introduced in version 4.2.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -1551,7 +1561,7 @@ root.created_at_hour = this.created_at.ts_round("1h".parse_duration())
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to format a timestamp value as a string according to a specified strftime-compatible format. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format.
 
@@ -1597,7 +1607,7 @@ root.something_at = this.created_at.ts_strftime("%Y-%b-%d %H:%M:%S.%f", "UTC")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to parse a string as a timestamp following a specified strptime-compatible format and outputs a timestamp, which can then be fed into <<ts_format, `ts_format`>>.
 
@@ -1630,12 +1640,13 @@ root.doc.timestamp = this.doc.timestamp.ts_strptime("%Y-%b-%d %H:%M:%S.%f")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Returns the difference in nanoseconds between the target timestamp (t1) and the timestamp provided as a parameter (t2). The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
+ifndef::env-cloud[]
 Introduced in version 4.23.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -1657,7 +1668,7 @@ root.between = this.started_at.ts_sub("2020-08-14T05:54:23Z").abs()
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Parse parameter string as ISO 8601 period and subtract it from value with high precision for units larger than an hour.
 
@@ -1669,12 +1680,14 @@ Parse parameter string as ISO 8601 period and subtract it from value with high p
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Returns the result of converting a timestamp to a specified timezone. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
+ifndef::env-cloud[]
 Introduced in version 4.3.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -1694,7 +1707,7 @@ root.created_at_utc = this.created_at.ts_tz("UTC")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to format a timestamp value as a unix timestamp. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -1712,7 +1725,7 @@ root.created_at_unix = this.created_at.ts_unix()
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to format a timestamp value as a unix timestamp with microsecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -1730,7 +1743,7 @@ root.created_at_unix = this.created_at.ts_unix_micro()
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to format a timestamp value as a unix timestamp with millisecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -1748,7 +1761,7 @@ root.created_at_unix = this.created_at.ts_unix_milli()
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Attempts to format a timestamp value as a unix timestamp with nanosecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -2094,12 +2107,13 @@ root.has_bar = this.thing.contains(20)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Create a diff by comparing the current value with the given one. Wraps the github.com/r3labs/diff/v3 package. See its https://pkg.go.dev/github.com/r3labs/diff/v3[docs^] for more information.
 
+ifndef::env-cloud[]
 Introduced in version 4.25.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -2185,7 +2199,7 @@ root.new_dict = this.dict.filter(item -> item.value.contains("foo"))
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Returns the index of the first occurrence of a value in an array. `-1` is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
@@ -2214,7 +2228,7 @@ root.index = this.things.find(this.goal)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Returns an array containing the indexes of all occurrences of a value in an array. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
@@ -2243,7 +2257,7 @@ root.indexes = this.things.find_all(this.goal)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Returns an array containing the indexes of all occurrences of an array where the provided query resolves to a boolean `true`. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
@@ -2265,7 +2279,7 @@ root.index = this.find_all_by(v -> v != "bar")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Returns the index of the first occurrence of an array where the provided query resolves to a boolean `true`. `-1` is returned if there are no matches.
 
@@ -2406,7 +2420,7 @@ root.joined_numbers = this.numbers.map_each(this.string()).join(",")
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Executes the given JSONPath expression on an object or array and returns the result. The JSONPath expression syntax can be found at https://goessner.net/articles/JsonPath/. For more complex logic, you can use Gval expressions (https://github.com/PaesslerAG/gval).
 
@@ -2438,7 +2452,7 @@ root.text_objects = this.json_path("$.body[?(@.type=='text')]")
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Checks a https://json-schema.org/[JSON schema^] against a value and returns the value if it matches or throws and error if it does not.
 
@@ -2601,12 +2615,13 @@ root = this.foo.merge(this.bar)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Create a diff by comparing the current value with the given one. Wraps the github.com/r3labs/diff/v3 package. See its https://pkg.go.dev/github.com/r3labs/diff/v3[docs^] for more information.
 
+ifndef::env-cloud[]
 Introduced in version 4.25.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -2799,7 +2814,7 @@ root.foo = this.foo.zip(this.bar, this.baz)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
 ====
 Executes an argument Bloblang mapping on the target. This method can be used in order to execute dynamic mappings. Imports and functions that interact with the environment, such as `file` and `env`, or that access message information directly, such as `content` or `json`, are not enabled for dynamic Bloblang mappings.
 
@@ -2824,8 +2839,9 @@ root.body = this.body.bloblang(this.mapping)
 
 [CAUTION]
 ====
-This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+This method is mostly stable. However, if a fundamental problems is found, breaking changes could still be made to it outside of major version releases.
 ====
+
 Serializes a target value into a pretty-printed JSON byte array (with 4 space indentation by default).
 
 ==== Parameters
@@ -3394,14 +3410,45 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 # Out: {"h1":"c99465aa","h2":"df373d3c"}
 ```
 
+== SQL
+
+=== `vector`
+
+[CAUTION]
+====
+This method is mostly stable. However, breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+====
+
+Creates a vector from a given array of floating point numbers.
+
+This vector can be inserted into various SQL databases if they have support for embeddings vectors (for example `pgvector`).
+
+ifndef::env-cloud[]
+Introduced in version 4.33.0.
+endif::[]
+
+==== Examples
+
+Create a vector from an array literal
+
+```coffeescript
+root.embeddings = [1.2, 0.6, 0.9].vector()
+```
+Create a vector from an array
+
+```coffeescript
+root.embedding_vector = this.embedding_array.vector()
+```
+
 == JSON Web Tokens
 
 === `parse_jwt_es256`
 
 Parses a claims object from a JWT string encoded with ES256. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3424,8 +3471,9 @@ dp0Gta53G35VerNDgUUXmp78J2kfh4qLdh0XtmOMI587tCaqjvDAXfs//w==
 
 Parses a claims object from a JWT string encoded with ES384. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3449,8 +3497,9 @@ MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERoz74/B6SwmLhs8X7CWhnrWyRrB13AuU
 
 Parses a claims object from a JWT string encoded with ES512. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3475,8 +3524,9 @@ UeYyTt05zRRWuD+p5bY=
 
 Parses a claims object from a JWT string encoded with HS256. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3496,8 +3546,9 @@ root.claims = this.signed.parse_jwt_hs256("""dont-tell-anyone""")
 
 Parses a claims object from a JWT string encoded with HS384. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3517,8 +3568,9 @@ root.claims = this.signed.parse_jwt_hs384("""dont-tell-anyone""")
 
 Parses a claims object from a JWT string encoded with HS512. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3538,8 +3590,9 @@ root.claims = this.signed.parse_jwt_hs512("""dont-tell-anyone""")
 
 Parses a claims object from a JWT string encoded with RS256. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3567,8 +3620,9 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 
 Parses a claims object from a JWT string encoded with RS384. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3596,8 +3650,9 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 
 Parses a claims object from a JWT string encoded with RS512. This method does not validate JWT claims.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3625,7 +3680,9 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 
 Hash and sign an object representing JSON Web Token (JWT) claims using ES256.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
+endif::[]
 
 
 ==== Parameters
@@ -3648,8 +3705,9 @@ root.signed = this.claims.sign_jwt_es256("""-----BEGIN EC PRIVATE KEY-----
 
 Hash and sign an object representing JSON Web Token (JWT) claims using ES384.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3671,8 +3729,9 @@ root.signed = this.claims.sign_jwt_es384("""-----BEGIN EC PRIVATE KEY-----
 
 Hash and sign an object representing JSON Web Token (JWT) claims using ES512.
 
+ifndef::env-cloud[]
 Introduced in version v4.20.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3694,8 +3753,9 @@ root.signed = this.claims.sign_jwt_es512("""-----BEGIN EC PRIVATE KEY-----
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS256.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3715,8 +3775,9 @@ root.signed = this.claims.sign_jwt_hs256("""dont-tell-anyone""")
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS384.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3736,8 +3797,9 @@ root.signed = this.claims.sign_jwt_hs384("""dont-tell-anyone""")
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS512.
 
+ifndef::env-cloud[]
 Introduced in version v4.12.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3757,8 +3819,9 @@ root.signed = this.claims.sign_jwt_hs512("""dont-tell-anyone""")
 
 Hash and sign an object representing JSON Web Token (JWT) claims using RS256.
 
+ifndef::env-cloud[]
 Introduced in version v4.18.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3780,8 +3843,9 @@ root.signed = this.claims.sign_jwt_rs256("""-----BEGIN RSA PRIVATE KEY-----
 
 Hash and sign an object representing JSON Web Token (JWT) claims using RS384.
 
+ifndef::env-cloud[]
 Introduced in version v4.18.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3803,8 +3867,9 @@ root.signed = this.claims.sign_jwt_rs384("""-----BEGIN RSA PRIVATE KEY-----
 
 Hash and sign an object representing JSON Web Token (JWT) claims using RS512.
 
+ifndef::env-cloud[]
 Introduced in version v4.18.0.
-
+endif::[]
 
 ==== Parameters
 
@@ -3829,7 +3894,7 @@ root.signed = this.claims.sign_jwt_rs512("""-----BEGIN RSA PRIVATE KEY-----
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the anonymous IP associated with it.
 
@@ -3842,7 +3907,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the ASN associated with it.
 
@@ -3855,7 +3920,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the city associated with it.
 
@@ -3868,7 +3933,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the connection type associated with it.
 
@@ -3881,7 +3946,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the country associated with it.
 
@@ -3894,7 +3959,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the domain associated with it.
 
@@ -3907,7 +3972,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the enterprise associated with it.
 
@@ -3920,7 +3985,7 @@ Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind databas
 [CAUTION]
 .Experimental
 ====
-This method is experimental and therefore breaking changes could be made to it outside of major version releases.
+This method is experimental and breaking changes could be made to it outside of major version releases.
 ====
 Looks up an IP address against a https://www.maxmind.com/en/home[MaxMind database file^] and, if found, returns an object describing the ISP associated with it.
 

--- a/modules/guides/pages/bloblang/methods.adoc
+++ b/modules/guides/pages/bloblang/methods.adoc
@@ -526,10 +526,7 @@ root.the_rest = this.value.slice(0, -4)
 
 === `slug`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Creates a "slug" from a given string. Wraps the github.com/gosimple/slug package. See its https://pkg.go.dev/github.com/gosimple/slug[docs^] for more information.
 
@@ -1400,10 +1397,7 @@ root.delay_for_s = this.delay_for.parse_duration() / 1000000000
 
 === `parse_duration_iso8601`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Attempts to parse a string using ISO-8601 rules as a duration and returns an integer of nanoseconds. A duration string is represented by the format "P[n]Y[n]M[n]DT[n]H[n]M[n]S" or "P[n]W". In these representations, the "[n]" is replaced by the value for each of the date and time elements that follow the "[n]". For example, "P3Y6M4DT12H30M5S" represents a duration of "three years, six months, four days, twelve hours, thirty minutes, and five seconds". The last field of the format allows fractions with one decimal place, so "P3.5S" will return 3500000000ns. Any additional decimals will be truncated.
 
@@ -1439,10 +1433,7 @@ root.delay_for_s = this.delay_for.parse_duration_iso8601() / 1000000000
 
 === `ts_add_iso8601`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Parse parameter string as ISO 8601 period and add it to value with high precision for units larger than an hour.
 
@@ -1452,10 +1443,7 @@ Parse parameter string as ISO 8601 period and add it to value with high precisio
 
 === `ts_format`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Attempts to format a timestamp value as a string according to a specified format, or RFC 3339 by default. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format.
 
@@ -1505,10 +1493,7 @@ root.something_at = this.created_at.ts_format("2006-Jan-02 15:04:05.999999", "UT
 
 === `ts_parse`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Attempts to parse a string as a timestamp following a specified format and outputs a timestamp, which can then be fed into methods such as <<ts_format, `ts_format`>>.
 
@@ -1530,10 +1515,7 @@ root.doc.timestamp = this.doc.timestamp.ts_parse("2006-Jan-02")
 
 === `ts_round`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Returns the result of rounding a timestamp to the nearest multiple of the argument duration (nanoseconds). The rounding behavior for halfway values is to round up. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -1559,10 +1541,8 @@ root.created_at_hour = this.created_at.ts_round("1h".parse_duration())
 
 === `ts_strftime`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to format a timestamp value as a string according to a specified strftime-compatible format. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format.
 
 ==== Parameters
@@ -1605,10 +1585,8 @@ root.something_at = this.created_at.ts_strftime("%Y-%b-%d %H:%M:%S.%f", "UTC")
 
 === `ts_strptime`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to parse a string as a timestamp following a specified strptime-compatible format and outputs a timestamp, which can then be fed into <<ts_format, `ts_format`>>.
 
 ==== Parameters
@@ -1638,10 +1616,8 @@ root.doc.timestamp = this.doc.timestamp.ts_strptime("%Y-%b-%d %H:%M:%S.%f")
 
 === `ts_sub`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Returns the difference in nanoseconds between the target timestamp (t1) and the timestamp provided as a parameter (t2). The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
 ifndef::env-cloud[]
@@ -1666,10 +1642,8 @@ root.between = this.started_at.ts_sub("2020-08-14T05:54:23Z").abs()
 
 === `ts_sub_iso8601`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Parse parameter string as ISO 8601 period and subtract it from value with high precision for units larger than an hour.
 
 ==== Parameters
@@ -1678,10 +1652,7 @@ Parse parameter string as ISO 8601 period and subtract it from value with high p
 
 === `ts_tz`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Returns the result of converting a timestamp to a specified timezone. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
@@ -1705,10 +1676,8 @@ root.created_at_utc = this.created_at.ts_tz("UTC")
 
 === `ts_unix`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to format a timestamp value as a unix timestamp. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
 ==== Examples
@@ -1723,10 +1692,8 @@ root.created_at_unix = this.created_at.ts_unix()
 
 === `ts_unix_micro`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to format a timestamp value as a unix timestamp with microsecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
 ==== Examples
@@ -1741,10 +1708,8 @@ root.created_at_unix = this.created_at.ts_unix_micro()
 
 === `ts_unix_milli`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to format a timestamp value as a unix timestamp with millisecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
 ==== Examples
@@ -1759,10 +1724,8 @@ root.created_at_unix = this.created_at.ts_unix_milli()
 
 === `ts_unix_nano`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Attempts to format a timestamp value as a unix timestamp with nanosecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The <<ts_parse, `ts_parse`>> method can be used in order to parse different timestamp formats.
 
 ==== Examples
@@ -2105,10 +2068,8 @@ root.has_bar = this.thing.contains(20)
 
 === `diff`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Create a diff by comparing the current value with the given one. Wraps the github.com/r3labs/diff/v3 package. See its https://pkg.go.dev/github.com/r3labs/diff/v3[docs^] for more information.
 
 ifndef::env-cloud[]
@@ -2197,10 +2158,8 @@ root.new_dict = this.dict.filter(item -> item.value.contains("foo"))
 
 === `find`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Returns the index of the first occurrence of a value in an array. `-1` is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
 ==== Parameters
@@ -2226,10 +2185,8 @@ root.index = this.things.find(this.goal)
 
 === `find_all`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Returns an array containing the indexes of all occurrences of a value in an array. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
 ==== Parameters
@@ -2255,10 +2212,8 @@ root.indexes = this.things.find_all(this.goal)
 
 === `find_all_by`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Returns an array containing the indexes of all occurrences of an array where the provided query resolves to a boolean `true`. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
 
 ==== Parameters
@@ -2277,10 +2232,8 @@ root.index = this.find_all_by(v -> v != "bar")
 
 === `find_by`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Returns the index of the first occurrence of an array where the provided query resolves to a boolean `true`. `-1` is returned if there are no matches.
 
 ==== Parameters
@@ -2450,10 +2403,8 @@ root.text_objects = this.json_path("$.body[?(@.type=='text')]")
 
 === `json_schema`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Checks a https://json-schema.org/[JSON schema^] against a value and returns the value if it matches or throws and error if it does not.
 
 ==== Parameters
@@ -2613,10 +2564,8 @@ root = this.foo.merge(this.bar)
 
 === `patch`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Create a diff by comparing the current value with the given one. Wraps the github.com/r3labs/diff/v3 package. See its https://pkg.go.dev/github.com/r3labs/diff/v3[docs^] for more information.
 
 ifndef::env-cloud[]
@@ -2812,10 +2761,8 @@ root.foo = this.foo.zip(this.bar, this.baz)
 
 === `bloblang`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problem is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
+
 Executes an argument Bloblang mapping on the target. This method can be used in order to execute dynamic mappings. Imports and functions that interact with the environment, such as `file` and `env`, or that access message information directly, such as `content` or `json`, are not enabled for dynamic Bloblang mappings.
 
 ==== Parameters
@@ -2837,10 +2784,7 @@ root.body = this.body.bloblang(this.mapping)
 
 === `format_json`
 
-[CAUTION]
-====
-This method is mostly stable. However, if a fundamental problems is found, breaking changes could still be made to it outside of major version releases.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Serializes a target value into a pretty-printed JSON byte array (with 4 space indentation by default).
 
@@ -3414,14 +3358,11 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 
 === `vector`
 
-[CAUTION]
-====
-This method is mostly stable. However, breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
-====
+include::components:partial$feature_stability_caution.adoc[]
 
 Creates a vector from a given array of floating point numbers.
 
-This vector can be inserted into various SQL databases if they have support for embeddings vectors (for example `pgvector`).
+You can insert this vector into SQL databases that support embeddings vectors. For example, `pgvector`.
 
 ifndef::env-cloud[]
 Introduced in version 4.33.0.
@@ -3429,12 +3370,12 @@ endif::[]
 
 ==== Examples
 
-Create a vector from an array literal
+Create a vector from an array literal.
 
 ```coffeescript
 root.embeddings = [1.2, 0.6, 0.9].vector()
 ```
-Create a vector from an array
+Create a vector from an array.
 
 ```coffeescript
 root.embedding_vector = this.embedding_array.vector()


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2744
Review deadline: 10th October

## Page previews

Added `content_md5` field to [aws_s3 output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/aws_s3/?tab=tabs-1-advanced)
Added `send_ack` field to [nats_input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/nats/#send_ack)
Added auth fields to [schema_registry input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/schema_registry/#oauth) and [schema_registry output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/schema_registry/#oauth-enabled)
Added `job_project` to [gcp_bigquery output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/gcp_bigquery/) and reworded field descriptions
Made specifying the `schema_registry` in the [redpanda_migrator_bundle input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator_bundle/) and [redpanda_migrator_bundle output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_bundle/) optional
Added `replication_factor` and `replication_factor_override` to [kafka_migrator input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator/?tab=tabs-1-advanced#replication_factor_override) and [kafka_migrator output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/#replication_factor_override)
Added `metadata_max_age` to [kafka_franz input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka_franz/#metadata_max_age)
Added `metadata_max_age` to [redpanda_migrator input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator/#metadata_max_age)
Added version number (4.37.0) to [redpanda_migrator_bundle input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator_bundle/) and [redpanda_migrator_bundle output](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_bundle/)
Added `fetch_in_order` field to the [schema_registry input](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/components/inputs/schema_registry/#fetch_in_order)
Added `vector` method to [Bloblang methods ](https://deploy-preview-65--redpanda-connect.netlify.app/redpanda-connect/guides/bloblang/methods/)


## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)