### PR TITLE
DOC-987 Add crosslinking between snowflake_streaming assets

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -553,7 +553,7 @@ See also: xref:cookbooks:snowflake_ingestion.adoc[Ingest data into Snowflake coo
 endif::[]
 
 ifdef::env-cloud[]
-See also: xref:redpanda-cloud:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingest data into Snowflake cookbook]
+See also: xref:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingest data into Snowflake cookbook]
 endif::[]
 
 [tabs]

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -548,6 +548,14 @@ The following examples show you how to ingest, process, and write data to Snowfl
 * A Redpanda cluster
 * A REST API that posts JSON payloads to a HTTP server
 
+ifndef::env-cloud[]
+See also: xref:cookbooks:snowflake_ingestion.adoc[Ingest data into Snowflake cookbook]
+endif::[]
+
+ifdef::env-cloud[]
+See also: xref:redpanda-cloud:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingest data into Snowflake cookbook]
+endif::[]
+
 [tabs]
 ======
 Write data exactly once to a Snowflake table using CDC::

--- a/modules/cookbooks/pages/snowflake_ingestion.adoc
+++ b/modules/cookbooks/pages/snowflake_ingestion.adoc
@@ -7,6 +7,8 @@ ifndef::env-cloud[]
 
 Configure a Redpanda Connect pipeline to generate and write data into a local Redpanda topic, and then ingest that data into https://www.snowflake.com/en/[Snowflake^] using https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview[Snowpipe Streaming^].
 
+See also: xref:redpanda-cloud:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingesting data into Snowflake] using Redpanda Cloud
+
 == Prerequisites
 
 - https://docs.redpanda.com/current/get-started/rpk-install/[`rpk` installed]
@@ -267,5 +269,10 @@ The data produced into the `demo_topic` is consumed and streamed into Snowflake 
 ----
 SELECT * FROM STREAMING_DB.STREAMING_SCHEMA.STREAMING_DATA LIMIT 50;
 ----
+
+See also:
+
+- The xref:components:inputs/kafka_franz.adoc[`kafka_franz` input]
+- The xref:components:outputs/snowflake_streaming.adoc[`snowflake_streaming`] output
 
 // end::single-source[]

--- a/modules/cookbooks/pages/snowflake_ingestion.adoc
+++ b/modules/cookbooks/pages/snowflake_ingestion.adoc
@@ -7,7 +7,7 @@ ifndef::env-cloud[]
 
 Configure a Redpanda Connect pipeline to generate and write data into a local Redpanda topic, and then ingest that data into https://www.snowflake.com/en/[Snowflake^] using https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview[Snowpipe Streaming^].
 
-See also: xref:redpanda-cloud:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingesting data into Snowflake] using Redpanda Cloud
+See also: xref:redpanda-cloud:develop:connect/cookbooks/snowflake_ingestion.adoc[Ingest data into Snowflake] using Redpanda Cloud
 
 == Prerequisites
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 30th January

## Page previews

**Self-managed**

[snowflake_streaming output](https://deploy-preview-163--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)
[snowflake cookbook](https://deploy-preview-163--redpanda-connect.netlify.app/redpanda-connect/cookbooks/snowflake_ingestion/)

**Cloud**

[snowflake_streaming output](https://deploy-preview-163--redpanda-connect.netlify.app/redpanda-cloud/develop/connect/components/outputs/snowflake_streaming/)
[snowflake cookbook](https://deploy-preview-163--redpanda-connect.netlify.app/redpanda-cloud/develop/connect/cookbooks/snowflake_ingestion/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)