### PR TITLE
DOC-972 Remove beta attribute from snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -1,7 +1,6 @@
 = snowflake_streaming
 // tag::single-source[]
 :type: output
-:page-beta: true
 :categories: ["Services"]
 
 component_type_dropdown::[]


### PR DESCRIPTION
## Description

Resolves [DOC-972](https://redpandadata.atlassian.net/browse/DOC-972)
Review deadline: 4th February

Related PR for Cloud: [https://github.com/redpanda-data/cloud-docs/pull/195](https://github.com/redpanda-data/cloud-docs/pull/195)

## Page previews

[`snowflake_streaming` output](https://deploy-preview-168--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-972]: https://redpandadata.atlassian.net/browse/DOC-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ