### PR TITLE
DOC-997 Add unchanged_toast_value to postgres_cdc

### DIFF
--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -31,6 +31,7 @@ input:
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
+    unchanged_toast_value: null
     auto_replay_nacks: true
     batching:
       count: 0
@@ -373,6 +374,21 @@ Specify the maximum number of tables that are processed in parallel when the ini
 *Type*: `int`
 
 *Default*: `1`
+
+
+=== `unchanged_toast_value`
+
+Specify the value to emit when unchanged <<receive-toast-and-deleted-values, TOAST values>> appear in the message stream. Unchanged values occur for data updates and deletes when `REPLICA IDENTITY` is not set to `FULL`.
+
+*Type*: `unknown`
+
+*Default*: `null`
+
+```yml
+# Examples
+
+unchanged_toast_value: __redpanda_connect_unchanged_toast_value__
+```
 
 === `auto_replay_nacks`
 

--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -388,7 +388,8 @@ Specify the value to emit when unchanged <<receive-toast-and-deleted-values, TOA
 # Examples
 
 unchanged_toast_value: __redpanda_connect_unchanged_toast_value__ 
-# Appears as {"toast":"__redpanda_connect_unchanged_toast_value__"} in a message
+
+unchanged_toast_value: {"$": "unchanged_toast_value"}
 ```
 
 === `auto_replay_nacks`

--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -380,14 +380,15 @@ Specify the maximum number of tables that are processed in parallel when the ini
 
 Specify the value to emit when unchanged <<receive-toast-and-deleted-values, TOAST values>> appear in the message stream. Unchanged values occur for data updates and deletes when `REPLICA IDENTITY` is not set to `FULL`.
 
-*Type*: `unknown`
+*Type*: `any`
 
 *Default*: `null`
 
 ```yml
 # Examples
 
-unchanged_toast_value: __redpanda_connect_unchanged_toast_value__
+unchanged_toast_value: __redpanda_connect_unchanged_toast_value__ 
+# Appears as {"toast":"__redpanda_connect_unchanged_toast_value__"} in a message
 ```
 
 === `auto_replay_nacks`


### PR DESCRIPTION
## Description

Resolves [DOC-997](https://redpandadata.atlassian.net/browse/DOC-997)
Review deadline: 6th February

## Page previews

[`postgres_cdc` input](https://deploy-preview-169--redpanda-connect.netlify.app/redpanda-connect/components/inputs/postgres_cdc/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-997]: https://redpandadata.atlassian.net/browse/DOC-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ