### PR TITLE
DOC-667 Telemetry service

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:configuration:templating.adoc[]
 ** xref:configuration:dynamic_inputs_and_outputs.adoc[]
 ** xref:configuration:using_cue.adoc[]
+** xref:configuration:telemetry.adoc[]
 
 * xref:components:about.adoc[]
 ** xref:components:catalog.adoc[]

--- a/modules/configuration/pages/telemetry.adoc
+++ b/modules/configuration/pages/telemetry.adoc
@@ -1,0 +1,55 @@
+= Telemetry
+// tag::single-source[]
+
+:description: How Redpanda collects usage statistics to help improve Redpanda Connect.
+
+From version 3.48.0, the default Redpanda Connect configuration includes a telemetry service that sends anonymized usage statistics to Redpanda. Redpanda analyzes the data to find out how often each Redpanda Connect component is used in production environments, and common usage patterns. This data analysis aims to help:
+
+* Identify gaps in functionality. 
+* Prioritize the delivery of new features, enhancements, and bug fixes.
+
+For example, if usage data shows that most `aws_s3` outputs are paired with a `mutation` processor, then embedding a `mutation` field in the component might be a useful enhancement.
+
+== Data collection method
+
+When a Redpanda Connect instance executes a configuration, it sends a JSON payload to the collection server. The payload contains a high-level, anonymized summary of the contents of the configuration file. Specific field values are never transmitted, nor are decorations of the configuration, such as label names.
+
+For example, a Redpanda Connect instance executes the following configuration:
+
+```yml
+input:
+  label: message_input
+  generate:
+    interval: 1s
+    mapping: 'root.input_field = "string"'
+
+
+output:
+  label: message_output
+  aws_s3:
+    bucket: bucket_name
+    path: filename.txt
+```
+
+Redpanda extracts the following details:
+
+* A unique identifier for the Redpanda Connect instance.
+* How long the configuration has been running for.
+* Components used in the configuration. In this case, a `generate` input and an `aws_s3` output.
+* The IP address of the running Redpanda Connect instance.
+
+
+The code responsible for extracting usage data is available in the `connect` repository in https://github.com/redpanda-data/connect/blob/v4.38.0/internal/telemetry/payload.go[./payload.go^].
+
+== Data collection frequency
+
+To avoid analyzing instances used for experimentation or testing, a Redpanda Connect instance must have been running for at least 5 minutes before any usage data is collected. Once usage data starts to be emitted, it is sent to the collection server once every 24 hours. 
+
+
+== Blocking the telemetry service
+
+The telemetry service configuration is only included in the build artifacts released through https://github.com/redpanda-data/connect/releases[GitHub] or Redpanda’s official https://hub.docker.com/r/redpandadata/connect/[Docker images]. Custom builds do not send usage data. 
+
+To continue to use the official Redpanda artifacts or images but disable the telemetry service, you can block internet traffic. Redpanda Connect continues to operate normally if it is unable to send usage data.
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves: [DOC-667](https://redpandadata.atlassian.net/browse/DOC-667)
Review deadline: 30th October

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)