### PR TITLE
DOC-667 Azure Data Lake Gen2 output

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -187,6 +187,7 @@
 *** xref:components:outputs/aws_sqs.adoc[]
 *** xref:components:outputs/azure_blob_storage.adoc[]
 *** xref:components:outputs/azure_cosmosdb.adoc[]
+*** xref:components:outputs/azure_data_lake_gen2.adoc[]
 *** xref:components:outputs/azure_queue_storage.adoc[]
 *** xref:components:outputs/azure_table_storage.adoc[]
 *** xref:components:outputs/beanstalkd.adoc[]

--- a/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/modules/components/pages/outputs/amqp_0_9.adoc
@@ -11,7 +11,7 @@
 component_type_dropdown::[]
 
 
-Sends messages to an AMQP (0.91) exchange. AMQP is a messaging protocol used by various message brokers, including RabbitMQ.Connects to an AMQP (0.91) queue. AMQP is a messaging protocol used by various message brokers, including RabbitMQ.
+Sends messages to an AMQP (0.91) exchange. AMQP is a messaging protocol used by various message brokers, including RabbitMQ.
 
 
 [tabs]

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -33,7 +33,7 @@ output:
     max_in_flight: 64
 ```
 To specify a different <<path,`path` value>> (file name) for each file, use xref:configuration:interpolation.adoc#bloblang-queries[function
-interpolations], which are calculated for each message in a batch.
+interpolations]. Function interpolations are calculated for each message in a batch.
 
 == Authentication methods
 
@@ -45,9 +45,6 @@ This output supports multiple authentication methods. You must configure at leas
 - `storage_account` to access using https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DefaultAzureCredential[DefaultAzureCredential^]
 
 If you configure multiple authentication methods, the `storage_connection_string` takes precedence.
-
-NOTE: If the `storage_connection_string` field does not contain the `AccountName` parameter value, specify it in the
-`storage_account` field.
 
 == Performance
 
@@ -74,6 +71,9 @@ The access key for the storage account. Use this field along with `storage_accou
 === `storage_connection_string`
 
 The connection string for the storage account. You must enter a value for this field if no other authentication method is specified.
+
+NOTE: If the `storage_connection_string` field does not contain the `AccountName` parameter value, specify it in the
+`storage_account` field.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -48,7 +48,7 @@ If you configure multiple authentication methods, the `storage_connection_string
 
 == Performance
 
-This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+Sends multiple messages in flight in parallel for improved performance. You can tune the number of in flight messages (or message batches) with the field `max_in_flight`.
 
 == Fields
 
@@ -114,7 +114,7 @@ path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```
 === `max_in_flight`
 
-The maximum number of messages to have in flight at a given time. Increase this number to improve throughput.
+The maximum number of messages to have in flight at a given time. Increase this number to improve throughput or until performance plateaus.
 
 *Type*: `int`
 

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -104,7 +104,7 @@ The path (file name) of each message to upload to the data lake storage file sys
 
 *Type*: `string`
 
-*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
+*Default*: `${!counter()}-${!timestamp_unix_nano()}.txt`
 
 ```yml
 # Examples

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -119,3 +119,5 @@ The maximum number of messages to have in flight at a given time. Increase this 
 *Type*: `int`
 
 *Default*: `64`
+
+// end::single-source[]

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -12,7 +12,7 @@
 component_type_dropdown::[]
 
 
-Sends message parts as files to an Azure Data Lake Gen2 file system. Each file is uploaded with the file name specified in the `path` field.
+Sends message parts as files to an https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction[Azure Data Lake Gen2^] file system. Each file is uploaded with the file name specified in the `path` field.
 
 ifndef::env-cloud[]
 Introduced in version 4.38.0.

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -114,7 +114,7 @@ path: ${!json("doc.namespace")}/${!json("doc.id")}.json
 ```
 === `max_in_flight`
 
-The maximum number of messages to have in flight at a given time. Increase this number to improve throughput or until performance plateaus.
+The maximum number of messages to have in flight at a given time. Increase this number to improve throughput until performance plateaus.
 
 *Type*: `int`
 

--- a/modules/components/pages/outputs/azure_data_lake_gen2.adoc
+++ b/modules/components/pages/outputs/azure_data_lake_gen2.adoc
@@ -1,0 +1,121 @@
+= azure_data_lake_gen2
+//tag::single-source[]
+:type: output
+:page-beta: true
+
+:categories: ["Services","Azure"]
+
+
+// © 2024 Redpanda Data Inc.
+
+
+component_type_dropdown::[]
+
+
+Sends message parts as files to an Azure Data Lake Gen2 file system. Each file is uploaded with the file name specified in the `path` field.
+
+ifndef::env-cloud[]
+Introduced in version 4.38.0.
+endif::[]
+
+
+```yml
+# Configuration fields, showing default values
+output:
+  label: ""
+  azure_data_lake_gen2:
+    storage_account: "" # No default (optional)
+    storage_access_key: "" # No default (optional)
+    storage_connection_string: "" # No default (optional)
+    storage_sas_token: "" # No default (optional)
+    filesystem: messages-${!timestamp("2006")} # No default (required)
+    path: ${!counter()}-${!timestamp_unix_nano()}.txt
+    max_in_flight: 64
+```
+To specify a different <<path,`path` value>> (file name) for each file, use xref:configuration:interpolation.adoc#bloblang-queries[function
+interpolations], which are calculated for each message in a batch.
+
+== Authentication methods
+
+This output supports multiple authentication methods. You must configure at least one method from the following list:
+
+- `storage_connection_string`
+- `storage_account` and `storage_access_key`
+- `storage_account` and `storage_sas_token`
+- `storage_account` to access using https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#DefaultAzureCredential[DefaultAzureCredential^]
+
+If you configure multiple authentication methods, the `storage_connection_string` takes precedence.
+
+NOTE: If the `storage_connection_string` field does not contain the `AccountName` parameter value, specify it in the
+`storage_account` field.
+
+== Performance
+
+This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+
+== Fields
+
+=== `storage_account`
+
+The storage account to access. This field is ignored when the `storage_connection_string` field is populated.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `storage_access_key`
+
+The access key for the storage account. Use this field along with `storage_account` for authentication. This field is ignored when the `storage_connection_string` field is populated.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `storage_connection_string`
+
+The connection string for the storage account. You must enter a value for this field if no other authentication method is specified.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `storage_sas_token`
+
+The SAS token for the storage account. Use this field along with `storage_account` for authentication. This field is ignored when either the `storage_connection_string` or `storage_access_key` fields are populated.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `filesystem`
+
+The name of the data lake storage file system you want to upload messages to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+```yml
+# Examples
+filesystem: messages-${!timestamp("2006")}
+```
+
+=== `path`
+
+The path (file name) of each message to upload to the data lake storage file system. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `"${!counter()}-${!timestamp_unix_nano()}.txt"`
+
+```yml
+# Examples
+path: ${!counter()}-${!timestamp_unix_nano()}.json
+path: ${!meta("kafka_key")}.json
+path: ${!json("doc.namespace")}/${!json("doc.id")}.json
+```
+=== `max_in_flight`
+
+The maximum number of messages to have in flight at a given time. Increase this number to improve throughput.
+
+*Type*: `int`
+
+*Default*: `64`


### PR DESCRIPTION
## Description

Resolves [DOC-667](https://redpandadata.atlassian.net/browse/DOC-667)
Review deadline: 31st October

Cloud version is enabled in this PR: https://github.com/redpanda-data/cloud-docs/pull/101

## Page previews

[azure_data_lake_gen2 output](https://deploy-preview-78--redpanda-connect.netlify.app/redpanda-connect/components/outputs/azure_data_lake_gen2/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-667]: https://redpandadata.atlassian.net/browse/DOC-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ