### PR TITLE
DOC-778 Updates to Kafka components

### DIFF
--- a/modules/components/pages/inputs/cassandra.adoc
+++ b/modules/components/pages/inputs/cassandra.adoc
@@ -343,7 +343,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. 
 
 
 *Type*: `string`

--- a/modules/components/pages/inputs/kafka.adoc
+++ b/modules/components/pages/inputs/kafka.adoc
@@ -102,6 +102,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_lag
+- kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message
 - All existing message headers (version 0.11+)

--- a/modules/components/pages/inputs/kafka_franz.adoc
+++ b/modules/components/pages/inputs/kafka_franz.adoc
@@ -88,7 +88,7 @@ This input adds the following metadata fields to each message:
 - kafka_topic
 - kafka_partition
 - kafka_offset
--  kafka_timestamp_ms
+- kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message
 - All record headers

--- a/modules/components/pages/inputs/kafka_franz.adoc
+++ b/modules/components/pages/inputs/kafka_franz.adoc
@@ -88,6 +88,7 @@ This input adds the following metadata fields to each message:
 - kafka_topic
 - kafka_partition
 - kafka_offset
+-  kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message
 - All record headers

--- a/modules/components/pages/inputs/redpanda.adoc
+++ b/modules/components/pages/inputs/redpanda.adoc
@@ -128,7 +128,7 @@ This input adds the following metadata fields to each message:
 - `kafka_topic`
 - `kafka_partition`
 - `kafka_offset`
-- `kafka_timestamp`
+- `kafka_timestamp_ms`
 - `kafka_timestamp_unix`
 - `kafka_tombstone_message`
 - All record headers

--- a/modules/components/pages/inputs/redpanda_common.adoc
+++ b/modules/components/pages/inputs/redpanda_common.adoc
@@ -143,7 +143,7 @@ This input adds the following metadata fields to each message:
 - `kafka_topic`
 - `kafka_partition`
 - `kafka_offset`
-- `kafka_timestamp`
+- `kafka_timestamp_ms`
 - `kafka_timestamp_unix`
 - `kafka_tombstone_message`
 - All record headers

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -102,6 +102,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_lag
+- kafka_timestamp_ms
 - kafka_timestamp_unix
 - kafka_tombstone_message
 - All record headers

--- a/modules/components/pages/inputs/schema_registry.adoc
+++ b/modules/components/pages/inputs/schema_registry.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Reads schemas from a schema registry. You can use this connector to extract and backup schemas during a data migration.
+Reads schemas from a schema registry. You can use this connector to extract and backup schemas during a data migration. This input uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 4.32.2.

--- a/modules/components/pages/inputs/schema_registry.adoc
+++ b/modules/components/pages/inputs/schema_registry.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Reads schemas from a schema registry. You can use this connector to extract and backup schemas during a data migration. This input uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
+Reads schemas from a schema registry. You can use this connector to extract and backup schemas during a data migration. This input uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 4.32.2.

--- a/modules/components/pages/inputs/schema_registry.adoc
+++ b/modules/components/pages/inputs/schema_registry.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Reads schemas from a schema registry. You can use this connector to extract and backup schemas during a data migration. This input uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
+Reads schemas from a schema registry. You can use this connector to extract and back up schemas during a data migration. This input uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 4.32.2.

--- a/modules/components/pages/outputs/aws_dynamodb.adoc
+++ b/modules/components/pages/outputs/aws_dynamodb.adoc
@@ -412,7 +412,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/aws_kinesis.adoc
+++ b/modules/components/pages/outputs/aws_kinesis.adoc
@@ -351,7 +351,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/aws_kinesis_firehose.adoc
+++ b/modules/components/pages/outputs/aws_kinesis_firehose.adoc
@@ -321,7 +321,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/aws_sqs.adoc
+++ b/modules/components/pages/outputs/aws_sqs.adoc
@@ -378,7 +378,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/cassandra.adoc
+++ b/modules/components/pages/outputs/cassandra.adoc
@@ -381,7 +381,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/elasticsearch.adoc
+++ b/modules/components/pages/outputs/elasticsearch.adoc
@@ -393,7 +393,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/kafka.adoc
+++ b/modules/components/pages/outputs/kafka.adoc
@@ -99,7 +99,7 @@ output:
       initial_interval: 3s
       max_interval: 10s
       max_elapsed_time: 30s
-    timestamp: ${! timestamp_unix() } # No default (optional)
+    timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
 ```
 
 --
@@ -809,9 +809,9 @@ max_elapsed_time: 1m
 max_elapsed_time: 1h
 ```
 
-=== `timestamp`
+=== `timestamp_ms`
 
-An optional timestamp to set for each message. When left empty, the current timestamp is used.
+An optional timestamp (in milliseconds) to set for each message. When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
@@ -821,9 +821,9 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 // end::single-source[]

--- a/modules/components/pages/outputs/kafka.adoc
+++ b/modules/components/pages/outputs/kafka.adoc
@@ -105,7 +105,7 @@ output:
 --
 ======
 
-The configuration field `ack_replicas` determines whether we wait for acknowledgement from all replicas or just a single broker.
+The configuration field `ack_replicas` determines whether Redpanda Connect waits for acknowledgement from all replicas or just a single broker.
 
 Both the `key` and `topic` fields can be dynamically set using function interpolations described in xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries].
 

--- a/modules/components/pages/outputs/kafka.adoc
+++ b/modules/components/pages/outputs/kafka.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-The kafka output type writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating it back to the input.
+The `kafka` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating them back to the input.
 
 
 [tabs]
@@ -105,7 +105,7 @@ output:
 --
 ======
 
-The config field `ack_replicas` determines whether we wait for acknowledgement from all replicas or just a single broker.
+The configuration field `ack_replicas` determines whether we wait for acknowledgement from all replicas or just a single broker.
 
 Both the `key` and `topic` fields can be dynamically set using function interpolations described in xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries].
 

--- a/modules/components/pages/outputs/kafka.adoc
+++ b/modules/components/pages/outputs/kafka.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-The `kafka` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating them back to the input.
+The `kafka` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating any acknowledgements back to the input.
 
 
 [tabs]
@@ -760,7 +760,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. 
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/kafka.adoc
+++ b/modules/components/pages/outputs/kafka.adoc
@@ -811,7 +811,7 @@ max_elapsed_time: 1h
 
 === `timestamp_ms`
 
-An optional timestamp (in milliseconds) to set for each message. When left empty, the current timestamp is used.
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -10,7 +10,9 @@
 component_type_dropdown::[]
 
 
-A Kafka output using the https://github.com/twmb/franz-go[Franz Kafka client library^].
+The `kafka_franz` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating them back to the input. This output often outperforms the traditional `kafka` output, as well as providing more useful logs and error messages.
+
+This output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
 ifndef::env-cloud[]
 Introduced in version 3.61.0.
@@ -86,11 +88,6 @@ output:
 
 --
 ======
-
-Writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating it back to the input.
-
-This output often out-performs the traditional `kafka` output as well as providing more useful logs and error messages.
-
 
 == Fields
 

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -81,7 +81,7 @@ output:
       root_cas_file: ""
       client_certs: []
     sasl: [] # No default (optional)
-    timestamp: ${! timestamp_unix() } # No default (optional)
+    timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
 ```
 
 --
@@ -735,21 +735,20 @@ An external ID to provide when assuming a role.
 
 *Default*: `""`
 
-=== `timestamp`
+=== `timestamp_ms`
 
-An optional timestamp to set for each message. When left empty, the current timestamp is used.
+An optional timestamp (in milliseconds) to set for each message. When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
 
-
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 // end::single-source[]

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-The `kafka_franz` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating them back to the input. This output often outperforms the traditional `kafka` output, as well as providing more useful logs and error messages.
+The `kafka_franz` output writes a batch of messages to Kafka brokers and waits for acknowledgement before propagating any acknowledgments back to the input. This output often outperforms the traditional `kafka` output, as well as providing more useful logs and error messages.
 
 This output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -25,7 +25,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   kafka_franz:
@@ -50,7 +50,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   kafka_franz:
@@ -734,7 +734,7 @@ An external ID to provide when assuming a role.
 
 === `timestamp_ms`
 
-An optional timestamp (in milliseconds) to set for each message. When left empty, the current timestamp is used.
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -87,7 +87,7 @@ input:
         root_cas_file: ""
         client_certs: []
       sasl: [] # No default (optional)
-      timestamp: ${! timestamp_unix() } # No default (optional)
+      timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
     disable_content_encryption: false
     enrollment_ticket: "" # No default (optional)
     identity_name: "" # No default (optional)
@@ -644,9 +644,9 @@ An external ID to use when assuming a role.
 
 *Default*: `""`
 
-=== `kafka.timestamp`
+=== `kafka.timestamp_ms`
 
-Sets a timestamp for each message. Leave this field empty to use the current timestamp.
+Sets a timestamp (in milliseconds) for each message (optional). Leave this field empty to use the current timestamp.
 
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
@@ -654,8 +654,8 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 ```yml
 # Examples
-timestamp: ${! timestamp_unix() }
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! timestamp_unix_milli() }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 === `disable_content_encryption`

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -646,7 +646,7 @@ An external ID to use when assuming a role.
 
 === `kafka.timestamp_ms`
 
-Sets a timestamp (in milliseconds) for each message (optional). Leave this field empty to use the current timestamp.
+Set a timestamp (in milliseconds) for each message (optional). Leave this field empty to use the current timestamp.
 
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -65,7 +65,7 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
-    timestamp: ${! timestamp_unix() } # No default (optional)
+    timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
     max_in_flight: 256
     partitioner: "" # No default (optional)
     idempotent_write: true
@@ -510,7 +510,7 @@ include_patterns:
 
 === `timestamp`
 
-Set a timestamp for each message (optional). When left empty, the current timestamp is used. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
@@ -519,9 +519,9 @@ Set a timestamp for each message (optional). When left empty, the current timest
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 === `max_in_flight`

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -508,7 +508,7 @@ include_patterns:
   - _timestamp_unix$
 ```
 
-=== `timestamp`
+=== `timestamp_ms`
 
 Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -7,7 +7,7 @@
 component_type_dropdown::[]
 
 
-Sends message data to Kafka brokers and waits for acknowledgement before propagating the data back to the input.
+Sends message data to Kafka brokers and waits for acknowledgement before propagating any acknowledgements back to the input.
 
 ifndef::env-cloud[]
 Introduced in version 4.39.0.

--- a/modules/components/pages/outputs/redpanda_common.adoc
+++ b/modules/components/pages/outputs/redpanda_common.adoc
@@ -58,7 +58,7 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
-    timestamp: ${! timestamp_unix_milli() } # No default (optional)
+    timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
     max_in_flight: 10
     batching:
       count: 0

--- a/modules/components/pages/outputs/redpanda_common.adoc
+++ b/modules/components/pages/outputs/redpanda_common.adoc
@@ -58,7 +58,7 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
-    timestamp: ${! timestamp_unix() } # No default (optional)
+    timestamp: ${! timestamp_unix_milli() } # No default (optional)
     max_in_flight: 10
     batching:
       count: 0
@@ -178,9 +178,9 @@ include_patterns:
   - _timestamp_unix$
 ```
 
-=== `timestamp`
+=== `timestamp_ms`
 
-Set a timestamp for each message (optional). When left empty, the current timestamp is used. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -188,9 +188,9 @@ Set a timestamp for each message (optional). When left empty, the current timest
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 === `max_in_flight`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -246,14 +246,7 @@ Replication factor for created topics. This is only used when `replication_facto
 
 *Default*: `3`
 
-=== `client_id`
 
-An identifier for the client connection.
-
-
-*Type*: `string`
-
-*Default*: `"benthos"`
 
 === `translate_schema_ids`
 
@@ -269,7 +262,16 @@ The label of the xref:components:outputs/schema_registry.adoc[schema_registry ou
 
 *Type*: `string`
 
-*Default*: `"schema_registry_output"`
+*Default*: `schema_registry_output`
+
+=== `client_id`
+
+An identifier for the client connection.
+
+
+*Type*: `string`
+
+*Default*: `benthos`
 
 === `rack_id`
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -247,7 +247,6 @@ Replication factor for created topics. This is only used when `replication_facto
 *Default*: `3`
 
 
-
 === `translate_schema_ids`
 
 Encodes Redpanda schema IDs ready for consumption by an Apache Kafka broker.

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -25,7 +25,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   redpanda_migrator:
@@ -50,7 +50,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   redpanda_migrator:
@@ -258,7 +258,7 @@ Encodes Redpanda schema IDs ready for consumption by an Apache Kafka broker.
 
 === `schema_registry_output_resource`
 
-The label of the xref:components:outputs/schema_registry.adoc[schema_registry output] to user for fetching schema IDs.
+The label of the xref:components:outputs/schema_registry.adoc[schema_registry output] to use for fetching schema IDs.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -89,7 +89,7 @@ output:
       root_cas_file: ""
       client_certs: []
     sasl: [] # No default (optional)
-    timestamp: ${! timestamp_unix() } # No default (optional)
+    timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
 ```
 
 --
@@ -126,7 +126,7 @@ output:
     key: ${! metadata("kafka_key") }
     partitioner: manual
     partition: ${! metadata("kafka_partition").or(throw("missing kafka_partition metadata")) }
-    timestamp: ${! metadata("kafka_timestamp_unix").or(timestamp_unix()) }
+    timestamp_ms: ${! metadata("kafka_timestamp_ms").or(timestamp_unix_milli()) }
     input_resource: redpanda_migrator_input
     max_in_flight: 1
 ```
@@ -846,9 +846,9 @@ An external ID to provide when assuming a role.
 
 *Default*: `""`
 
-=== `timestamp`
+=== `timestamp_ms`
 
-An optional timestamp to set for each message. When left empty, the current timestamp is used.
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
@@ -858,9 +858,9 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -62,6 +62,8 @@ output:
     input_resource: redpanda_migrator_input
     replication_factor_override: true
     replication_factor: 3
+    translate_schema_ids: true
+    schema_registry_output_resource: schema_registry_output
     client_id: benthos
     rack_id: ""
     idempotent_write: true
@@ -188,7 +190,7 @@ Override the default murmur2 hashing partitioner.
 | Option | Summary
 
 | `least_backup`
-| Chooses the least backed up partition (the partition with the fewest amount of buffered records). Partitions are selected per batch.
+| Chooses the least backed up partition (the partition with the fewest buffered records). Partitions are selected per batch.
 | `manual`
 | Manually select a partition for each message. You must also specify a value for the `partition` field.
 | `murmur2_hash`
@@ -252,6 +254,22 @@ An identifier for the client connection.
 *Type*: `string`
 
 *Default*: `"benthos"`
+
+=== `translate_schema_ids`
+
+Encodes Redpanda schema IDs ready for consumption by an Apache Kafka broker.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `schema_registry_output_resource`
+
+The label of the xref:components:outputs/schema_registry.adoc[schema_registry output] to user for fetching schema IDs.
+
+*Type*: `string`
+
+*Default*: `"schema_registry_output"`
 
 === `rack_id`
 
@@ -375,7 +393,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 
 *Type*: `int`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -10,7 +10,7 @@
 
 component_type_dropdown::[]
 
-Writes a batch of messages to an Apache Kafka broker and waits for acknowledgement before propagating them back to the input.
+Writes a batch of messages to an Apache Kafka broker and waits for acknowledgement before propagating any acknowledgements back to the input.
 
 Use this connector in conjunction with the xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] to migrate topics between Kafka brokers. The `redpanda_migrator` output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
@@ -246,10 +246,9 @@ Replication factor for created topics. This is only used when `replication_facto
 
 *Default*: `3`
 
-
 === `translate_schema_ids`
 
-Encodes Redpanda schema IDs ready for consumption by an Apache Kafka broker.
+When set to `true` translates the schema ID in each message ready to write to the destination schema registry.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -457,7 +457,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `max_in_flight`
 
-The maximum number of message batches to send parallel at any given time.
+The maximum number of message batches to send in parallel at any given time.
 
 *Type*: `int`
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -12,7 +12,7 @@
 component_type_dropdown::[]
 
 
-Use the `redpanda_migrator_offsets` output in conjunction with the `kafka_franz` input that is configured to read the `__consumer_offsets` topic.
+Use the `redpanda_migrator_offsets` output in conjunction with a `kafka_franz` input that is configured to read the `__consumer_offsets` topic.
 This output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
 
@@ -47,12 +47,7 @@ output:
   label: ""
   redpanda_migrator_offsets:
     seed_brokers: [] # No default (required)
-    kafka_key: ${! @kafka_key }
     client_id: benthos
-    max_in_flight: 1
-    timeout: 10s
-    max_message_bytes: 1MB
-    broker_write_max_bytes: 100MB
     tls:
       enabled: false
       skip_cert_verify: false
@@ -61,6 +56,12 @@ output:
       root_cas_file: ""
       client_certs: []
     sasl: [] # No default (optional)
+    metadata_max_age: 5m
+    kafka_key: ${! @kafka_key }
+    max_in_flight: 1
+    timeout: 10s
+    max_message_bytes: 1MB
+    broker_write_max_bytes: 100MB
     max_retries: 0
     backoff:
       initial_interval: 1s
@@ -76,7 +77,6 @@ output:
 === `seed_brokers`
 
 A list of broker addresses to connect to. Use commas to separate multiple addresses in a single list item.
-
 
 *Type*: `array`
 
@@ -95,77 +95,14 @@ seed_brokers:
   - foo:9092,bar:9092
 ```
 
-=== `kafka_key`
-
-Kafka key.
-
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
-
-*Type*: `string`
-
-*Default*: `"${! @kafka_key }"`
-
 === `client_id`
 
 An identifier for the client connection.
 
-
 *Type*: `string`
 
-*Default*: `"benthos"`
+*Default*: `benthos`
 
-=== `max_in_flight`
-
-The maximum number of batches to send parallel at any given time.
-
-
-*Type*: `int`
-
-*Default*: `1`
-
-=== `timeout`
-
-The maximum period of time to wait for message sends before abandoning the request and retrying
-
-
-*Type*: `string`
-
-*Default*: `"10s"`
-
-=== `max_message_bytes`
-
-The maximum space in bytes that an individual message may use. Messages larger than this value are rejected. This field corresponds to Kafka's `max.message.bytes`.
-
-
-*Type*: `string`
-
-*Default*: `"1MB"`
-
-```yml
-# Examples
-
-max_message_bytes: 100MB
-
-max_message_bytes: 50mib
-```
-
-=== `broker_write_max_bytes`
-
-The upper bound for the number of bytes written to a broker connection in a single write. This field corresponds to Kafka's `socket.request.max.bytes`.
-
-
-*Type*: `string`
-
-*Default*: `"100MB"`
-
-```yml
-# Examples
-
-broker_write_max_bytes: 128MB
-
-broker_write_max_bytes: 50mib
-```
 
 === `tls`
 
@@ -174,11 +111,9 @@ Override system defaults with custom TLS settings.
 
 *Type*: `object`
 
-
 === `tls.enabled`
 
 Whether custom TLS settings are enabled.
-
 
 *Type*: `bool`
 
@@ -187,7 +122,6 @@ Whether custom TLS settings are enabled.
 === `tls.skip_cert_verify`
 
 Whether to skip server-side certificate verification.
-
 
 *Type*: `bool`
 
@@ -208,7 +142,7 @@ endif::[]
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -227,7 +161,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 
 *Type*: `string`
@@ -308,7 +242,6 @@ Because the obsolete `pbeWithMD5AndDES-CBC` algorithm does not authenticate the 
 include::components:partial$secret_warning.adoc[]
 
 
-
 *Type*: `string`
 
 *Default*: `""`
@@ -323,7 +256,7 @@ password: ${KEY_PASSWORD}
 
 === `sasl`
 
-Specify one or more methods of SASL authentication. SASL mechanisms are tried in order. If the broker supports the first mechanism, all connections use that mechanism. If the first mechanism fails, the client picks the first supported mechanism. Connections fail if the broker does not support any client mechanisms.
+Specify one or more methods of SASL authentication, which are attempted in order. If the broker supports the first mechanism, all connections use that mechanism. If the first mechanism fails, the client picks the first supported mechanism. Connections fail if the broker does not support any client mechanisms.
 
 
 *Type*: `array`
@@ -350,23 +283,23 @@ The SASL mechanism to use.
 | Option | Summary
 
 | `AWS_MSK_IAM`
-| AWS IAM based authentication as specified by the `aws-msk-iam-auth` java library.
+| AWS IAM-based authentication as specified by the `aws-msk-iam-auth` Java library.
 | `OAUTHBEARER`
-| OAuth Bearer based authentication.
+| OAuth bearer-based authentication.
 | `PLAIN`
 | Plain text authentication.
 | `SCRAM-SHA-256`
-| SCRAM based authentication as specified in RFC5802.
+| SCRAM-based authentication as specified in RFC 5802.
 | `SCRAM-SHA-512`
-| SCRAM based authentication as specified in RFC5802.
+| SCRAM-based authentication as specified in RFC 5802.
 | `none`
-| Disable sasl authentication
+| Disable SASL authentication
 
 |===
 
 === `sasl[].username`
 
-A username to provide for PLAIN or SCRAM-* authentication.
+A username to provide for `PLAIN` or `SCRAM-*` authentication.
 
 
 *Type*: `string`
@@ -375,10 +308,9 @@ A username to provide for PLAIN or SCRAM-* authentication.
 
 === `sasl[].password`
 
-A password to provide for PLAIN or SCRAM-* authentication.
+A password to provide for `PLAIN` or `SCRAM-*` authentication.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -387,7 +319,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `sasl[].token`
 
-The token to use for a single session's OAUTHBEARER authentication.
+The token to use for a single session's `OAUTHBEARER` authentication.
 
 
 *Type*: `string`
@@ -396,7 +328,7 @@ The token to use for a single session's OAUTHBEARER authentication.
 
 === `sasl[].extensions`
 
-Key/value pairs to add to OAUTHBEARER authentication requests.
+Key/value pairs to add to `OAUTHBEARER` authentication requests.
 
 
 *Type*: `object`
@@ -430,11 +362,9 @@ Specify a custom endpoint for the AWS API.
 
 === `sasl[].aws.credentials`
 
-Manual configuration of AWS credentials to use (optional). For more information, see xref:guides:cloud/aws.adoc[].
-
+Manually configure the AWS credentials to use (optional). For more information, see the xref:guides:cloud/aws.adoc[Amazon Web Services guide].
 
 *Type*: `object`
-
 
 === `sasl[].aws.credentials.profile`
 
@@ -459,7 +389,6 @@ The ID of credentials to use.
 The secret for the credentials being used.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -501,10 +430,81 @@ A role ARN to assume.
 
 An external ID to provide when assuming a role.
 
-
 *Type*: `string`
 
 *Default*: `""`
+
+
+== metadata_max_age
+
+The maximum period of time after which metadata is refreshed.
+
+*Type*: `string`
+
+*Default*: `5m`
+
+
+=== `kafka_key`
+
+The Kafka key of a message.
+
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `${! @kafka_key }`
+
+
+=== `max_in_flight`
+
+The maximum number of message batches to send parallel at any given time.
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `timeout`
+
+The maximum period of time to wait for message sends before abandoning the request and retrying it.
+
+
+*Type*: `string`
+
+*Default*: `10s`
+
+=== `max_message_bytes`
+
+The maximum number of bytes that an individual message may use. Messages larger than this value are rejected. This field corresponds to Kafka's `max.message.bytes`.
+
+
+*Type*: `string`
+
+*Default*: `1MB`
+
+```yml
+# Examples
+
+max_message_bytes: 100MB
+
+max_message_bytes: 50mib
+```
+
+=== `broker_write_max_bytes`
+
+The upper bound for the number of bytes written to a broker connection in a single write. This field corresponds to Kafka's `socket.request.max.bytes`.
+
+
+*Type*: `string`
+
+*Default*: `100MB`
+
+```yml
+# Examples
+
+broker_write_max_bytes: 128MB
+
+broker_write_max_bytes: 50mib
+```
 
 === `max_retries`
 
@@ -515,39 +515,38 @@ The maximum number of retries before giving up on the request. If set to `0`, th
 
 *Default*: `0`
 
+
 === `backoff`
 
 Control the time intervals between retry attempts.
-
 
 *Type*: `object`
 
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
-
+The initial amount of time to wait between retry attempts. This value increases for each failed attempt up to the `backoff.max_interval` value.
 
 *Type*: `string`
 
-*Default*: `"1s"`
+*Default*: `1s`
+
 
 === `backoff.max_interval`
 
-The maximum period to wait between retry attempts.
-
+The maximum amount of time to wait between retry attempts.
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
+
 
 === `backoff.max_elapsed_time`
 
-The maximum period to wait before retry attempts are abandoned. If set to `0`, there is no waiting period.
-
+The maximum amount of time to wait before retry attempts are abandoned. If set to `0`, there is no waiting period.
 
 *Type*: `string`
 
-*Default*: `"30s"`
+*Default*: `30s`
 
 // end::single-source[]

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -446,7 +446,7 @@ The maximum period of time after which metadata is refreshed.
 
 === `kafka_key`
 
-The Kafka key of a message.
+The Kafka message key.
 
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -435,7 +435,7 @@ An external ID to provide when assuming a role.
 *Default*: `""`
 
 
-== metadata_max_age
+=== metadata_max_age
 
 The maximum period of time after which metadata is refreshed.
 

--- a/modules/components/pages/outputs/retry.adoc
+++ b/modules/components/pages/outputs/retry.adoc
@@ -75,7 +75,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. 
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -11,7 +11,7 @@
 component_type_dropdown::[]
 
 
-Publishes schemas to a schema registry.
+Publishes schemas to a schema registry. This output uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 4.32.2.
@@ -45,6 +45,8 @@ output:
   schema_registry:
     url: "" # No default (required)
     subject: "" # No default (required)
+    backfill_dependencies: true
+    input_resource: schema_registry_input
     tls:
       enabled: false
       skip_cert_verify: false
@@ -108,17 +110,31 @@ output:
 
 The base URL of the schema registry service.
 
-
 *Type*: `string`
-
 
 === `subject`
 
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+The subject name.
 
+This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
+=== `backfill_dependencies`
+
+Backfill missing schema references and previous versions.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `input_resource`
+
+The label of the xref:components:inputs/schema_registry.adoc[`schema_registry` input] from which to read source schemas.
+
+*Type*: `string`
+
+*Default*: `schema_registry_input`
 
 === `tls`
 
@@ -161,7 +177,7 @@ endif::[]
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -180,7 +196,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -11,7 +11,7 @@
 component_type_dropdown::[]
 
 
-Publishes schemas to a schema registry. This output uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
+Publishes schemas to a schema registry. This output uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 4.32.2.
@@ -46,7 +46,6 @@ output:
     url: "" # No default (required)
     subject: "" # No default (required)
     backfill_dependencies: true
-    translate_ids: true
     input_resource: schema_registry_input
     tls:
       enabled: false
@@ -123,15 +122,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `backfill_dependencies`
 
-Backfill missing schema references and previous versions.
-
-*Type*: `bool`
-
-*Default*: `true`
-
-=== `translate_ids`
-
-Encodes Redpanda schema IDs ready to publish to a schema registry.
+Backfill missing schema references and previous schema versions. If set to `true`, you must also configure a xref:components:inputs/schema_registry.adoc[`schema_registry`] input to read source schemas.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -46,6 +46,7 @@ output:
     url: "" # No default (required)
     subject: "" # No default (required)
     backfill_dependencies: true
+    translate_ids: true
     input_resource: schema_registry_input
     tls:
       enabled: false
@@ -123,6 +124,14 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 === `backfill_dependencies`
 
 Backfill missing schema references and previous versions.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `translate_ids`
+
+Encodes Redpanda schema IDs ready to publish to a schema registry.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/redpanda_data_transform.adoc
+++ b/modules/components/pages/processors/redpanda_data_transform.adoc
@@ -53,7 +53,7 @@ redpanda_data_transform:
   output_metadata:
     include_prefixes: []
     include_patterns: []
-  timestamp: ${! timestamp_unix() } # No default (optional)
+  timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
   timeout: 10s
   max_memory_pages: 1600
 ```
@@ -195,7 +195,7 @@ include_patterns:
 
 === `timestamp`
 
-An optional timestamp to set for each message. When left empty, the current timestamp is used.
+Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
@@ -205,9 +205,9 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 ```yml
 # Examples
 
-timestamp: ${! timestamp_unix() }
+timestamp_ms: ${! timestamp_unix_milli() }
 
-timestamp: ${! metadata("kafka_timestamp_unix") }
+timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 ```
 
 === `timeout`

--- a/modules/components/pages/processors/redpanda_data_transform.adoc
+++ b/modules/components/pages/processors/redpanda_data_transform.adoc
@@ -193,7 +193,7 @@ include_patterns:
   - _timestamp_unix$
 ```
 
-=== `timestamp`
+=== `timestamp_ms`
 
 Set a timestamp (in milliseconds) for each message (optional). When left empty, the current timestamp is used.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].

--- a/modules/components/pages/processors/retry.adoc
+++ b/modules/components/pages/processors/retry.adoc
@@ -104,7 +104,7 @@ Determine time intervals and cut offs for retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
 
 
 *Type*: `string`

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -12,6 +12,8 @@ component_type_dropdown::[]
 
 Automatically decodes and validates messages with schemas from a Confluent Schema Registry service.
 
+This processor uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
+
 
 [tabs]
 ======
@@ -66,7 +68,7 @@ schema_registry_decode:
 
 Decodes messages automatically from a schema stored within a https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry service^] by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error handling methods].
 
-Avro, Protobuf and Json schemas are supported, all are capable of expanding from schema references as of v4.22.0.
+Avro, Protobuf and JSON schemas are supported, all are capable of expanding from schema references as of v4.22.0.
 
 == Avro JSON format
 

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -12,7 +12,7 @@ component_type_dropdown::[]
 
 Automatically decodes and validates messages with schemas from a Confluent Schema Registry service.
 
-This processor uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
+This processor uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
 
 
 [tabs]

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -12,7 +12,7 @@ component_type_dropdown::[]
 
 Automatically encodes and validates messages with schemas from a Confluent Schema Registry service. 
 
-This processor uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
+This processor uses the https://github.com/twmb/franz-go/tree/master/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 3.58.0.

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -10,7 +10,9 @@
 component_type_dropdown::[]
 
 
-Automatically encodes and validates messages with schemas from a Confluent Schema Registry service.
+Automatically encodes and validates messages with schemas from a Confluent Schema Registry service. 
+
+This processor uses the https://pkg.go.dev/github.com/twmb/franz-go/pkg/sr[Franz Kafka Schema Registry client^].
 
 ifndef::env-cloud[]
 Introduced in version 3.58.0.


### PR DESCRIPTION
## Description

Resolves [https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>](https://redpandadata.atlassian.net/browse/DOC-778)
Review deadline: 2nd December

Includes all changes in v4.40.0 for related Kafka components, including:

- Changes to timestamps from `timestamp` to `timestamp_ms` including updates to metadata fields
- New schema and backfill fields
- Update to Schema registry client
- Addition of metadata_max-age to `redpanda_migrator_offsets` output

## Page previews

**Inputs**
[kafka](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka/)
[kafka_franz](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka_franz/)
[redpanda](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda/)
[redpanda_common](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_common/)
[redpanda_migrator](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator/)
[schema_registry](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/inputs/schema_registry/)

**Outputs**
[kafka](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/kafka/)
[kafka_franz](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/kafka_franz/)
[ockam_kafka](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/ockam_kafka/)
[redpanda](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda/)
[redpanda_common](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_common/)
[redpanda_migrator](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/)
[redpanda_migrator_offsets](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_offsets/)
[schema_registry](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/outputs/schema_registry/)

**Processors**
[redpanda_data_transform](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/processors/redpanda_data_transform/)
[schema_registry_encode](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_encode/)
[schema_registry_decode](https://deploy-preview-107--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_decode/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)