### PR TITLE
DOC-734 Add spicedb_watch input

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -74,6 +74,7 @@
 *** xref:components:inputs/socket.adoc[]
 *** xref:components:inputs/socket_server.adoc[]
 *** xref:components:inputs/splunk.adoc[]
+*** xref:components:inputs/spicedb_watch.adoc[]
 *** xref:components:inputs/sql_raw.adoc[]
 *** xref:components:inputs/sql_select.adoc[]
 *** xref:components:inputs/stdin.adoc[]

--- a/modules/components/pages/inputs/spicedb_watch.adoc
+++ b/modules/components/pages/inputs/spicedb_watch.adoc
@@ -1,0 +1,260 @@
+= spicedb_watch
+// tag::single-source[]
+:type: input
+:page-beta: true
+:categories: ["Services"]
+
+component_type_dropdown::[]
+
+Consumes messages from the https://buf.build/authzed/api/docs/main:authzed.api.v1#authzed.api.v1.WatchService.Watch[Watch API^] of a https://authzed.com/docs/spicedb/getting-started/discovering-spicedb[SpiceDB^] instance. This input is useful if you have downstream applications that need to react to real-time changes in data managed by SpiceDB.
+
+ifndef::env-cloud[]
+Introduced in version 4.39.0.
+endif::[]
+
+[tabs]
+======
+Common::
++
+--
+```yml
+# Common configuration fields, showing default values
+input:
+  label: ""
+  spicedb_watch:
+    endpoint: grpc.authzed.com:443 # No default (required)
+    bearer_token: ""
+    cache: "" # No default (required)
+```
+--
+Advanced::
++
+--
+```yml
+# All configuration fields, showing default values
+input:
+  label: ""
+  spicedb_watch:
+    endpoint: grpc.authzed.com:443 # No default (required)
+    bearer_token: ""
+    max_receive_message_bytes: 4MB
+    cache: "" # No default (required)
+    cache_key: authzed.com/spicedb/watch/last_zed_token
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+```
+--
+======
+
+== Authentication
+
+For this input to authenticate with your SpiceDB instance, you must provide:
+
+- The endpoint of the SpiceDB instance
+- A Bearer token
+
+== Configure a Cache
+
+You must store the https://authzed.com/docs/spicedb/concepts/consistency#zedtokens[ZedToken^] (ID) of the latest message consumed and acknowledged by this input in a cache. Ideally, the cache should persistent across restarts. This means that every time the input is initialized, it starts reading from the newest data updates.
+
+== Fields
+
+=== `endpoint`
+
+The endpoint of your SpiceDB instance.
+
+*Type*: `string`
+
+
+```yml
+# Examples
+endpoint: grpc.authzed.com:443
+```
+
+=== `bearer_token`
+
+The SpiceDB Bearer token to use to authenticate with your SpiceDB instance.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `max_receive_message_bytes`
+
+The maximum message size (in bytes) this input can receive.
+
+*Type*: `string`
+
+*Default*: `4MB`
+
+```yml
+# Examples
+
+max_receive_message_bytes: 100MB
+
+max_receive_message_bytes: 50mib
+```
+
+=== `cache`
+
+A cache resource to use for performing unread message backfills. The ZedToken (ID) of the last message received must be stored in this cache, which is then used for subsequent requests.
+
+=== `cache_key`
+
+The key identifier to use when storing the ZedToken (ID) of the last message received.
+
+*Type*: `string`
+
+*Default*: `authzed.com/spicedb/watch/last_zed_token`
+
+
+=== `tls`
+
+Override system defaults with custom TLS settings.
+
+*Type*: `object`
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server-side certificate verification.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 3.45.0 or newer
+endif::[]
+
+=== `tls.root_cas`
+
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+The plain text certificate to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+The plain text certificate key to use.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path to the certificate to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+The plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format. 
+
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding Oracle attacks which may allow an attacker recover the plain text password.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves: 
Review deadline: 14 November

Part of v4.39.0 release

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)