### PR TITLE
DOC-995 Add metadata field and standardize Avro JSON content

### DIFF
--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -80,7 +80,7 @@ Avro, Protobuf and JSON schemas are supported, all are capable of expanding from
 By default, this processor expects documents formatted as https://avro.apache.org/docs/current/specification/[Avro JSON^] when decoding with Avro schemas. In this format, the value of a union is encoded in JSON as follows:
 
 - If the union's type is `null`, it is encoded as a JSON `null`.
-- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively-encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
+- Otherwise, the union is encoded as a JSON object with one name/value pair. The name is the type's name, and the value is the recursively-encoded value. The user-specified name is used for Avro's named types (record, fixed, or enum). For other types, the type name is used.
 
 For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
@@ -92,7 +92,7 @@ Alternatively, you can create documents in https://pkg.go.dev/github.com/linkedi
 
 == Protobuf format
 
-This processor decodes Protobuf messages to JSON documents For more information about the JSON mapping of Protobuf messages, see the https://developers.google.com/protocol-buffers/docs/proto3#json[Protocol Buffers Documentation^].
+This processor decodes Protobuf messages to JSON documents. For more information about the JSON mapping of Protobuf messages, see the https://developers.google.com/protocol-buffers/docs/proto3#json[Protocol Buffers documentation^].
 
 == Metadata
 

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -25,6 +25,9 @@ Common::
 # Common configuration fields, showing default values
 label: ""
 schema_registry_decode:
+  avro:
+    raw_unions: false # No default (optional)
+    preserve_logical_types: false
   url: "" # No default (required)
 ```
 
@@ -37,7 +40,9 @@ Advanced::
 # All configuration fields, showing default values
 label: ""
 schema_registry_decode:
-  avro_raw_json: false
+  avro:
+    raw_unions: false
+    preserve_logical_types: false
   url: "" # No default (required)
   oauth:
     enabled: false
@@ -75,19 +80,19 @@ Avro, Protobuf and JSON schemas are supported, all are capable of expanding from
 By default, this processor expects documents formatted as https://avro.apache.org/docs/current/specification/[Avro JSON^] when decoding with Avro schemas. In this format, the value of a union is encoded in JSON as follows:
 
 - If the union's type is `null`, it is encoded as a JSON `null`.
-- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
+- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively-encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
 
 For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
-- The `null` as a JSON `null`
+- `null` as a JSON `null`
 - The string `"a"` as `{"string": "a"}`
 - A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance
 
-Alternatively, you can create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro_raw_json,`avro_raw_json`>> to `true`.
+Alternatively, you can create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro-raw_unions,`avro.raw_unions`>> to `true`.
 
 == Protobuf format
 
-This processor decodes protobuf messages to JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
+This processor decodes Protobuf messages to JSON documents For more information about the JSON mapping of Protobuf messages, see the https://developers.google.com/protocol-buffers/docs/proto3#json[Protocol Buffers Documentation^].
 
 == Metadata
 
@@ -97,10 +102,38 @@ This processor adds the following metadata to processed messages:
 
 == Fields
 
-=== `avro_raw_json`
+=== `avro.raw_unions`
 
-Whether messages should be decoded into normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. If `true`, the schema returned from the subject is decoded as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
+Whether Avro messages should be decoded into normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. 
 
+If set to `false`, Avro messages are decoded as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^].
+
+For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would be decoded as:
+
+- A `null` as a JSON `null`
+- The string `"a"` as `{"string": "a"}`
+- A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance.
+
+If set to `true`, Avro messages are decoded as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^].
+
+For example, the same union schema `["null","string","Transaction"]` is decoded as:
+
+- A `null` as JSON `null`
+- The string `"a"` as `"a"`
+- A `Transaction` instance as `{...}`, where `{...}` indicates the JSON encoding of a `Transaction` instance.
+
+For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `avro.preserve_logical_types`
+
+Whether to preserve logical types or transform them back into their primitive type.
+
+When set to `false`, logical types are transformed. For example, decimals are decoded as raw bytes and timestamps are decoded as plain integers. 
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -134,7 +134,7 @@ For more details on the difference between standard JSON and Avro JSON, see the 
 Choose whether to:
 
 - Transform logical types into their primitive type (default). For example, decimals become raw bytes and timestamps become plain integers.
-- Preserve logical types
+- Preserve logical types.
 
 Set to `true` to preserve logical types.
 

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -22,7 +22,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 schema_registry_decode:
   url: "" # No default (required)
@@ -34,7 +34,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 schema_registry_decode:
   avro_raw_json: false
@@ -66,35 +66,40 @@ schema_registry_decode:
 --
 ======
 
-Decodes messages automatically from a schema stored within a https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry service^] by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error handling methods].
+Decodes messages automatically from a schema stored within a https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry service^] by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error-handling methods].
 
 Avro, Protobuf and JSON schemas are supported, all are capable of expanding from schema references as of v4.22.0.
 
 == Avro JSON format
 
-This processor creates documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default, this processor expects documents formatted as https://avro.apache.org/docs/current/specification/[Avro JSON^] when decoding with Avro schemas. In this format, the value of a union is encoded in JSON as follows:
 
-- if its type is `null`, then it is encoded as a JSON `null`;
-- otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
+- If the union's type is `null`, it is encoded as a JSON `null`.
+- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
 
-For example, the union schema `["null","string","Foo"]`, where `Foo` is a record name, would encode:
+For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
-- `null` as `null`;
-- the string `"a"` as `\{"string": "a"}`; and
-- a `Foo` instance as `\{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
+- The `null` as a JSON `null`
+- The string `"a"` as `{"string": "a"}`
+- A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance
 
-However, it is possible to instead create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro_raw_json, `avro_raw_json`>> to `true`.
+Alternatively, you can create documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro_raw_json,`avro_raw_json`>> to `true`.
 
 == Protobuf format
 
 This processor decodes protobuf messages to JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
 
+== Metadata
+
+This processor adds the following metadata to processed messages:
+
+- `schema_id`: The ID of the schema in the schema registry associated with the message.
 
 == Fields
 
 === `avro_raw_json`
 
-Whether Avro messages should be decoded into normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^]. If `true` the schema returned from the subject should be decoded as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard json^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[avro json^]. There is a https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in goavro^], the https://github.com/linkedin/goavro[underlining library used for avro serialization^], that explains in more detail the difference between the standard json and avro json.
+Whether messages should be decoded into normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. If `true`, the schema returned from the subject is decoded as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
 
 
 *Type*: `bool`

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -131,9 +131,12 @@ For more details on the difference between standard JSON and Avro JSON, see the 
 
 === `avro.preserve_logical_types`
 
-Whether to preserve logical types or transform them back into their primitive type.
+Choose whether to:
 
-When set to `false`, logical types are transformed. For example, decimals are decoded as raw bytes and timestamps are decoded as plain integers. 
+- Transform logical types into their primitive type (default). For example, decimals become raw bytes and timestamps become plain integers.
+- Preserve logical types
+
+Set to `true` to preserve logical types.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -77,7 +77,7 @@ Encodes messages automatically from schemas obtains from a https://docs.confluen
 
 If a message fails to encode under the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error-handling methods].
 
-Avro, Protobuf and Json schemas are supported, all are capable of expanding from schema references as of v4.22.0.
+Avro, Protobuf and JSON schemas are supported, all are capable of expanding from schema references as of v4.22.0.
 
 == Avro JSON format
 
@@ -88,7 +88,7 @@ By default, this processor expects documents formatted as https://avro.apache.or
 
 For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
-- The `null` as a JSON `null`
+- A `null` as a JSON `null`
 - The string `"a"` as `{"string": "a"}`
 - A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance
 
@@ -100,11 +100,11 @@ Important! There is an outstanding issue in the https://github.com/linkedin/goav
 
 == Protobuf format
 
-This processor encodes protobuf messages either from any format parsed within Redpanda Connect (encoded as JSON by default), or from raw JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
+This processor encodes Protobuf messages either from any format parsed within Redpanda Connect (encoded as JSON by default), or from raw JSON documents, you can read more about JSON mapping of Protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
 
 === Multiple message support
 
-When a target subject presents a protobuf schema that contains multiple messages it becomes ambiguous which message definition a given input data should be encoded against. In such scenarios Redpanda Connect will attempt to encode the data against each of them and select the first to successfully match against the data, this process currently *ignores all nested message definitions*. In order to speed up this exhaustive search the last known successful message will be attempted first for each subsequent input.
+When a target subject presents a Protobuf schema that contains multiple messages it becomes ambiguous which message definition a given input data should be encoded against. In such scenarios Redpanda Connect will attempt to encode the data against each of them and select the first to successfully match against the data, this process currently *ignores all nested message definitions*. In order to speed up this exhaustive search the last known successful message will be attempted first for each subsequent input.
 
 We will be considering alternative approaches in future so please https://redpanda.com/slack[get in touch^] with thoughts and feedback.
 
@@ -155,8 +155,9 @@ refresh_period: 1h
 
 === `avro_raw_json`
 
-Whether messages encoded in Avro format should be parsed as normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. If `true`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
+Whether messages encoded in Avro format should be parsed as normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. 
 
+If set to `true`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -155,9 +155,25 @@ refresh_period: 1h
 
 === `avro_raw_json`
 
-Whether messages encoded in Avro format should be parsed as normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. 
+Whether Avro messages should be parsed as normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. 
 
-If set to `true`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
+If set to `false`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^].
+
+For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would be decoded as:
+
+- A `null` as a JSON `null`
+- The string `"a"` as `{"string": "a"}`
+- A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance.
+
+If set to `true`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^].
+
+For example, the same union schema `["null","string","Transaction"]` is decoded as:
+
+- A `null` as JSON `null`
+- The string `"a"` as `"a"`
+- A `Transaction` instance as `{...}`, where `{...}` indicates the JSON encoding of a `Transaction` instance.
+
+For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -81,18 +81,18 @@ Avro, Protobuf and Json schemas are supported, all are capable of expanding from
 
 == Avro JSON format
 
-By default this processor expects documents formatted as https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^] when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default, this processor expects documents formatted as https://avro.apache.org/docs/current/specification/[Avro JSON^] when encoding with Avro schemas. In this format, the value of a union is encoded in JSON as follows:
 
-- if its type is `null`, then it is encoded as a JSON `null`;
-- otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
+- If the union's type is `null`, it is encoded as a JSON `null`.
+- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
 
-For example, the union schema `["null","string","Foo"]`, where `Foo` is a record name, would encode:
+For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
-- `null` as `null`;
-- the string `"a"` as `\{"string": "a"}`; and
-- a `Foo` instance as `\{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
+- The `null` as a JSON `null`
+- The string `"a"` as `{"string": "a"}`
+- A `Transaction` instance as `{"Transaction": {...}}`, where `{...}` indicates the JSON encoding of a `Transaction` instance
 
-However, it is possible to instead consume documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro_raw_json, `avro_raw_json`>> to `true`.
+Alternatively, you can consume documents in https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard/raw JSON format^] by setting the field <<avro_raw_json,`avro_raw_json`>> to `true`.
 
 === Known issues
 
@@ -155,7 +155,7 @@ refresh_period: 1h
 
 === `avro_raw_json`
 
-Whether messages encoded in Avro format should be parsed as normal JSON ("json that meets the expectations of regular internet json") rather than https://avro.apache.org/docs/current/specification/_print/#json-encoding[Avro JSON^]. If `true` the schema returned from the subject should be parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard json^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[avro json^]. There is a https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in goavro^], the https://github.com/linkedin/goavro[underlining library used for avro serialization^], that explains in more detail the difference between standard json and avro json.
+Whether messages encoded in Avro format should be parsed as normal JSON (JSON that meets the expectations of regular internet JSON) rather than https://avro.apache.org/docs/current/specification/[Avro JSON^]. If `true`, the schema returned from the subject is parsed as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull[standard JSON^] instead of as https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec[Avro JSON^]. For more details on the difference between standard JSON and Avro JSON, see the https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249[comment in Goavro^] and the https://github.com/linkedin/goavro[underlying library used for Avro serialization^].
 
 
 *Type*: `bool`

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -84,7 +84,7 @@ Avro, Protobuf and JSON schemas are supported, all are capable of expanding from
 By default, this processor expects documents formatted as https://avro.apache.org/docs/current/specification/[Avro JSON^] when encoding with Avro schemas. In this format, the value of a union is encoded in JSON as follows:
 
 - If the union's type is `null`, it is encoded as a JSON `null`.
-- Otherwise, the union is encoded as a JSON object with one name/value pair. The `"name"` is the type's name and the `"value"` is the recursively encoded value. For Avro's named types (record, fixed or enum), the user-specified name is used. For other types, the type name is used.
+- Otherwise, the union is encoded as a JSON object with one name/value pair. The name is the type's name, and the value is the recursively-encoded value. The user-specified name is used for Avro's named types (record, fixed, or enum). For other types, the type name is used.
 
 For example, the union schema `["null","string","Transaction"]`, where `Transaction` is a record name, would encode:
 
@@ -100,7 +100,7 @@ Important! There is an outstanding issue in the https://github.com/linkedin/goav
 
 == Protobuf format
 
-This processor encodes Protobuf messages either from any format parsed within Redpanda Connect (encoded as JSON by default), or from raw JSON documents, you can read more about JSON mapping of Protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
+This processor encodes Protobuf messages either from any format parsed within Redpanda Connect (encoded as JSON by default), or from raw JSON documents. For more information about the JSON mapping of Protobuf messages, see the https://developers.google.com/protocol-buffers/docs/proto3#json[Protocol Buffers documentation^].
 
 === Multiple message support
 

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -75,7 +75,7 @@ schema_registry_encode:
 
 Encodes messages automatically from schemas obtains from a https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry service^] by polling the service for the latest schema version for target subjects.
 
-If a message fails to encode under the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error handling methods].
+If a message fails to encode under the schema then it will remain unchanged and the error can be caught using xref:configuration:error_handling.adoc[error-handling methods].
 
 Avro, Protobuf and Json schemas are supported, all are capable of expanding from schema references as of v4.22.0.
 

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -25,7 +25,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 schema_registry_encode:
   url: "" # No default (required)
@@ -39,7 +39,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 schema_registry_encode:
   url: "" # No default (required)


### PR DESCRIPTION
## Description

Resolves: [DOC-995](https://redpandadata.atlassian.net/browse/DOC-995), [DOC-994](https://redpandadata.atlassian.net/browse/DOC-994) and tries to standardize Avro JSON content
Review deadline: 7th February

## Page previews

Processors:
[schema_registry_decode](https://deploy-preview-170--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_decode/) with new metadata info and new fields
[schema_registry_encode](https://deploy-preview-170--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_encode/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-995]: https://redpandadata.atlassian.net/browse/DOC-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-994]: https://redpandadata.atlassian.net/browse/DOC-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ