### PR TITLE
DOC-810 Tag enterprise features

### DIFF
--- a/modules/components/pages/redpanda/about.adoc
+++ b/modules/components/pages/redpanda/about.adoc
@@ -1,6 +1,6 @@
 = redpanda
 
-component_type_dropdown::[]
+include::components:partial$enterprise_component_note.adoc[]
 
 // tag::single-source[]
 

--- a/modules/components/partials/enterprise_component_note.adoc
+++ b/modules/components/partials/enterprise_component_note.adoc
@@ -1,6 +1,6 @@
 ifndef::env-cloud[]
 [NOTE]
 ====
-This component requires an enterprise license. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
+This component requires an xref:get-started:licensing.adoc[enterprise license]. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
 ====
 endif::[]

--- a/modules/components/partials/enterprise_component_note.adoc
+++ b/modules/components/partials/enterprise_component_note.adoc
@@ -1,0 +1,6 @@
+ifndef::env-cloud[]
+[NOTE]
+====
+This component requires an enterprise license. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
+====
+endif::[]

--- a/modules/components/partials/enterprise_feature_note.adoc
+++ b/modules/components/partials/enterprise_feature_note.adoc
@@ -1,6 +1,6 @@
 ifndef::env-cloud[]
 [NOTE]
 ====
-This feature requires an enterprise license. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
+This feature requires an xref:get-started:licensing.adoc[enterprise license]. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
 ====
 endif::[]

--- a/modules/components/partials/enterprise_feature_note.adoc
+++ b/modules/components/partials/enterprise_feature_note.adoc
@@ -1,0 +1,6 @@
+ifndef::env-cloud[]
+[NOTE]
+====
+This feature requires an enterprise license. You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that’s valid for 30 days.
+====
+endif::[]

--- a/modules/configuration/pages/allow_and_deny_lists.adoc
+++ b/modules/configuration/pages/allow_and_deny_lists.adoc
@@ -1,6 +1,8 @@
 = Configure an Allow or Deny List
 :description: Learn how to configure an allow or deny list for a Redpanda Connect instance.
 
+include::components:partial$enterprise_feature_note.adoc[]
+
 You can configure an allow or deny list to limit the Redpanda Connect components that users can run within data pipelines on a Redpanda Connect instance.
 
 Introduced in version 4.39.0.

--- a/modules/configuration/pages/secrets.adoc
+++ b/modules/configuration/pages/secrets.adoc
@@ -23,6 +23,8 @@ For more information about this syntax, see the xref:configuration:interpolation
 
 == Look up secrets on a remote system at runtime
 
+include::components:partial$enterprise_feature_note.adoc[]
+
 Starting with version 4.39.0, you can use the `rpk connect` CLI flag `--secrets` to look up secrets values on a remote system at runtime (for example, in your secrets management solution). This means that Redpanda Connect resolves interpolations in your configuration at runtime without setting environment variables.
 
 

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -10,7 +10,7 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 | Limit the Redpanda Connect components that users can run within data pipelines on a Redpanda Connect instance.
 
 | https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Enterprise connectors]
-| Additional inputs, outputs, and processors available only to Enterprise customers.
+| Additional inputs, outputs, and processors available only to enterprise customers.
 
 | xref:components:redpanda/about.adoc[Redpanda Connect configuration service]
 | A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
@@ -50,6 +50,6 @@ Replace the following placeholders:
 
 == Verify a license
 
-Redpanda Connect checks the license key status at runtime. If the license key is unavailable or has expired, you are blocked from using Enterprise connectors.
+Redpanda Connect checks the license key status at runtime. If the license key is unavailable or has expired, you are blocked from using enterprise connectors.
 
 You can view the license key’s expiration date at any time in the Redpanda Connect logs.

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -9,11 +9,11 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 | xref:configuration:allow_and_deny_lists.adoc[Allow or deny lists]
 | Limit the Redpanda Connect components that users can run within data pipelines on a Redpanda Connect instance.
 
+| https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Enterprise connectors]
+| Additional inputs, outputs, and processors available only to Enterprise customers.
+
 | xref:components:redpanda/about.adoc[Redpanda Connect configuration service]
 | A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
-
-| https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Redpanda enterprise connectors]
-| Additional inputs, outputs, and processors available only to Enterprise customers.
 
 | xref:configuration:secrets.adoc#look-up-secrets-on-a-remote-system-at-runtime[Secrets management]
 | Retrieve secrets values from a remote system, such as a secret management solution, without setting environment variables.

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -1,7 +1,24 @@
 = Enterprise Licensing 
 :description: Learn how to purchase and apply an Enterprise Edition license.
 
-Anyone can use the Certified and Community connectors, but you need a valid Enterprise Edition license to use Enterprise connectors. 
+You need a valid Enterprise Edition license to use the following enterprise features:
+
+|===
+| Feature | Description
+
+| xref:configuration:allow_and_deny_lists.adoc[Allow or deny lists]
+| Limit the Redpanda Connect components that users can run within data pipelines on a Redpanda Connect instance.
+
+| xref:components:redpanda/about.adoc[Redpanda configuration service]
+| A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
+
+| https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Redpanda enterprise connectors]
+| Additional inputs, outputs, and processors available only to Enterprise customers.
+
+| xref:configuration:secrets.adoc#look-up-secrets-on-a-remote-system-at-runtime[Secrets management]
+| Retrieve secrets values from a remote system, such as a secret management solution, without setting environment variables.
+
+|===
 
 == Get an enterprise license
 
@@ -33,6 +50,6 @@ Replace the following placeholders:
 
 == Verify a license
 
-Redpanda Connect checks the license key status at runtime. If the license key is unavailable or has expired, you are blocked from using Enterprise connectors. 
+Redpanda Connect checks the license key status at runtime. If the license key is unavailable or has expired, you are blocked from using Enterprise connectors.
 
 You can view the license key’s expiration date at any time in the Redpanda Connect logs.

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -9,7 +9,7 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 | xref:configuration:allow_and_deny_lists.adoc[Allow or deny lists]
 | Limit the Redpanda Connect components that users can run within data pipelines on a Redpanda Connect instance.
 
-| xref:components:redpanda/about.adoc[Redpanda configuration service]
+| xref:components:redpanda/about.adoc[Redpanda Connect configuration service]
 | A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
 
 | https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Redpanda enterprise connectors]


### PR DESCRIPTION
## Description

Resolves [DOC-810](https://redpandadata.atlassian.net/browse/DOC-810), [DOC-835](https://redpandadata.atlassian.net/browse/DOC-835)
Review deadline: 20th December

For consistent messaging > related PRs: [https://github.com/redpanda-data/docs/pull/930](https://github.com/redpanda-data/docs/pull/930) and [https://github.com/redpanda-data/docs-extensions-and-macros/pull/89](https://github.com/redpanda-data/docs-extensions-and-macros/pull/89)

## Page previews

[Enterprise Licensing](https://deploy-preview-137--redpanda-connect.netlify.app/redpanda-connect/get-started/licensing/). Links from the table show each enterprise feature marked with a note.

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-810]: https://redpandadata.atlassian.net/browse/DOC-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-835]: https://redpandadata.atlassian.net/browse/DOC-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ