### PR TITLE
Update templating.adoc

### DIFF
--- a/modules/configuration/pages/templating.adoc
+++ b/modules/configuration/pages/templating.adoc
@@ -14,7 +14,7 @@ A template is defined in a YAML file that can be imported when Redpanda Connect 
 
 [source,bash]
 ----
-rpk connect run -t "./templates/*.yaml" -c ./config.yaml
+rpk connect run -t "./templates/*.yaml" ./config.yaml
 ----
 
 The template describes the type of the component and configuration fields that can be used to customize it, followed by a xref:guides:bloblang/about.adoc[Bloblang mapping] that translates an object containing those fields into a Redpanda Connect config structure. This allows you to use logic to generate more complex configurations:


### PR DESCRIPTION
## Description

Fix a small typo. It was raised here https://github.com/redpanda-data/connect/pull/3040
## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)