### PR TITLE
Fix typo in pg_stream doc

### DIFF
--- a/modules/components/pages/inputs/pg_stream.adoc
+++ b/modules/components/pages/inputs/pg_stream.adoc
@@ -165,7 +165,7 @@ This input adds the following metadata fields to each message:
 
 - `mode`: Whether a message is part of the snapshot processing of existing data in a database (`snapshot`) or a data update streamed to Redpanda Connect (`streaming`).
 - `table`: The name of the database table from which the message originated.
-- `operation`: The type of database operation that generated the message, such as `INSERT`, `UPDATE`, `DELETE`, `BEGIN` and `COMMIT`. `BEGIN` are `COMMIT` operations are only included if the `include_transaction_markers` field is set to `true`.
+- `operation`: The type of database operation that generated the message, such as `INSERT`, `UPDATE`, `DELETE`, `BEGIN` and `COMMIT`. `BEGIN` and `COMMIT` operations are only included if the `include_transaction_markers` field is set to `true`.
 
 == Fields
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)