### PR TITLE
DOC-778 Updates to snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -44,7 +44,7 @@ output:
       byte_size: 0
       period: ""
       check: ""
-    max_in_flight: 64
+    max_in_flight: 4
 ```
 
 --
@@ -80,14 +80,16 @@ output:
           this == "timestamp" => "TIMESTAMP"
           _ => "VARIANT"
         }
-    build_parallelism: 1
+    build_options:
+      parallelism: 1
+      chunk_size: 50000
     batching:
       count: 0
       byte_size: 0
       period: ""
       check: ""
       processors: [] # No default (optional)
-    max_in_flight: 64
+    max_in_flight: 4
     channel_prefix: "" # No default (optional)
 ```
 
@@ -175,15 +177,18 @@ This output emits the following metrics.
 
 === `account`
 
-The Snowflake account name to use, also known as the https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used[account identifier^].
+The https://docs.snowflake.com/en/user-guide/admin-account-identifier#account-name[Snowflake account name to use^]. 
 
-NOTE: If you use an https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier[account locator^] to identify an account, for example: `<account_locator>.<region_id>.<cloud>`, specify only the `<account locator>` element in the `account` field.
+Use the format `<orgname>-<account_name>` where:
+
+- The `<orgname>` is the name of your Snowflake organization.
+- The `<account_name>` is the unique name of your account with your Snowflake organization.
 
 *Type*: `string`
 
 ```yml
 # Examples
-account: AAAAAAA-AAAAAAA
+account: ORG-ACCOUNT
 ```
 
 === `user`
@@ -307,13 +312,27 @@ root = match this.value.type() {
   }
 ```
 
-=== `build_parallelism`
+=== `build_options`
 
-The maximum amount of parallel processing to use when building the output for Snowflake. Monitor the `snowflake_build_output_latency_ns` metric to assess whether you need to increase this value.
+Options for optimizing the build of the output data that is sent to Snowflake. Monitor the `snowflake_build_output_latency_ns` metric to assess whether you need to update these options.
+
+*Type*: `object`
+
+=== `build_options.parallelism`
+
+The maximum amount of parallel processing to use when building the output for Snowflake.
 
 *Type*: `int`
 
 *Default*: `1`
+
+=== `build_options.chunk_size`
+
+The number of table rows to submit in each chunk for processing.
+
+*Type*: `int`
+
+*Default*: `50000`
 
 === `batching`
 
@@ -414,7 +433,7 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 *Type*: `int`
 
-*Default*: `64`
+*Default*: `4`
 
 === `channel_prefix`
 
@@ -473,6 +492,8 @@ output:
     table: "MYTABLE"
     private_key_file: "my/private/key.p8"
     channel_prefix: "snowflake-channel-for-${HOST}"
+    schema_evolution:
+      enabled:true
 ```
 --
 HTTP server to push data to Snowflake::


### PR DESCRIPTION
## Description

Resolves [https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>](https://redpandadata.atlassian.net/browse/DOC-778)
Review deadline: 27 November

Includes:

- Changes to `max_in_flight` default 
- New build options
- `schema_evolution` set to `true` in example to autocreate tables
- Updates to `account` field description

## Page previews

[snowflake_streaming output](https://deploy-preview-108--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)