### PR TITLE
DOC-734 Add new timeplus input

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -78,6 +78,7 @@
 *** xref:components:inputs/sql_select.adoc[]
 *** xref:components:inputs/stdin.adoc[]
 *** xref:components:inputs/subprocess.adoc[]
+*** xref:components:inputs/timeplus.adoc[]
 *** xref:components:inputs/twitter_search.adoc[]
 *** xref:components:inputs/websocket.adoc[]
 *** xref:components:inputs/zmq4.adoc[]

--- a/modules/components/pages/inputs/timeplus.adoc
+++ b/modules/components/pages/inputs/timeplus.adoc
@@ -75,7 +75,7 @@ Replace the following placeholders with your own values:
 
 --
 
-Timeplus Enterprise (Self-Hosted) using TCP::
+timeplusd using TCP::
 +
 --
 Make sure the schema of the `url` is `tcp`.

--- a/modules/components/pages/inputs/timeplus.adoc
+++ b/modules/components/pages/inputs/timeplus.adoc
@@ -1,0 +1,156 @@
+= timeplus
+// tag::single-source[]
+:type: input
+:page-beta: true
+:categories: ["Services"]
+
+// © 2024 Redpanda Data Inc.
+
+
+component_type_dropdown::[]
+
+Executes a streaming or table query on https://docs.timeplus.com/[Timeplus Enterprise (Cloud or Self-Hosted)^] or the `timeplusd` component, and creates a structured message for each table row received.
+
+If you execute a streaming query, this input runs until the query terminates. For table queries, it shuts down after all rows returned by the query are exhausted.
+
+```yml
+# Common configuration fields, showing default values
+input:
+  label: ""
+  timeplus:
+    query: select * from iot # No default (required)
+    url: tcp://localhost:8463
+    workspace: "" # No default (optional)
+    apikey: "" # No default (optional)
+    username: "" # No default (optional)
+    password: "" # No default (optional)
+```
+
+== Examples
+
+[tabs]
+======
+Timeplus Enterprise (Cloud) using HTTP::
++
+--
+You must https://docs.timeplus.com/apikey[generate an API key^] using the web console of Timeplus Enterprise (Cloud).
+
+```yaml
+input:
+  timeplus:
+    url: https://us-west-2.timeplus.cloud
+    workspace: <workspace-id>
+    query: select * from <table-name>
+    apikey: <api-key>
+```
+Replace the following placeholders with your own values:
+
+- `<workspace-id>`: The ID of the workspace you want to read messages from.
+- `<table-name>`: The table you want to query.
+- `<api-key>`: The API key for Timeplus Enterprise REST API.
+
+--
+
+Timeplus Enterprise (Self-Hosted) using HTTP::
++
+--
+You must specify the username, password, and URL of the application server.
+
+```yaml
+input:
+  timeplus:
+    url: http://localhost:8000
+    workspace: `<workspace-id>`
+    query: select * from <table-name>
+    username: <timeplus-username>
+    password: <timeplus-password>
+```
+
+Replace the following placeholders with your own values:
+
+- `<workspace-id>`: The ID of the workspace you want to read messages from.
+- `<table-name>`: The table you want to query.
+- `<timeplus-username>`: The username for the Timeplus application server.
+- `<timeplus-password>`: The password for the Timeplus application server.
+
+--
+
+Timeplus Enterprise (Self-Hosted) using TCP::
++
+--
+Make sure the schema of the `url` is `tcp`.
+```yaml
+input:
+  timeplus:
+    url: tcp://localhost:8463
+    query: select * from <table-name>
+    username: <timeplus-username>
+    password: <timeplus-password>
+```
+
+Replace the following placeholders with your own values:
+
+- `<table-name>`: The table you want to query.
+- `<timeplus-username>`: The username for the Timeplus application server.
+- `<timeplus-password>`: The password for the Timeplus application server.
+
+--
+======
+
+== Fields
+
+=== `query`
+
+The query to execute on Timeplus Enterprise (Cloud or Self-Hosted) or `timeplusd`.
+
+*Type*: `string`
+
+```yml
+# Examples
+query: select * from iot
+query: select count(*) from table(iot)
+```
+
+=== `url`
+
+The URL of your Timeplus instance, which should always include the schema and host.
+
+*Type*: `string`
+
+*Default*: `tcp://localhost:8463`
+
+```yml
+# Examples
+url: http://localhost:8000
+url: http://127.0.0.1:3218
+```
+
+=== `workspace`
+
+The ID of the workspace you want to read messages from. This field is required if you are connecting to Timeplus Enterprise (Cloud or Self-Hosted) using HTTP.
+
+*Type*: `string`
+
+=== `apikey`
+
+The API key for the Timeplus Enterprise REST API. You need to generate the key in the web console of Timeplus Enterprise (Cloud). This field is required if you are reading messages from Timeplus Enterprise (Cloud).
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+=== `username`
+
+The username for the Timeplus application server. This field is required if you are reading messages from Timeplus Enterprise (Self-Hosted) or `timeplusd`.
+
+*Type*: `string`
+
+=== `password`
+
+The password for the Timeplus application server. This field is required if you are reading messages from Timeplus Enterprise (Self-Hosted) or `timeplusd`.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+// end::single-source[]

--- a/modules/components/pages/outputs/timeplus.adoc
+++ b/modules/components/pages/outputs/timeplus.adoc
@@ -4,9 +4,6 @@
 :page-beta: true
 :categories: ["Services"]
 
-// © 2024 Redpanda Data Inc.
-
-
 component_type_dropdown::[]
 
 

--- a/modules/components/pages/outputs/timeplus.adoc
+++ b/modules/components/pages/outputs/timeplus.adoc
@@ -201,7 +201,7 @@ The name of the destination data stream. Make sure the schema of the data stream
 
 === `apikey`
 
-The API key for the Ingest API. You need to generate this in the web console of Timeplus Enterprise (Cloud). This field is required if you are sending message to Timeplus Enterprise (Cloud).
+The API key for the Ingest API. You need to generate this in the web console of Timeplus Enterprise (Cloud). This field is required if you are sending messages to Timeplus Enterprise (Cloud).
 
 include::components:partial$secret_warning.adoc[]
 


### PR DESCRIPTION
## Description

Resolves [DOC-734](https://redpandadata.atlassian.net/browse/DOC-734)
Review deadline: 14 November

Part of docs release for v4.39.0.

Associated PR adds this connector to the Cloud docs: https://github.com/redpanda-data/cloud-docs/pull/117

## Page previews

[`timeplus` input](https://deploy-preview-91--redpanda-connect.netlify.app/redpanda-connect/components/inputs/timeplus/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-734]: https://redpandadata.atlassian.net/browse/DOC-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ