### PR TITLE
DOC-849 Add benchmark processor to Self-Managed

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -119,6 +119,7 @@
 *** xref:components:processors/aws_dynamodb_partiql.adoc[]
 *** xref:components:processors/aws_lambda.adoc[]
 *** xref:components:processors/azure_cosmosdb.adoc[]
+*** xref:components:processors/benchmark.adoc[]
 *** xref:components:processors/bloblang.adoc[]
 *** xref:components:processors/bounds_check.adoc[]
 *** xref:components:processors/branch.adoc[]

--- a/modules/components/pages/processors/benchmark.adoc
+++ b/modules/components/pages/processors/benchmark.adoc
@@ -1,0 +1,60 @@
+= benchmark
+// tag::single-source[]
+:type: processor
+:page-beta: true
+:categories: ["Utility"]
+
+component_type_dropdown::[]
+
+Logs throughput statistics for messages that pass through this processor, and provides a summary of those statistics over the lifetime of the processor.
+
+ifndef::env-cloud[]
+Introduced in version 4.40.0.
+endif::[]
+
+```yml
+# Configuration fields, showing default values
+label: ""
+benchmark:
+  interval: 5s
+  count_bytes: true
+```
+
+== Throughput statistics
+
+This output logs the following rolling statistics at a <<interval,configurable interval>> to help you to understand the current performance of your pipeline:
+
+- The number of messages processed per second.
+- The number of bytes of messages processed per second (optional).
+
+For example:
+
+```bash
+INFO rolling stats: 1 msg/sec, 407 B/sec
+```
+
+When the processor shuts down, it also writes a summary of the number and size of messages processed during the lifetime of the processor to the logs. For example:
+
+```bash
+INFO total stats: 1.00186 msg/sec, 425 B/sec 
+```
+
+== Fields
+
+=== `interval`
+
+How often to emit rolling statistics. Set to `0`, if you only want to log summary statistics when the processor shuts down.
+
+*Type*: `string`
+
+*Default*: `5s`
+
+=== `count_bytes`
+
+Whether to measure the number of bytes per second of throughput. Redpanda Connect must serialize structured data to count the number of bytes processed, which can cause unnecessary performance degradation if serialization is not required elsewhere in your pipeline.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+// end::single-source[]

--- a/modules/components/pages/processors/benchmark.adoc
+++ b/modules/components/pages/processors/benchmark.adoc
@@ -25,7 +25,7 @@ benchmark:
 This output logs the following rolling statistics at a <<interval,configurable interval>> to help you to understand the current performance of your pipeline:
 
 - The number of messages processed per second.
-- The number of bytes of messages processed per second (optional).
+- The number of bytes processed per second (optional).
 
 For example:
 

--- a/modules/components/pages/processors/benchmark.adoc
+++ b/modules/components/pages/processors/benchmark.adoc
@@ -6,7 +6,7 @@
 
 component_type_dropdown::[]
 
-Logs throughput statistics for messages that pass through this processor, and provides a summary of those statistics over the lifetime of the processor.
+Logs throughput statistics for processed messages, and provides a summary of those statistics over the lifetime of the processor.
 
 ifndef::env-cloud[]
 Introduced in version 4.40.0.
@@ -33,7 +33,7 @@ For example:
 INFO rolling stats: 1 msg/sec, 407 B/sec
 ```
 
-When the processor shuts down, it also writes a summary of the number and size of messages processed during the lifetime of the processor to the logs. For example:
+When the processor shuts down, it also logs a summary of the number and size of messages processed during its lifetime. For example:
 
 ```bash
 INFO total stats: 1.00186 msg/sec, 425 B/sec 
@@ -51,7 +51,7 @@ How often to emit rolling statistics. Set to `0`, if you only want to log summar
 
 === `count_bytes`
 
-Whether to measure the number of bytes per second of throughput. Redpanda Connect must serialize structured data to count the number of bytes processed, which can cause unnecessary performance degradation if serialization is not required elsewhere in your pipeline.
+Whether to measure the number of bytes per second of throughput. If set to `true`, Redpanda Connect must serialize structured data to count the number of bytes processed, which can unnecessarily degrade performance if serialization is not required elsewhere in your pipeline.
 
 *Type*: `bool`
 


### PR DESCRIPTION
## Description

Resolves [DOC-849](https://redpandadata.atlassian.net/browse/DOC-849)
Review deadline: 11th December

Related PR to add the same content to Cloud docs: https://github.com/redpanda-data/cloud-docs/pull/151

## Page previews

[`benchmark` processor](https://deploy-preview-125--redpanda-connect.netlify.app/redpanda-connect/components/processors/benchmark/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-849]: https://redpandadata.atlassian.net/browse/DOC-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ