### PR TITLE
DOC-370 Fix SQL tagging and style issues

### DIFF
--- a/modules/components/pages/caches/sql.adoc
+++ b/modules/components/pages/caches/sql.adoc
@@ -23,11 +23,11 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 sql:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   key_column: foo # No default (required)
   value_column: bar # No default (required)
@@ -40,11 +40,11 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 sql:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   key_column: foo # No default (required)
   value_column: bar # No default (required)
@@ -123,12 +123,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -136,7 +131,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/inputs/sql_raw.adoc
+++ b/modules/components/pages/inputs/sql_raw.adoc
@@ -23,12 +23,12 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   sql_raw:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     query: SELECT * FROM footable WHERE user_id = $1; # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     auto_replay_nacks: true
@@ -40,12 +40,12 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   sql_raw:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     query: SELECT * FROM footable WHERE user_id = $1; # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     auto_replay_nacks: true
@@ -128,12 +128,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -141,7 +136,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/inputs/sql_select.adoc
+++ b/modules/components/pages/inputs/sql_select.adoc
@@ -23,12 +23,12 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   sql_select:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     table: foo # No default (required)
     columns: [] # No default (required)
     where: type = ? and created_at > ? # No default (optional)
@@ -42,12 +42,12 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   sql_select:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     table: foo # No default (required)
     columns: [] # No default (required)
     where: type = ? and created_at > ? # No default (optional)
@@ -136,12 +136,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -149,7 +144,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/outputs/sql_insert.adoc
+++ b/modules/components/pages/outputs/sql_insert.adoc
@@ -23,12 +23,12 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   sql_insert:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     table: foo # No default (required)
     columns: [] # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
@@ -46,12 +46,12 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   sql_insert:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     table: foo # No default (required)
     columns: [] # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
@@ -144,12 +144,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -157,7 +152,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/outputs/sql_raw.adoc
+++ b/modules/components/pages/outputs/sql_raw.adoc
@@ -23,12 +23,12 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   sql_raw:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
     max_in_flight: 64
@@ -45,12 +45,12 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   sql_raw:
     driver: "" # No default (required)
-    dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+    dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
     query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
     unsafe_dynamic_query: false
     args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
@@ -140,12 +140,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -153,7 +148,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/processors/sql_insert.adoc
+++ b/modules/components/pages/processors/sql_insert.adoc
@@ -23,11 +23,11 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 sql_insert:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   columns: [] # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
@@ -39,11 +39,11 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 sql_insert:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   columns: [] # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (required)
@@ -132,12 +132,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -145,7 +140,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/processors/sql_raw.adoc
+++ b/modules/components/pages/processors/sql_raw.adoc
@@ -23,11 +23,11 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 sql_raw:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
   exec_only: false
@@ -39,11 +39,11 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 sql_raw:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   query: INSERT INTO footable (foo, bar, baz) VALUES (?, ?, ?); # No default (required)
   unsafe_dynamic_query: false
   args_mapping: root = [ this.cat.meow, this.doc.woofs[0] ] # No default (optional)
@@ -145,12 +145,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -158,7 +153,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/pages/processors/sql_select.adoc
+++ b/modules/components/pages/processors/sql_select.adoc
@@ -23,11 +23,11 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 sql_select:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   columns: [] # No default (required)
   where: meow = ? and woof = ? # No default (optional)
@@ -40,11 +40,11 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 sql_select:
   driver: "" # No default (required)
-  dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60 # No default (required)
+  dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60" # No default (required)
   table: foo # No default (required)
   columns: [] # No default (required)
   where: meow = ? and woof = ? # No default (optional)
@@ -136,12 +136,7 @@ The following is a list of supported drivers, their placeholder style, and their
 
 include::components:partial$drivers_table.adoc[]
 
-Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
-
-The `snowflake` driver supports multiple DSN formats. Please consult https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[the docs^] for more details. For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8` using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0` (you can use `gbasenc` insted of `basenc` on OSX if you install `coreutils` via Homebrew). If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
-
-The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. Please refer to the https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^] for details.
-
+include::components:partial$drivers_note.adoc[]
 
 *Type*: `string`
 
@@ -149,7 +144,7 @@ The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is stil
 ```yml
 # Examples
 
-dsn: clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60
+dsn: "clickhouse://username:password@host1:9000,host2:9000/database?dial_timeout=200ms&max_execution_time=60"
 
 dsn: foouser:foopassword@tcp(localhost:3306)/foodb
 

--- a/modules/components/partials/drivers_note.adoc
+++ b/modules/components/partials/drivers_note.adoc
@@ -1,0 +1,8 @@
+[NOTE]
+====
+- By default, the `postgres` driver enforces SSL. You can override this with the parameter `sslmode=disable`.
+- The `snowflake` driver supports multiple DSN formats. For more details, see the https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String[gosnowflake documentation^]. 
++
+For https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication[key pair authentication^], the DSN has the following format: `<snowflake_user>@<snowflake_account>/<db_name>/<schema_name>?warehouse=<warehouse>&role=<role>&authenticator=snowflake_jwt&privateKey=<base64_url_encoded_private_key>`, where the value for the `privateKey` parameter can be constructed from an unencrypted RSA private key file `rsa_key.p8`, using `openssl enc -d -base64 -in rsa_key.p8 | basenc --base64url -w0`. On macOS, if you install `coreutils` with Homebrew, you can use `gbasenc` instead of `basenc`. If you have a password-encrypted private key, you can decrypt it using `openssl pkcs8 -in rsa_key_encrypted.p8 -out rsa_key.p8`. Also, make sure fields such as the username are URL-encoded.
+- The https://pkg.go.dev/github.com/microsoft/gocosmos[`gocosmos`^] driver is still experimental, but it has support for https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys[hierarchical partition keys^] as well as https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-query-container#cross-partition-query[cross-partition queries^]. For more details, see https://github.com/microsoft/gocosmos/blob/main/SQL.md[SQL notes^].
+====


### PR DESCRIPTION
## Description

Resolves: [DOC-370](https://redpandadata.atlassian.net/browse/DOC-370)
Review deadline: 7th November

- Resolves formatting error. In DSN field, text after `&` was incorrectly highlighted. Fix is to enclose value in quotes as still valid YAML.
- Updates format of note under drivers table and pulls this into a partial for easier management/maintenance.

## Page previews

- [`sql` cache](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/caches/sql/)
- [`sql_raw` input](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/inputs/sql_raw/)
- [`sql_select` input](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/inputs/sql_select/)
- [`sql_insert` output](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/outputs/sql_insert/)
- [`sql_raw` output](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/outputs/sql_raw/)
- [`sql_insert` processor](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/processors/sql_insert/)
- [`sql_raw` processor](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/processors/sql_raw/)
- [`sql_select` processor](https://deploy-preview-87--redpanda-connect.netlify.app/redpanda-connect/components/processors/sql_select/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-370]: https://redpandadata.atlassian.net/browse/DOC-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ