### PR TITLE
Update sql.adoc to refer to sql_insert instead of sql

### DIFF
--- a/modules/components/pages/outputs/sql.adoc
+++ b/modules/components/pages/outputs/sql.adoc
@@ -70,7 +70,7 @@ output:
 
 == Alternatives
 
-For basic inserts use the xref:components:outputs/sql.adoc[`sql_insert`] output. For more complex queries use the xref:components:outputs/sql_raw.adoc[`sql_raw`] output.
+For basic inserts use the xref:components:outputs/sql_insert.adoc[`sql_insert`] output. For more complex queries use the xref:components:outputs/sql_raw.adoc[`sql_raw`] output.
 
 == Fields
 


### PR DESCRIPTION
## Description

I found the link on https://docs.redpanda.com/redpanda-connect/components/outputs/sql/#alternatives go back to sql instead of the expected sql_insert page

## Preview
[https://deploy-preview-135--redpanda-connect.netlify.app/redpanda-connect/components/outputs/sql/#alternatives](https://deploy-preview-135--redpanda-connect.netlify.app/redpanda-connect/components/outputs/sql/#alternatives)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)