### PR TITLE
Update http_server.adoc to talk about headers more.

### DIFF
--- a/modules/components/pages/inputs/http_server.adoc
+++ b/modules/components/pages/inputs/http_server.adoc
@@ -133,6 +133,13 @@ If HTTPS is enabled, the following fields are added as well:
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolation].
 
+=== Headers
+
+Request headers are available as metadata keyed off the header name with now additional prefix. Header name casing is changed during processing to train case:
+```text
+x-api-key available as metadata("X-Api-Key")
+```
+
 == Examples
 
 [tabs]

--- a/modules/components/pages/inputs/http_server.adoc
+++ b/modules/components/pages/inputs/http_server.adoc
@@ -135,7 +135,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 === Headers
 
-Request headers are available as metadata keyed off the header name with now additional prefix. Header name casing is changed during processing to train case:
+Request headers are available as metadata keyed off the header name with no additional prefix. Header name casing is changed during processing to train case:
 ```text
 x-api-key available as metadata("X-Api-Key")
 ```

--- a/modules/components/pages/inputs/http_server.adoc
+++ b/modules/components/pages/inputs/http_server.adoc
@@ -135,7 +135,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 === Headers
 
-Request headers are available as metadata keyed off the header name with no additional prefix. Header name casing is changed during processing to train case:
+Request headers are available as metadata and use the HTTP header name with no additional prefix as a key. During processing, Redpanda Connect changes the format of the header name, as in the following example:
 ```text
 x-api-key available as metadata("X-Api-Key")
 ```


### PR DESCRIPTION
## Description
https://redpandacommunity.slack.com/archives/C075M18MAEA/p1728753394495179?thread_ts=1728740922.545079&cid=C075M18MAEA

I was having a hard time figuring out how headers were being translated into connect based on the existing documentation. This should help in the future.

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)