### PR TITLE
DOC-933 Fields to support consumer group timeouts

### DIFF
--- a/modules/components/pages/inputs/kafka_franz.adoc
+++ b/modules/components/pages/inputs/kafka_franz.adoc
@@ -23,7 +23,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   kafka_franz:
@@ -40,7 +40,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   kafka_franz:
@@ -58,6 +58,9 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
+    rebalance_timeout: 45s
+    session_timeout: 1m
+    heartbeat_interval: 3s
     start_from_oldest: true
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
@@ -525,6 +528,38 @@ A rack specifies where the client is physically located, and changes fetch reque
 *Type*: `string`
 
 *Default*: `""`
+
+=== `rebalance_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+
+*Type*: `string`
+
+*Default*: `45s`
+
+=== `session_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
+
+broker
+
+*Type*: `string`
+
+*Default*: `1m`
+
+=== `heartbeat_interval`
+
+When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+
+You must set `heartbeat_interval` to less than one-third of `session_timeout`.
+
+This field is equivalent to the Java `heartbeat.interval.ms` setting.
+
+client
+
+*Type*: `string`
+
+*Default*: `3s`
 
 === `start_from_oldest`
 

--- a/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/modules/components/pages/inputs/ockam_kafka.adoc
@@ -61,6 +61,9 @@ input:
       topics: [] # No default (required)
       regexp_topics: false
       rack_id: ""
+      rebalance_timeout: 45s
+      session_timeout: 1m
+      heartbeat_interval: 3s
       start_from_oldest: true
       fetch_max_bytes: 50MiB
       fetch_max_wait: 5s
@@ -298,6 +301,38 @@ A rack identifier for this client.
 *Type*: `string`
 
 *Default*: `""`
+
+=== `kafka.rebalance_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+
+*Type*: `string`
+
+*Default*: `45s`
+
+=== `kafka.session_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
+
+broker
+
+*Type*: `string`
+
+*Default*: `1m`
+
+=== `kafka.heartbeat_interval`
+
+When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+
+You must set `heartbeat_interval` to less than one-third of `session_timeout`.
+
+This field is equivalent to the Java `heartbeat.interval.ms` setting.
+
+client
+
+*Type*: `string`
+
+*Default*: `3s`
 
 === `kafka.start_from_oldest`
 

--- a/modules/components/pages/inputs/redpanda.adoc
+++ b/modules/components/pages/inputs/redpanda.adoc
@@ -57,6 +57,9 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
+    rebalance_timeout: 45s
+    session_timeout: 1m
+    heartbeat_interval: 3s
     start_from_oldest: true
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
@@ -544,6 +547,38 @@ A rack specifies where the client is physically located, and changes fetch reque
 *Type*: `string`
 
 *Default* `""`
+
+=== `rebalance_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+
+*Type*: `string`
+
+*Default*: `45s`
+
+=== `session_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
+
+broker
+
+*Type*: `string`
+
+*Default*: `1m`
+
+=== `heartbeat_interval`
+
+When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+
+You must set `heartbeat_interval` to less than one-third of `session_timeout`.
+
+This field is equivalent to the Java `heartbeat.interval.ms` setting.
+
+client
+
+*Type*: `string`
+
+*Default*: `3s`
 
 === `start_from_oldest`
 

--- a/modules/components/pages/inputs/redpanda_common.adoc
+++ b/modules/components/pages/inputs/redpanda_common.adoc
@@ -46,6 +46,9 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
+    rebalance_timeout: 45s
+    session_timeout: 1m
+    heartbeat_interval: 3s
     start_from_oldest: true
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
@@ -210,6 +213,38 @@ A rack specifies where the client is physically located, and changes fetch reque
 *Type*: `string`
 
 *Default*: `""`
+
+=== `rebalance_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+
+*Type*: `string`
+
+*Default*: `45s`
+
+=== `session_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
+
+broker
+
+*Type*: `string`
+
+*Default*: `1m`
+
+=== `heartbeat_interval`
+
+When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+
+You must set `heartbeat_interval` to less than one-third of `session_timeout`.
+
+This field is equivalent to the Java `heartbeat.interval.ms` setting.
+
+client
+
+*Type*: `string`
+
+*Default*: `3s`
 
 === `start_from_oldest`
 

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -58,6 +58,9 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     rack_id: ""
+    rebalance_timeout: 45s
+    session_timeout: 1m
+    heartbeat_interval: 3s
     start_from_oldest: true
     fetch_max_bytes: 50MiB
     fetch_max_wait: 5s
@@ -520,6 +523,38 @@ A rack identifier for this client.
 *Type*: `string`
 
 *Default*: `""`
+
+=== `rebalance_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+
+*Type*: `string`
+
+*Default*: `45s`
+
+=== `session_timeout`
+
+When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
+
+broker
+
+*Type*: `string`
+
+*Default*: `1m`
+
+=== `heartbeat_interval`
+
+When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+
+You must set `heartbeat_interval` to less than one-third of `session_timeout`.
+
+This field is equivalent to the Java `heartbeat.interval.ms` setting.
+
+client
+
+*Type*: `string`
+
+*Default*: `3s`
 
 === `start_from_oldest`
 


### PR DESCRIPTION
## Description

Resolves DOC-993
Review deadline: 6th February

## Page previews

`kafka_franz` input
`ockam_kafka` input
`redpanda_common` input
`redpanda_migrator` input
`redpanda` input

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)