### PR TITLE
Fix Redpanda Migrator cookbook

### DIFF
--- a/modules/cookbooks/pages/redpanda_migrator.adoc
+++ b/modules/cookbooks/pages/redpanda_migrator.adoc
@@ -398,6 +398,7 @@ input:
       regexp_topics: true
       consumer_group: migrator_bundle
       start_from_oldest: true
+      replication_factor_override: false
 
     schema_registry:
       url: http://localhost:8081
@@ -409,6 +410,7 @@ output:
     redpanda_migrator:
       seed_brokers: [ "localhost:9093" ]
       max_in_flight: 1
+      replication_factor_override: false
 
     schema_registry:
       url: http://localhost:8082


### PR DESCRIPTION
## Description

We need to set `replication_factor_override: false` because the default behaviour is to have topics created with replication factor set to `3` and that is not compatible with having a single Redpanda Docker container. This fix is only needed for the localhost setup.

This fix and the rename of `kafka_migrator_bundle` to `redpanda_migrator_bundle` should also be applied to the blog post: https://www.redpanda.com/blog/kafka-migrator-redpanda-connect. We should probably also adjust its URL if it's possible to do it without breaking existing links.

Review deadline: 9th October.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)