### PR TITLE
DOC-909 Interpolation support removed for fields in javascript processor

### DIFF
--- a/modules/components/pages/processors/javascript.adoc
+++ b/modules/components/pages/processors/javascript.adoc
@@ -92,7 +92,7 @@ pipeline:
 
 == Runtime
 
-In order to optimize code execution, JavaScript runtimes are created on demand (in order to support parallel execution) and are reused across invocations. Therefore, it is important to understand that the global state created by your programs will outlive individual invocations. In order for your programs to avoid failing after the first invocation, ensure that you do not define variables at the global scope.
+To optimize code execution, JavaScript runtimes are created on demand (in order to support parallel execution) and are reused across invocations. Therefore, it's important to understand that the global state created by your programs will outlive individual invocations. For your programs to avoid failing after the first invocation, ensure that you do not define variables at the global scope.
 
 Although technically possible, it is recommended that you do not rely on the global state for maintaining state across invocations as the pooling nature of the runtimes will prevent deterministic behavior. We aim to support deterministic strategies for mutating global state in the future.
 
@@ -106,8 +106,8 @@ Executes an HTTP request synchronously and returns the result as an object of th
 
 **`url`** &lt;string&gt; The URL to fetch  
 **`headers`** &lt;object(string,string)&gt; An object of string/string key/value pairs to add the request as headers.  
-**`method`** &lt;string&gt; The method of the request.  
-**`body`** &lt;(optional) string&gt; A body to send.  
+**`method`** &lt;string&gt; The method of the request.
+**`body`** &lt;(optional) string&gt; A body to send.
 
 #### Examples
 

--- a/modules/components/pages/processors/javascript.adoc
+++ b/modules/components/pages/processors/javascript.adoc
@@ -9,12 +9,12 @@
 component_type_dropdown::[]
 
 
-Executes a provided JavaScript code block or file for each message.
+Executes a JavaScript code block or file for each message.
 
 Introduced in version 4.14.0.
 
 ```yml
-# Config fields, showing default values
+# Configuration fields, showing default values
 label: ""
 javascript:
   code: "" # No default (optional)
@@ -32,26 +32,19 @@ This processor is implemented using the https://github.com/dop251/goja[github.co
 
 === `code`
 
-An inline JavaScript program to run. One of `code` or `file` must be defined.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+An inline JavaScript program to run. You must specify a value for either the `code` or `file` field.
 
 *Type*: `string`
-
 
 === `file`
 
-A file containing a JavaScript program to run. One of `code` or `file` must be defined.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+A file containing a JavaScript program to run. You must specify a value for either the `code` or `file` field.
 
 *Type*: `string`
 
-
 === `global_folders`
 
-List of folders that will be used to load modules from if the requested JS module is not found elsewhere.
-
+A list of directories to load modules from if the requested JavaScript module is not found elsewhere.
 
 *Type*: `array`
 
@@ -99,7 +92,7 @@ pipeline:
 
 == Runtime
 
-In order to optimize code execution JS runtimes are created on demand (in order to support parallel execution) and are reused across invocations. Therefore, it is important to understand that global state created by your programs will outlive individual invocations. In order for your programs to avoid failing after the first invocation ensure that you do not define variables at the global scope.
+In order to optimize code execution, JavaScript runtimes are created on demand (in order to support parallel execution) and are reused across invocations. Therefore, it is important to understand that the global state created by your programs will outlive individual invocations. In order for your programs to avoid failing after the first invocation, ensure that you do not define variables at the global scope.
 
 Although technically possible, it is recommended that you do not rely on the global state for maintaining state across invocations as the pooling nature of the runtimes will prevent deterministic behavior. We aim to support deterministic strategies for mutating global state in the future.
 


### PR DESCRIPTION
## Description

Resolves [DOC-909](https://redpandadata.atlassian.net/browse/DOC-909). Also, includes minor style updates.
Review deadline: 14th January

## Page previews

[`javascript` processor](https://deploy-preview-143--redpanda-connect.netlify.app/redpanda-connect/components/processors/javascript/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-909]: https://redpandadata.atlassian.net/browse/DOC-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ