### PR TITLE
DOC-726 Add single sourcing to mqtt components

### DIFF
--- a/modules/components/pages/inputs/mqtt.adoc
+++ b/modules/components/pages/inputs/mqtt.adoc
@@ -5,6 +5,7 @@
 
 // © 2024 Redpanda Data Inc.
 
+// tag::single-source[]
 
 component_type_dropdown::[]
 
@@ -412,4 +413,4 @@ Whether messages that are rejected (nacked) at the output level should be automa
 
 *Default*: `true`
 
-
+// end::single-source[]

--- a/modules/components/pages/outputs/mqtt.adoc
+++ b/modules/components/pages/outputs/mqtt.adoc
@@ -5,6 +5,7 @@
 
 // © 2024 Redpanda Data Inc.
 
+// tag::single-source[]
 
 component_type_dropdown::[]
 
@@ -440,4 +441,4 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 *Default*: `64`
 
-
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves: DOC-726
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)