### PR TITLE
DOC-1000 Kafka outputs default updates

### DIFF
--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -60,7 +60,6 @@ output:
     partitioner: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
     client_id: benthos
-    rack_id: ""
     idempotent_write: true
     metadata:
       include_prefixes: []
@@ -73,7 +72,8 @@ output:
       period: ""
       check: ""
       processors: [] # No default (optional)
-    max_message_bytes: 1MB
+    max_message_bytes: 1MiB
+    broker_write_max_bytes: 100MiB
     compression: "" # No default (optional)
     tls:
       enabled: false
@@ -83,6 +83,7 @@ output:
       root_cas_file: ""
       client_certs: []
     sasl: [] # No default (optional)
+    metadata_max_age: 5m
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
 ```
 
@@ -93,8 +94,7 @@ output:
 
 === `seed_brokers`
 
-A list of broker addresses to connect to in order to establish connections. If an item of the list contains commas it will be expanded into multiple addresses.
-
+A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item.
 
 *Type*: `array`
 
@@ -115,49 +115,42 @@ seed_brokers:
 
 === `topic`
 
-A topic to write messages to.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+A topic to write messages to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
-
 
 === `key`
 
-An optional key to populate for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
-
 
 === `partitioner`
 
 Override the default murmur2 hashing partitioner.
 
-
 *Type*: `string`
-
 
 |===
 | Option | Summary
 
 | `least_backup`
-| Chooses the least backed up partition (the partition with the fewest amount of buffered records). Partitions are selected per batch.
+| Chooses the least backed up partition (the partition with the fewest buffered records). Partitions are selected per batch.
 | `manual`
-| Manually select a partition for each message, requires the field `partition` to be specified.
+| Manually select a partition for each message. You must also specify a value for the `partition` field.
 | `murmur2_hash`
-| Kafka's default hash algorithm that uses a 32-bit murmur2 hash of the key to compute which partition the record will be on.
+| Kafka's default hash algorithm that uses a 32-bit murmur2 hash of the key to compute the partition for the record.
 | `round_robin`
-| Round-robin's messages through all available partitions. This algorithm has lower throughput and causes higher CPU load on brokers, but can be useful if you want to ensure an even distribution of records to partitions.
+| Use round-robin messages through all available partitions. This algorithm has lower throughput and causes higher CPU load on brokers, but is useful if you want to ensure an even distribution of records to partitions.
 
 |===
 
 === `partition`
 
-An optional explicit partition to set for each message. This field is only relevant when the `partitioner` is set to `manual`. The provided interpolation string must be a valid integer.
+Set a partition for each message (optional). This field is only relevant when the `partitioner` is set to `manual`.
 This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
+You must provide an interpolation string that is a valid integer.
 
 *Type*: `string`
 
@@ -172,24 +165,13 @@ partition: ${! meta("partition") }
 
 An identifier for the client connection.
 
-
 *Type*: `string`
 
-*Default*: `"benthos"`
-
-=== `rack_id`
-
-A rack identifier for this client.
-
-
-*Type*: `string`
-
-*Default*: `""`
+*Default*: `benthos`
 
 === `idempotent_write`
 
-Enable the idempotent write producer option. This requires the `IDEMPOTENT_WRITE` permission on `CLUSTER` and can be disabled if this permission is not available.
-
+Enables the idempotent write producer option. This requires the `IDEMPOTENT_WRITE` permission on `CLUSTER`. Disable this option if the `IDEMPOTENT_WRITE` permission is unavailable.
 
 *Type*: `bool`
 
@@ -197,8 +179,7 @@ Enable the idempotent write producer option. This requires the `IDEMPOTENT_WRITE
 
 === `metadata`
 
-Determine which (if any) metadata values should be added to messages as headers.
-
+Specify which (if any) metadata values are added to messages as headers.
 
 *Type*: `object`
 
@@ -247,8 +228,7 @@ include_patterns:
 
 === `max_in_flight`
 
-The maximum number of batches to be sending in parallel at any given time.
-
+The maximum number of batches to send in parallel at any given time.
 
 *Type*: `int`
 
@@ -256,12 +236,11 @@ The maximum number of batches to be sending in parallel at any given time.
 
 === `timeout`
 
-The maximum period of time to wait for message sends before abandoning the request and retrying
-
+The maximum period of time to wait for message sends before abandoning the request and retrying.
 
 *Type*: `string`
 
-*Default*: `"10s"`
+*Default*: `10s`
 
 === `batching`
 
@@ -291,8 +270,7 @@ batching:
 
 === `batching.count`
 
-A number of messages at which the batch should be flushed. If `0` disables count based batching.
-
+The number of messages after which the batch is flushed. Set to `0` to disable count-based batching.
 
 *Type*: `int`
 
@@ -300,8 +278,7 @@ A number of messages at which the batch should be flushed. If `0` disables count
 
 === `batching.byte_size`
 
-An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
-
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -309,7 +286,7 @@ An amount of bytes at which the batch should be flushed. If `0` disables size ba
 
 === `batching.period`
 
-A period in which an incomplete batch should be flushed regardless of its size.
+The period after which an incomplete batch is flushed regardless of its size.
 
 
 *Type*: `string`
@@ -330,7 +307,6 @@ period: 500ms
 
 A xref:guides:bloblang/about.adoc[Bloblang query] that should return a boolean value indicating whether a message should end a batch.
 
-
 *Type*: `string`
 
 *Default*: `""`
@@ -343,7 +319,7 @@ check: this.type == "end_of_transaction"
 
 === `batching.processors`
 
-A list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
+For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches.
 
 
 *Type*: `array`
@@ -367,28 +343,41 @@ processors:
 
 === `max_message_bytes`
 
-The maximum space in bytes than an individual message may take, messages larger than this value will be rejected. This field corresponds to Kafka's `max.message.bytes`.
-
+The maximum space (in bytes) that an individual message may use. Messages larger than this value are rejected. This field corresponds to Kafka's `max.message.bytes`.
 
 *Type*: `string`
 
-*Default*: `"1MB"`
+*Default*: `1MiB`
 
 ```yml
 # Examples
 
-max_message_bytes: 100MB
+max_message_bytes: 100MiB
 
-max_message_bytes: 50mib
+max_message_bytes: 50MiB
+```
+
+=== `broker_write_max_bytes`
+
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+
+*Type*: `string`
+
+*Default*: `100MiB`
+
+```yml
+# Examples
+
+broker_write_max_bytes: 128MB
+
+broker_write_max_bytes: 50MiB
 ```
 
 === `compression`
 
-Optionally set an explicit compression type. The default preference is to use snappy when the broker supports it, and fall back to none if not.
-
+Set an explicit compression type (optional). The default preference is to use `snappy` when the broker supports it. Otherwise, use `none`.
 
 *Type*: `string`
-
 
 Options:
 `lz4`
@@ -396,20 +385,16 @@ Options:
 , `gzip`
 , `none`
 , `zstd`
-.
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
-
+Override system defaults with custom TLS settings.
 
 *Type*: `object`
-
 
 === `tls.enabled`
 
 Whether custom TLS settings are enabled.
-
 
 *Type*: `bool`
 
@@ -417,7 +402,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -439,7 +424,7 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -459,8 +444,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
-
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -474,8 +458,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
-
+A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 *Type*: `array`
 
@@ -495,7 +478,7 @@ client_certs:
 
 === `tls.client_certs[].cert`
 
-A plain text certificate to use.
+The plain text certificate to use.
 
 
 *Type*: `string`
@@ -504,7 +487,7 @@ A plain text certificate to use.
 
 === `tls.client_certs[].key`
 
-A plain text certificate key to use.
+The plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -514,8 +497,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `tls.client_certs[].cert_file`
 
-The path of a certificate to use.
-
+The path to the certificate to use.
 
 *Type*: `string`
 
@@ -532,9 +514,9 @@ The path of a certificate key to use.
 
 === `tls.client_certs[].password`
 
-A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+The plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks which may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -552,8 +534,7 @@ password: ${KEY_PASSWORD}
 
 === `sasl`
 
-Specify one or more methods of SASL authentication. SASL is tried in order; if the broker supports the first mechanism, all connections will use that mechanism. If the first mechanism fails, the client will pick the first supported mechanism. If the broker does not support any client mechanisms, connections will fail.
-
+Specify one or more methods or mechanisms of SASL authentication, which are attempted in order. If the broker supports the first SASL mechanism, all connections use it. If the first mechanism fails, the client picks the first supported mechanism. If the broker does not support any client mechanisms, all connections fail.
 
 *Type*: `array`
 
@@ -579,23 +560,23 @@ The SASL mechanism to use.
 | Option | Summary
 
 | `AWS_MSK_IAM`
-| AWS IAM based authentication as specified by the 'aws-msk-iam-auth' java library.
+| AWS IAM-based authentication as specified by the 'aws-msk-iam-auth' Java library.
 | `OAUTHBEARER`
-| OAuth Bearer based authentication.
+| OAuth bearer-based authentication.
 | `PLAIN`
 | Plain text authentication.
 | `SCRAM-SHA-256`
-| SCRAM based authentication as specified in RFC5802.
+| SCRAM-based authentication as specified in RFC5802.
 | `SCRAM-SHA-512`
-| SCRAM based authentication as specified in RFC5802.
+| SCRAM-based authentication as specified in RFC5802.
 | `none`
-| Disable sasl authentication
+| Disable SASL authentication
 
 |===
 
 === `sasl[].username`
 
-A username to provide for PLAIN or SCRAM-* authentication.
+A username to provide for `PLAIN` or `SCRAM-*` authentication.
 
 
 *Type*: `string`
@@ -604,7 +585,7 @@ A username to provide for PLAIN or SCRAM-* authentication.
 
 === `sasl[].password`
 
-A password to provide for PLAIN or SCRAM-* authentication.
+A password to provide for `PLAIN` or `SCRAM-*` authentication.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -615,7 +596,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `sasl[].token`
 
-The token to use for a single session's OAUTHBEARER authentication.
+The token to use for a single session's `OAUTHBEARER` authentication.
 
 
 *Type*: `string`
@@ -624,7 +605,7 @@ The token to use for a single session's OAUTHBEARER authentication.
 
 === `sasl[].extensions`
 
-Key/value pairs to add to OAUTHBEARER authentication requests.
+Key/value pairs to add to `OAUTHBEARER` authentication requests.
 
 
 *Type*: `object`
@@ -632,7 +613,7 @@ Key/value pairs to add to OAUTHBEARER authentication requests.
 
 === `sasl[].aws`
 
-Contains AWS specific fields for when the `mechanism` is set to `AWS_MSK_IAM`.
+AWS specific fields for when the `mechanism` is set to `AWS_MSK_IAM`.
 
 
 *Type*: `object`
@@ -649,7 +630,7 @@ The AWS region to target.
 
 === `sasl[].aws.endpoint`
 
-Allows you to specify a custom endpoint for the AWS API.
+Specify a custom endpoint for the AWS API.
 
 
 *Type*: `string`
@@ -658,15 +639,13 @@ Allows you to specify a custom endpoint for the AWS API.
 
 === `sasl[].aws.credentials`
 
-Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].
-
+Manually configure the AWS credentials to use (optional). For more information, see the xref:guides:cloud/aws.adoc[].
 
 *Type*: `object`
 
-
 === `sasl[].aws.credentials.profile`
 
-A profile from `~/.aws/credentials` to use.
+The profile from `~/.aws/credentials` to use.
 
 
 *Type*: `string`
@@ -675,8 +654,7 @@ A profile from `~/.aws/credentials` to use.
 
 === `sasl[].aws.credentials.id`
 
-The ID of credentials to use.
-
+The ID of the AWS credentials to use.
 
 *Type*: `string`
 
@@ -684,7 +662,7 @@ The ID of credentials to use.
 
 === `sasl[].aws.credentials.secret`
 
-The secret for the credentials being used.
+The secret for the AWS credentials in use.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -694,7 +672,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `sasl[].aws.credentials.token`
 
-The token for the credentials being used, required when using short term credentials.
+The token for the AWS credentials in use. This is a required value for short-term credentials.
 
 
 *Type*: `string`
@@ -716,7 +694,7 @@ endif::[]
 
 === `sasl[].aws.credentials.role`
 
-A role ARN to assume.
+The role ARN to assume.
 
 
 *Type*: `string`
@@ -725,7 +703,7 @@ A role ARN to assume.
 
 === `sasl[].aws.credentials.role_external_id`
 
-An external ID to provide when assuming a role.
+An external ID to use when assuming a role.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -135,7 +135,7 @@ Override the default murmur2 hashing partitioner.
 | Option | Summary
 
 | `least_backup`
-| Chooses the least backed up partition (the partition with the fewest buffered records). Partitions are selected per batch.
+| Choose the partition with the fewest buffered records. Partitions are selected per batch.
 | `manual`
 | Manually select a partition for each message. You must also specify a value for the `partition` field.
 | `murmur2_hash`

--- a/modules/components/pages/outputs/kafka_franz.adoc
+++ b/modules/components/pages/outputs/kafka_franz.adoc
@@ -359,7 +359,7 @@ max_message_bytes: 50MiB
 
 === `broker_write_max_bytes`
 
-The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka’s `socket.request.max.bytes`.
 
 *Type*: `string`
 
@@ -368,7 +368,7 @@ The maximum number of bytes this output can write to a broker connection in a si
 ```yml
 # Examples
 
-broker_write_max_bytes: 128MB
+broker_write_max_bytes: 128MiB
 
 broker_write_max_bytes: 50MiB
 ```
@@ -709,6 +709,15 @@ An external ID to use when assuming a role.
 *Type*: `string`
 
 *Default*: `""`
+
+=== `metadata_max_age`
+
+The maximum period of time after which metadata is refreshed.
+
+*Type*: `string`
+
+*Default*: `5m`
+
 
 === `timestamp_ms`
 

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -138,7 +138,7 @@ Override the default murmur2 hashing partitioner (optional).
 |===
 | Option | Summary
 | `least_backup`
-| Chooses the least backed up partition, which has the fewest buffered records. Partitions are selected per batch.
+| Choose the partition with the fewest buffered records. Partitions are selected per batch.
 | `manual`
 | Manually select a partition for each message. To use this option, specify a value in the `partition` field.
 | `murmur2_hash`

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -47,6 +47,7 @@ input:
     route_to_kafka_outlet: self
     allow_consumer: self
     route_to_consumer: /ip4/127.0.0.1/tcp/6262
+    encrypted_fields: []
 ```
 --
 Advanced::
@@ -63,8 +64,6 @@ input:
       key: "" # No default (optional)
       partitioner: "" # No default (optional)
       partition: ${! meta("partition") } # No default (optional)
-      client_id: benthos
-      rack_id: ""
       idempotent_write: true
       metadata:
         include_prefixes: []
@@ -77,7 +76,8 @@ input:
         period: ""
         check: ""
         processors: [] # No default (optional)
-      max_message_bytes: 1MB
+      max_message_bytes: 1MiB
+      broker_write_max_bytes: 100MiB
       compression: "" # No default (optional)
       tls:
         enabled: false
@@ -86,7 +86,6 @@ input:
         root_cas: ""
         root_cas_file: ""
         client_certs: []
-      sasl: [] # No default (optional)
       timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
     disable_content_encryption: false
     enrollment_ticket: "" # No default (optional)
@@ -95,6 +94,7 @@ input:
     route_to_kafka_outlet: self
     allow_consumer: self
     route_to_consumer: /ip4/127.0.0.1/tcp/6262
+    encrypted_fields: []
 ```
 --
 ======
@@ -160,23 +160,6 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 # Examples
 partition: ${! meta("partition") }
 ```
-
-=== `kafka.client_id`
-
-An identifier for the client connection.
-
-*Type*: `string`
-
-*Default*: `benthos`
-
-
-=== `kafka.rack_id`
-
-A rack identifier for this client.
-
-*Type*: `string`
-
-*Default*: `""`
 
 
 === `kafka.idempotent_write`
@@ -335,12 +318,28 @@ The maximum size of an individual message in bytes. Messages larger than this va
 
 *Type*: `string`
 
-*Default*: `1MB`
+*Default*: `1MiB`
 
 ```yml
 # Examples
-max_message_bytes: 100MB
-max_message_bytes: 50mib
+max_message_bytes: 100MiB
+max_message_bytes: 50MiB
+```
+
+=== `kafka.broker_write_max_bytes`
+
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+
+*Type*: `string`
+
+*Default*: `100MiB`
+
+```yml
+# Examples
+
+broker_write_max_bytes: 128MiB
+
+broker_write_max_bytes: 50MiB
 ```
 
 === `kafka.compression`
@@ -355,6 +354,9 @@ Options:
 , `gzip`
 , `none`
 , `zstd`
+
+
+
 
 === `kafka.tls`
 
@@ -488,162 +490,6 @@ password: foo
 password: ${KEY_PASSWORD}
 ```
 
-=== `kafka.sasl`
-
-Specify one or more methods or mechanisms of SASL authentication, which are attempted in order (optional). If the broker supports the first SASL mechanism, all connections use it. If the first mechanism fails, the client picks the first supported mechanism. If the broker does not support any client mechanisms, all connections fail.
-
-*Type*: `array`
-
-```yml
-# Examples
-sasl:
-  - mechanism: SCRAM-SHA-512
-    password: bar
-    username: foo
-```
-
-=== `kafka.sasl[].mechanism`
-
-The SASL mechanism to use.
-
-*Type*: `string`
-
-|===
-| Option | Summary
-| `AWS_MSK_IAM`
-| AWS IAM-based authentication as specified by the `aws-msk-iam-auth` Java library.
-| `OAUTHBEARER`
-| OAuth bearer-based authentication.
-| `PLAIN`
-| Plain text authentication.
-| `SCRAM-SHA-256`
-| SCRAM-based authentication as specified in RFC5802.
-| `SCRAM-SHA-512`
-| SCRAM-based authentication as specified in RFC5802.
-| `none`
-| Disable SASL authentication
-|===
-
-=== `kafka.sasl[].username`
-
-A username for `PLAIN` or `SCRAM-*` authentication.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].password`
-
-A password for `PLAIN` or `SCRAM-*` authentication.
-
-include::components:partial$secret_warning.adoc[]
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].token`
-
-The token to use for a single session's `OAUTHBEARER` authentication.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].extensions`
-
-Key/value pairs to add to `OAUTHBEARER` authentication requests.
-
-*Type*: `object`
-
-=== `kafka.sasl[].aws`
-
-AWS specific fields for when the `mechanism` is set to `AWS_MSK_IAM`.
-
-*Type*: `object`
-
-=== `kafka.sasl[].aws.region`
-
-The AWS region to target.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.endpoint`
-
-Specify a custom endpoint for the AWS API.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials`
-
-Manually configure the AWS credentials to use (optional). For more information, see the xref:guides:cloud/aws.adoc[Amazon Web Services guide].
-
-*Type*: `object`
-
-=== `kafka.sasl[].aws.credentials.profile`
-
-The profile from `~/.aws/credentials` to use.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials.id`
-
-The ID of credentials to use.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials.secret`
-
-The secret for the AWS credentials in use.
-
-include::components:partial$secret_warning.adoc[]
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials.token`
-
-The token for the AWS credentials in use. This is a required value for short-term credentials.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials.from_ec2_role`
-
-Use the credentials of a host EC2 machine configured to assume an https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[IAM role associated with the instance^].
-
-*Type*: `bool`
-
-*Default*: `false`
-
-Requires version 4.2.0 or newer
-
-=== `kafka.sasl[].aws.credentials.role`
-
-The role ARN to assume.
-
-*Type*: `string`
-
-*Default*: `""`
-
-=== `kafka.sasl[].aws.credentials.role_external_id`
-
-An external ID to use when assuming a role.
-
-*Type*: `string`
-
-*Default*: `""`
-
 === `kafka.timestamp_ms`
 
 Set a timestamp (in milliseconds) for each message (optional). Leave this field empty to use the current timestamp.
@@ -718,3 +564,11 @@ The route to the Kafka consumer. For example, `/project/default/service/forward_
 *Type*: `string`
 
 *Default*: `/ip4/127.0.0.1/tcp/6262`
+
+=== `kafka.encrypted_fields`
+
+Fields to encrypt in the Kafka messages when the record is a valid JSON map. By default, the whole record is encrypted.
+
+*Type*: `array`
+
+*Default*: `[]`

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -328,7 +328,7 @@ max_message_bytes: 50MiB
 
 === `kafka.broker_write_max_bytes`
 
-The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka’s `socket.request.max.bytes`.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -544,7 +544,7 @@ Override the default murmur2 hashing partitioner.
 | Option | Summary
 
 | `least_backup`
-| Chooses the least backed up partition. The partition with the fewest buffered records. Partitions are selected per batch.
+| Choose the partition with the fewest buffered records. Partitions are selected per batch.
 | `manual`
 | Manually select a partition for each message. You must also specify a value for the `partition` field.
 | `murmur2_hash`

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -71,8 +71,8 @@ output:
     idempotent_write: true
     compression: "" # No default (optional)
     timeout: 10s
-    max_message_bytes: 1MB
-    broker_write_max_bytes: 100MB
+    max_message_bytes: 1MiB
+    broker_write_max_bytes: 100MiB
 ```
 
 --
@@ -592,30 +592,30 @@ The maximum space (in bytes) that an individual message may use. Messages larger
 
 *Type*: `string`
 
-*Default*: `1MB`
+*Default*: `1MiB`
 
 ```yml
 # Examples
 
-max_message_bytes: 100MB
+max_message_bytes: 100MiB
 
-max_message_bytes: 50mib
+max_message_bytes: 50MiB
 ```
 
 === `broker_write_max_bytes`
 
-The upper bound for the number of bytes written to a broker connection in a single write. This field corresponds to Kafka's `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
 
 *Type*: `string`
 
-*Default*: `100MB`
+*Default*: `100MiB`
 
 ```yml
 # Examples
 
-broker_write_max_bytes: 128MB
+broker_write_max_bytes: 128MiB
 
-broker_write_max_bytes: 50mib
+broker_write_max_bytes: 50MiB
 ```
 
 // end::single-source[]

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -604,7 +604,7 @@ max_message_bytes: 50MiB
 
 === `broker_write_max_bytes`
 
-The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka’s `socket.request.max.bytes`.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -477,7 +477,7 @@ Override the default murmur2 hashing partitioner.
 | Option | Summary
 
 | `least_backup`
-| Chooses the least backed up partition (the partition with the fewest buffered records). Partitions are selected per batch.
+| Choose the partition with the fewest buffered records. Partitions are selected per batch.
 | `manual`
 | Manually select a partition for each message. You must also specify a value for the `partition` field.
 | `murmur2_hash`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -681,7 +681,7 @@ max_message_bytes: 50MiB
 
 === `broker_write_max_bytes`
 
-The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka’s `socket.request.max.bytes`.
 
 
 *Type*: `string`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -75,10 +75,10 @@ output:
     translate_schema_ids: true
     schema_registry_output_resource: schema_registry_output
     idempotent_write: true
-    compression: "" # No default (optional)  
+    compression: "" # No default (optional)
     timeout: 10s
-    max_message_bytes: 1MB
-    broker_write_max_bytes: 100MB
+    max_message_bytes: 1MiB
+    broker_write_max_bytes: 100MiB
 ```
 
 --
@@ -669,31 +669,31 @@ The maximum space in bytes that an individual message may use. Messages larger t
 
 *Type*: `string`
 
-*Default*: `"1MB"`
+*Default*: `1MiB`
 
 ```yml
 # Examples
 
-max_message_bytes: 100MB
+max_message_bytes: 100MiB
 
-max_message_bytes: 50mib
+max_message_bytes: 50MiB
 ```
 
 === `broker_write_max_bytes`
 
-The upper bound for the number of bytes written to a broker connection in a single write. This field corresponds to Kafka's `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
 
 
 *Type*: `string`
 
-*Default*: `100MB`
+*Default*: `100MiB`
 
 ```yml
 # Examples
 
-broker_write_max_bytes: 128MB
+broker_write_max_bytes: 128MiB
 
-broker_write_max_bytes: 50mib
+broker_write_max_bytes: 50MiB
 ```
 
 // end::single-source[]

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -68,8 +68,8 @@ output:
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
     timeout: 10s
-    max_message_bytes: 1MB
-    broker_write_max_bytes: 100MB
+    max_message_bytes: 1MiB
+    broker_write_max_bytes: 100MiB
     max_retries: 0
     backoff:
       initial_interval: 1s
@@ -507,19 +507,19 @@ The maximum number of bytes that an individual message may use. Messages larger 
 
 *Type*: `string`
 
-*Default*: `1MB`
+*Default*: `1MiB`
 
 ```yml
 # Examples
 
-max_message_bytes: 100MB
+max_message_bytes: 100MiB
 
-max_message_bytes: 50mib
+max_message_bytes: 50MiB
 ```
 
 === `broker_write_max_bytes`
 
-The upper bound for the number of bytes written to a broker connection in a single write. This field corresponds to Kafka's `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
 
 
 *Type*: `string`
@@ -529,9 +529,9 @@ The upper bound for the number of bytes written to a broker connection in a sing
 ```yml
 # Examples
 
-broker_write_max_bytes: 128MB
+broker_write_max_bytes: 128MiB
 
-broker_write_max_bytes: 50mib
+broker_write_max_bytes: 50MiB
 ```
 
 === `max_retries`

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -519,7 +519,7 @@ max_message_bytes: 50MiB
 
 === `broker_write_max_bytes`
 
-The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Apache Kafka’s `socket.request.max.bytes`.
+The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka’s `socket.request.max.bytes`.
 
 
 *Type*: `string`


### PR DESCRIPTION
## Description

Resolves [DOC-1000](https://redpandadata.atlassian.net/browse/DOC-1000) **and additional changes in [DOC-988](https://redpandadata.atlassian.net/browse/DOC-988)**
Review deadline: 18th February

## Page previews

Outputs
[kafka_franz](https://deploy-preview-167--redpanda-connect.netlify.app/redpanda-connect/components/outputs/kafka_franz/)
[ockam_kafka](https://deploy-preview-167--redpanda-connect.netlify.app/redpanda-connect/components/outputs/ockam_kafka/)
[redpanda](https://deploy-preview-167--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda/)
[redpanda_migrator](https://deploy-preview-167--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/)
[redpanda_migrator_offsets](https://deploy-preview-167--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_offsets/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1000]: https://redpandadata.atlassian.net/browse/DOC-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-988]: https://redpandadata.atlassian.net/browse/DOC-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ