### PR TITLE
Fix formatting bug

### DIFF
--- a/modules/guides/pages/bloblang/arithmetic.adoc
+++ b/modules/guides/pages/bloblang/arithmetic.adoc
@@ -7,7 +7,7 @@ Bloblang supports a range of comparison operators `!`, `>`, `>=`, `==`, `<`, `+<
 
 == Mathematical
 
-All mathematical operators (`+`, `-`, `*`, `/`, `%`) are valid against number values, and addition (`+`) is also supported when both the left and right hand side arguments are strings. If a mathematical operator is used with an argument that is non-numeric (with the aforementioned string exception) then a xref:guides:bloblang/about.adoc#error-handling[recoverable mapping error will be thrown].
+All mathematical operators (`\+`, `-`, `*`, `/`, `%`) are valid against number values, and addition (`+`) is also supported when both the left and right hand side arguments are strings. If a mathematical operator is used with an argument that is non-numeric (with the aforementioned string exception) then a xref:guides:bloblang/about.adoc#error-handling[recoverable mapping error will be thrown].
 
 === Number degradation
 


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/connect/issues/3029

It does look OK with this change, but I don't really understand why that `+` character needs to be escaped that way. I figured it out via https://stackoverflow.com/questions/63917351/how-to-escape-double-plus-plus-sign-in-asciidoctor-asciidoc.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>

Review deadline: N/A

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [+] Small fix (typos, links, copyedits, etc)