### PR TITLE
Fix the values for the level field of the log processor

### DIFF
--- a/modules/components/pages/processors/log.adoc
+++ b/modules/components/pages/processors/log.adoc
@@ -63,7 +63,6 @@ Options:
 , `INFO`
 , `DEBUG`
 , `TRACE`
-, `ALL`
 .
 
 === `fields_mapping`


### PR DESCRIPTION
We don't support `ALL`.

Matching Benthos PR: https://github.com/redpanda-data/benthos/pull/174

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)