### PR TITLE
DOC-768 Update http components

### DIFF
--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -4,14 +4,9 @@
 :status: stable
 :categories: ["Network"]
 
-// © 2024 Redpanda Data Inc.
-
-
 component_type_dropdown::[]
 
-
-Connects to a server and continuously performs requests for a single message.
-
+Connects to a server and continuously requests single messages.
 
 [tabs]
 ======
@@ -20,7 +15,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   http_client:
@@ -44,7 +39,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   http_client:
@@ -54,36 +49,36 @@ input:
     metadata:
       include_prefixes: []
       include_patterns: []
-    dump_request_log_level: ""
+    dump_request_log_level: "" # No default (optional)
     oauth:
       enabled: false
-      consumer_key: ""
-      consumer_secret: ""
-      access_token: ""
-      access_token_secret: ""
+      consumer_key: "" # No default (optional)
+      consumer_secret: "" # No default (optional)
+      access_token: "" # No default (optional)
+      access_token_secret: "" # No default (optional)
     oauth2:
       enabled: false
-      client_key: ""
-      client_secret: ""
-      token_url: ""
+      client_key: "" # No default (optional)
+      client_secret: "" # No default (optional)
+      token_url: "" # No default (optional)
       scopes: []
       endpoint_params: {}
     basic_auth:
       enabled: false
-      username: ""
-      password: ""
+      username: "" # No default (optional)
+      password: "" # No default (optional)
     jwt:
       enabled: false
-      private_key_file: ""
-      signing_method: ""
+      private_key_file: "" # No default (optional)
+      signing_method: "" # No default (optional)
       claims: {}
       headers: {}
     tls:
       enabled: false
       skip_cert_verify: false
       enable_renegotiation: false
-      root_cas: ""
-      root_cas_file: ""
+      root_cas: "" # No default (optional)
+      root_cas_file: "" # No default (optional)
       client_certs: []
     extract_headers:
       include_prefixes: []
@@ -111,25 +106,16 @@ input:
 --
 ======
 
-The URL and header values of this type can be dynamically set using function interpolations described xref:configuration:interpolation.adoc#bloblang-queries[here].
+== Dynamic URL and header settings
 
-== Streaming
+You can set the <<url,`url`>> and <<headers,`headers`>> values dynamically using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
 
-If you enable streaming then Redpanda Connect will consume the body of the response as a continuous stream of data, breaking messages out following a chosen scanner. This allows you to consume APIs that provide long lived streamed data feeds (such as Twitter).
+=== Pagination
 
-== Pagination
+You can also add xref:configuration:interpolation.adoc#bloblang-queries[function interpolations] to the <<url,`url`>> and <<headers,`headers`>> fields to implement basic pagination, such as page numbers or tokens, where subsequent requests need to include data from previously-consumed responses.
 
-This input supports interpolation functions in the `url` and `headers` fields where data from the previous successfully consumed message (if there was one) can be referenced. This can be used in order to support basic levels of pagination. However, in cases where pagination depends on logic it is recommended that you use an xref:components:processors/http.adoc[`http` processor] instead, often combined with a xref:components:inputs/generate.adoc[`generate` input] in order to schedule the processor.
+Example:
 
-== Examples
-
-[tabs]
-======
-Basic Pagination::
-+
---
-
-Interpolation functions within the `url` and `headers` fields can be used to reference the previously consumed message, which allows simple pagination.
 
 ```yaml
 input:
@@ -139,7 +125,7 @@ input:
         (timestamp_unix()-300).ts_format("2006-01-02T15:04:05Z","UTC").escape_url_query()
       ) }${! ("&next_token="+this.meta.next_token.not_null()) | "" }
     verb: GET
-    rate_limit: foo_searches
+    rate_limit: schedule_searches
     oauth2:
       enabled: true
       token_url: https://api.example.com/oauth2/token
@@ -147,34 +133,33 @@ input:
       client_secret: "${EXAMPLE_SECRET}"
 
 rate_limit_resources:
-  - label: foo_searches
+  - label: schedule_searches
     local:
       count: 1
       interval: 30s
 ```
 
---
-======
+TIP: If pagination requires more complex logic, consider using the xref:components:processors/http.adoc[`http` processor] combined with a xref:components:inputs/generate.adoc[`generate` input], which allows you to schedule the processor.
+
+== Streaming messages
+
+If you <<stream_enabled,enable streaming>>, Redpanda Connect consumes the body of the server response as a continuous stream of data, and breaks down the stream into smaller, logical messages using the <<stream_scanner,specified scanner>>. This functionality allows you to consume APIs that provide long-lived streamed data feeds, such as stock market feeds.
 
 == Fields
 
 === `url`
 
-The URL to connect to.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The URL to connect to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
-
 
 === `verb`
 
-A verb to connect with
-
+A verb to connect with.
 
 *Type*: `string`
 
-*Default*: `"GET"`
+*Default*: `GET`
 
 ```yml
 # Examples
@@ -188,9 +173,7 @@ verb: DELETE
 
 === `headers`
 
-A map of headers to add to the request.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+A map of headers to add to the request. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `object`
 
@@ -206,16 +189,13 @@ headers:
 
 === `metadata`
 
-Specify optional matching rules to determine which metadata keys should be added to the HTTP request as headers.
-
+Specify matching rules that determine which metadata keys to add to the HTTP request as headers (optional).
 
 *Type*: `object`
-
 
 === `metadata.include_prefixes`
 
 Provide a list of explicit metadata key prefixes to match against.
-
 
 *Type*: `array`
 
@@ -225,14 +205,11 @@ Provide a list of explicit metadata key prefixes to match against.
 # Examples
 
 include_prefixes:
-  - foo_
-  - bar_
-
-include_prefixes:
   - kafka_
 
 include_prefixes:
   - content-
+  - user_
 ```
 
 === `metadata.include_patterns`
@@ -256,8 +233,7 @@ include_patterns:
 
 === `dump_request_log_level`
 
-EXPERIMENTAL: Optionally set a level at which the request and response payload of each request made will be logged.
-
+EXPERIMENTAL: Set the logging level for the request and response payloads of each HTTP request.
 
 *Type*: `string`
 
@@ -274,13 +250,10 @@ Options:
 , `WARN`
 , `ERROR`
 , `FATAL`
-, ``
-.
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
-
+Allows you to specify open authentication using OAuth version 1.
 
 *Type*: `object`
 
@@ -298,18 +271,15 @@ Whether to use OAuth version 1 in requests.
 
 A value used to identify the client to the service provider.
 
-
 *Type*: `string`
 
 *Default*: `""`
 
 === `oauth.consumer_secret`
 
-A secret used to establish ownership of the consumer key.
+The secret used to establish ownership of the consumer key.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -317,8 +287,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth.access_token`
 
-A value used to gain access to the protected resources on behalf of the user.
-
+The value used to gain access to the protected resources on behalf of the user.
 
 *Type*: `string`
 
@@ -326,11 +295,9 @@ A value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-A secret provided in order to establish ownership of a given access token.
+The secret that establishes ownership of the `oauth.access_token`.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -338,7 +305,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth2`
 
-Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+Allows you to specify open authentication using OAuth version 2 and the client credentials token flow.
 
 
 *Type*: `object`
@@ -364,7 +331,7 @@ A value used to identify the client to the token provider.
 
 === `oauth2.client_secret`
 
-A secret used to establish ownership of the client key.
+The secret used to establish ownership of the client key.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -384,7 +351,7 @@ The URL of the token provider.
 
 === `oauth2.scopes`
 
-A list of optional requested permissions.
+A list of requested permissions (optional).
 
 
 *Type*: `array`
@@ -397,7 +364,7 @@ endif::[]
 
 === `oauth2.endpoint_params`
 
-A list of optional endpoint parameters, values should be arrays of strings.
+A list of endpoint parameters specified as arrays of strings (optional).
 
 
 *Type*: `object`
@@ -412,11 +379,11 @@ endif::[]
 # Examples
 
 endpoint_params:
-  bar:
-    - woof
-  foo:
-    - meow
-    - quack
+  grant_type:
+    - client_credentials
+  audience:
+    - https://api.example.com/
+    - https://api.example.com/resource
 ```
 
 === `basic_auth`
@@ -459,7 +426,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 
 *Type*: `object`
@@ -476,7 +443,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -485,7 +452,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -503,7 +470,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`
@@ -512,7 +479,7 @@ Add optional key/value headers to the JWT.
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
+Override system defaults with custom TLS settings.
 
 
 *Type*: `object`
@@ -529,7 +496,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -551,11 +518,9 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -572,7 +537,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 
 *Type*: `string`
@@ -587,7 +552,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 
 *Type*: `array`
@@ -608,7 +573,7 @@ client_certs:
 
 === `tls.client_certs[].cert`
 
-A plain text certificate to use.
+The plain text certificate to use.
 
 
 *Type*: `string`
@@ -617,7 +582,7 @@ A plain text certificate to use.
 
 === `tls.client_certs[].key`
 
-A plain text certificate key to use.
+The plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -648,11 +613,9 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks that may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -668,8 +631,7 @@ password: ${KEY_PASSWORD}
 
 === `extract_headers`
 
-Specify which response headers should be added to resulting messages as metadata. Header keys are lowercased before matching, so ensure that your patterns target lowercased versions of the header keys that you expect.
-
+Specify which response headers to add to the resulting messages as metadata. Header keys are automatically converted to lowercase before matching, so make sure that your patterns target the lowercase versions of the expected header keys.
 
 *Type*: `object`
 
@@ -687,8 +649,8 @@ Provide a list of explicit metadata key prefixes to match against.
 # Examples
 
 include_prefixes:
-  - foo_
-  - bar_
+  - content-
+  - user_
 
 include_prefixes:
   - kafka_
@@ -718,7 +680,7 @@ include_patterns:
 
 === `rate_limit`
 
-An optional xref:components:rate_limits/about.adoc[rate limit] to throttle requests by.
+A xref:components:rate_limits/about.adoc[rate limit] to throttle requests by (optional).
 
 
 *Type*: `string`
@@ -731,16 +693,16 @@ A static timeout to apply to requests.
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
 
 === `retry_period`
 
-The base period to wait between failed requests.
+The initial period to wait between failed requests before retrying.
 
 
 *Type*: `string`
 
-*Default*: `"1s"`
+*Default*: `1s`
 
 === `max_retry_backoff`
 
@@ -749,7 +711,7 @@ The maximum period to wait between failed requests.
 
 *Type*: `string`
 
-*Default*: `"300s"`
+*Default*: `300s`
 
 === `retries`
 
@@ -762,8 +724,7 @@ The maximum number of retry attempts to make.
 
 === `backoff_on`
 
-A list of status codes whereby the request should be considered to have failed and retries should be attempted, but the period between them should be increased gradually.
-
+A list of status codes that indicate a request failure, and trigger retries with an increasing backoff period between attempts.
 
 *Type*: `array`
 
@@ -771,7 +732,9 @@ A list of status codes whereby the request should be considered to have failed a
 
 === `drop_on`
 
-A list of status codes whereby the request should be considered to have failed but retries should not be attempted. This is useful for preventing wasted retries for requests that will never succeed. Note that with these status codes the _request_ is dropped, but _message_ that caused the request will not be dropped.
+A list of status codes that indicate a request failure, where the input should not attempt retries. This helps avoid unnecessary retries for requests that are unlikely to succeed.
+
+NOTE: In these cases, the _request_ is dropped, but the _message_ that triggered the request is retained.
 
 
 *Type*: `array`
@@ -780,7 +743,9 @@ A list of status codes whereby the request should be considered to have failed b
 
 === `successful_on`
 
-A list of status codes whereby the attempt should be considered successful, this is useful for dropping requests that return non-2XX codes indicating that the message has been dealt with, such as a 303 See Other or a 409 Conflict. All 2XX codes are considered successful unless they are present within `backoff_on` or `drop_on`, regardless of this field.
+A list of HTTP status codes that should be considered as successful, even if they are not 2XX codes. This is useful for handling cases where non-2XX codes indicate that the request was processed successfully, such as `303 See Other` or `409 Conflict`. 
+
+By default, all 2XX codes are considered successful unless they are specified in `backoff_on` or `drop_on` fields.
 
 
 *Type*: `array`
@@ -789,16 +754,14 @@ A list of status codes whereby the attempt should be considered successful, this
 
 === `proxy_url`
 
-An optional HTTP proxy URL.
-
+A HTTP proxy URL (optional).
 
 *Type*: `string`
 
 
 === `payload`
 
-An optional payload to deliver for each request.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+A payload to deliver for each request (optional). This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
@@ -806,7 +769,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `drop_empty_bodies`
 
-Whether empty payloads received from the target server should be dropped.
+Whether to drop empty payloads received from the target server.
 
 
 *Type*: `bool`
@@ -815,7 +778,7 @@ Whether empty payloads received from the target server should be dropped.
 
 === `stream`
 
-Allows you to set streaming mode, where requests are kept open and messages are processed line-by-line.
+Enables streaming mode, where the HTTP connection remains open and messages are processed line-by-line.
 
 
 *Type*: `object`
@@ -825,14 +788,13 @@ Allows you to set streaming mode, where requests are kept open and messages are 
 
 Enables streaming mode.
 
-
 *Type*: `bool`
 
 *Default*: `false`
 
 === `stream.reconnect`
 
-Sets whether to re-establish the connection once it is lost.
+Whether to automatically re-establish the HTTP connection if it is lost.
 
 
 *Type*: `bool`
@@ -841,8 +803,7 @@ Sets whether to re-establish the connection once it is lost.
 
 === `stream.scanner`
 
-The xref:components:scanners/about.adoc[scanner] by which the stream of bytes consumed will be broken out into individual messages. Scanners are useful for processing large sources of data without holding the entirety of it within memory. For example, the `csv` scanner allows you to process individual CSV rows without loading the entire CSV file in memory at once.
-
+The xref:components:scanners/about.adoc[scanner] used to split the stream of bytes into individual messages. Scanners are useful for processing large data sources efficiently without holding the entire data set in memory. For example, the `csv` scanner processes individual rows in a CSV file, which allows you to process large files without consuming excessive memory.
 
 *Type*: `scanner`
 
@@ -854,7 +815,9 @@ endif::[]
 
 === `auto_replay_nacks`
 
-Whether messages that are rejected (nacked) at the output level should be automatically replayed indefinitely, eventually resulting in back pressure if the cause of the rejections is persistent. If set to `false` these messages will instead be deleted. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data can be discarded immediately upon consumption and mutation.
+Whether to automatically replay rejected messages (negative acknowledgements) at the output level. If the cause of rejections persists, leaving this option enabled can result in back pressure.
+
+Set `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data is discarded immediately upon consumption and mutation.
 
 
 *Type*: `bool`

--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -143,7 +143,7 @@ TIP: If pagination requires more complex logic, consider using the xref:componen
 
 == Streaming messages
 
-If you <<stream_enabled,enable streaming>>, Redpanda Connect consumes the body of the server response as a continuous stream of data, and breaks down the stream into smaller, logical messages using the <<stream_scanner,specified scanner>>. This functionality allows you to consume APIs that provide long-lived streamed data feeds, such as stock market feeds.
+If you <<stream-enabled,enable streaming>>, Redpanda Connect consumes the body of the server response as a continuous stream of data, and breaks the stream down into smaller, logical messages using the <<stream-scanner,specified scanner>>. This functionality allows you to consume APIs that provide long-lived streamed data feeds, such as stock market feeds.
 
 == Fields
 
@@ -152,6 +152,8 @@ If you <<stream_enabled,enable streaming>>, Redpanda Connect consumes the body o
 The URL to connect to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
+
+*Default*: `""`
 
 === `verb`
 
@@ -794,7 +796,7 @@ Enables streaming mode.
 
 === `stream.reconnect`
 
-Whether to automatically re-establish the HTTP connection if it is lost.
+Whether to automatically reestablish the HTTP connection if it is lost.
 
 
 *Type*: `bool`
@@ -803,7 +805,7 @@ Whether to automatically re-establish the HTTP connection if it is lost.
 
 === `stream.scanner`
 
-The xref:components:scanners/about.adoc[scanner] used to split the stream of bytes into individual messages. Scanners are useful for processing large data sources efficiently without holding the entire data set in memory. For example, the `csv` scanner processes individual rows in a CSV file, which allows you to process large files without consuming excessive memory.
+The xref:components:scanners/about.adoc[scanner] used to split the stream of bytes into individual messages. Scanners are useful for processing large data sources efficiently without holding the entire data set in memory. For example, the `csv` scanner processes individual rows in a CSV file without loading the entire file in memory.
 
 *Type*: `scanner`
 

--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -49,36 +49,36 @@ input:
     metadata:
       include_prefixes: []
       include_patterns: []
-    dump_request_log_level: "" # No default (optional)
+    dump_request_log_level: "" # Optional
     oauth:
       enabled: false
-      consumer_key: "" # No default (optional)
-      consumer_secret: "" # No default (optional)
-      access_token: "" # No default (optional)
-      access_token_secret: "" # No default (optional)
+      consumer_key: "" # Optional
+      consumer_secret: "" # Optional
+      access_token: "" # Optional
+      access_token_secret: "" # Optional
     oauth2:
       enabled: false
-      client_key: "" # No default (optional)
-      client_secret: "" # No default (optional)
-      token_url: "" # No default (optional)
+      client_key: "" # Optional
+      client_secret: "" # Optional
+      token_url: "" # Optional
       scopes: []
       endpoint_params: {}
     basic_auth:
       enabled: false
-      username: "" # No default (optional)
-      password: "" # No default (optional)
+      username: "" # Optional
+      password: "" # Optional
     jwt:
       enabled: false
-      private_key_file: "" # No default (optional)
-      signing_method: "" # No default (optional)
+      private_key_file: "" # Optional
+      signing_method: "" # Optional
       claims: {}
       headers: {}
     tls:
       enabled: false
       skip_cert_verify: false
       enable_renegotiation: false
-      root_cas: "" # No default (optional)
-      root_cas_file: "" # No default (optional)
+      root_cas: "" # Optional
+      root_cas_file: "" # Optional
       client_certs: []
     extract_headers:
       include_prefixes: []

--- a/modules/components/pages/inputs/websocket.adoc
+++ b/modules/components/pages/inputs/websocket.adoc
@@ -318,7 +318,7 @@ max_retries: 10
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -415,8 +415,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
-
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 *Type*: `object`
 
@@ -432,7 +431,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -441,7 +440,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -459,7 +458,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Sends messages to an HTTP server.
+Sends messages to a HTTP server.
 
 
 [tabs]
@@ -20,7 +20,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   http_client:
@@ -33,8 +33,8 @@ output:
     batching:
       count: 0
       byte_size: 0
-      period: ""
-      check: ""
+      period: "" # No default (optional)
+      check: "" # No default (optional)
 ```
 
 --
@@ -43,7 +43,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   http_client:
@@ -53,28 +53,28 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
-    dump_request_log_level: ""
+    dump_request_log_level: "" # No default (optional)
     oauth:
       enabled: false
-      consumer_key: ""
-      consumer_secret: ""
-      access_token: ""
-      access_token_secret: ""
+      consumer_key: "" # No default (optional)
+      consumer_secret: "" # No default (optional)
+      access_token: "" # No default (optional)
+      access_token_secret: "" # No default (optional)
     oauth2:
       enabled: false
-      client_key: ""
-      client_secret: ""
-      token_url: ""
+      client_key: "" # No default (optional)
+      client_secret: "" # No default (optional)
+      token_url: "" # No default (optional)
       scopes: []
       endpoint_params: {}
     basic_auth:
       enabled: false
-      username: ""
-      password: ""
+      username: "" # No default (optional)
+      password: "" # No default (optional)
     jwt:
       enabled: false
-      private_key_file: ""
-      signing_method: ""
+      private_key_file: "" # No default (optional)
+      signing_method: "" # No default (optional)
       claims: {}
       headers: {}
     tls:
@@ -103,8 +103,8 @@ output:
     batching:
       count: 0
       byte_size: 0
-      period: ""
-      check: ""
+      period: "" # No default (optional)
+      check: "" # No default (optional)
       processors: [] # No default (optional)
     multipart: []
 ```
@@ -112,28 +112,32 @@ output:
 --
 ======
 
-When the number of retries expires the output will reject the message, the behavior after this will depend on the pipeline but usually this simply means the send is attempted again until successful whilst applying back pressure.
+== Message sends
 
-The URL and header values of this type can be dynamically set using function interpolations described in xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries].
+The body of the request sent to the HTTP server is the raw contents of the message payload. If the message has multiple parts (is a batch), the request is sent according to https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^]. To disable this behavior, set the <<batch_as_multipart, `batch_as_multipart`>> field to `false`.
 
-The body of the HTTP request is the raw contents of the message payload. If the message has multiple parts (is a batch) the request will be sent according to https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^]. This behavior can be disabled by setting the field <<batch_as_multipart, `batch_as_multipart`>> to `false`.
+When message retries are exhausted, this output rejects a message. Typically, a pipeline then continues attempts to send the message until it succeeds, whilst applying back pressure.
+
+== Dynamic URL and header settings
+
+You can set the <<url,`url`>> and <<headers,`headers`>> values dynamically using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
 
 == Propagate responses
 
-It's possible to propagate the response from each HTTP request back to the input source by setting `propagate_response` to `true`. Only inputs that support xref:guides:sync_responses.adoc[synchronous responses] are able to make use of these propagated responses.
+To propagate HTTP responses back to the input source, set the <<propagate_response,`propagate_response`>> field to `true` . This feature is only available for inputs that support xref:guides:sync_responses.adoc[synchronous responses].
 
 == Performance
 
-This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+For improved performance, this output sends:
 
-This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. You can find out more xref:configuration:batching.adoc[in this doc].
+- Multiple messages in parallel. Adjust the `max_in_flight` field value to tune the maximum number of in-flight messages (or message batches). 
+- Messages as batches. You can configure batches at both input and output level. For more information, see xref:configuration:batching.adoc[Message Batching].
 
 == Fields
 
 === `url`
 
-The URL to connect to.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+The URL to connect to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
@@ -141,12 +145,12 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `verb`
 
-A verb to connect with
+A verb to connect with.
 
 
 *Type*: `string`
 
-*Default*: `"POST"`
+*Default*: `POST`
 
 ```yml
 # Examples
@@ -160,8 +164,7 @@ verb: DELETE
 
 === `headers`
 
-A map of headers to add to the request.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+A map of headers to add to the request. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `object`
@@ -178,7 +181,7 @@ headers:
 
 === `metadata`
 
-Specify optional matching rules to determine which metadata keys should be added to the HTTP request as headers.
+Specify matching rules that determine which metadata keys to add to the HTTP request as headers (optional).
 
 
 *Type*: `object`
@@ -228,7 +231,7 @@ include_patterns:
 
 === `dump_request_log_level`
 
-EXPERIMENTAL: Optionally set a level at which the request and response payload of each request made will be logged.
+EXPERIMENTAL: Set the logging level for the request and response payloads of each HTTP request.
 
 
 *Type*: `string`
@@ -246,12 +249,10 @@ Options:
 , `WARN`
 , `ERROR`
 , `FATAL`
-, ``
-.
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -277,10 +278,9 @@ A value used to identify the client to the service provider.
 
 === `oauth.consumer_secret`
 
-A secret used to establish ownership of the consumer key.
+The secret used to establish ownership of the consumer key.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -289,7 +289,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth.access_token`
 
-A value used to gain access to the protected resources on behalf of the user.
+The value used to gain access to the protected resources on behalf of the user.
 
 
 *Type*: `string`
@@ -298,11 +298,9 @@ A value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-A secret provided in order to establish ownership of a given access token.
+The secret that establishes ownership of the `oauth.access_token`.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -310,7 +308,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth2`
 
-Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
+Allows you to specify open authentication using OAuth version 2 and the client credentials token flow.
 
 
 *Type*: `object`
@@ -336,10 +334,9 @@ A value used to identify the client to the token provider.
 
 === `oauth2.client_secret`
 
-A secret used to establish ownership of the client key.
+The secret used to establish ownership of the client key.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -357,7 +354,7 @@ The URL of the token provider.
 
 === `oauth2.scopes`
 
-A list of optional requested permissions.
+A list of requested permissions (optional).
 
 
 *Type*: `array`
@@ -370,7 +367,7 @@ endif::[]
 
 === `oauth2.endpoint_params`
 
-A list of optional endpoint parameters, values should be arrays of strings.
+A list of endpoint parameters specified as arrays of strings (optional).
 
 
 *Type*: `object`
@@ -385,11 +382,11 @@ endif::[]
 # Examples
 
 endpoint_params:
-  bar:
-    - woof
-  foo:
-    - meow
-    - quack
+  grant_type:
+    - client_credentials
+  audience:
+    - https://api.example.com/
+    - https://auth.example.com/
 ```
 
 === `basic_auth`
@@ -431,8 +428,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
-
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 *Type*: `object`
 
@@ -448,7 +444,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -457,7 +453,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -475,7 +471,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`
@@ -484,7 +480,7 @@ Add optional key/value headers to the JWT.
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
+Override system defaults with custom TLS settings.
 
 
 *Type*: `object`
@@ -501,7 +497,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -523,7 +519,7 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -543,7 +539,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 
 *Type*: `string`
@@ -558,7 +554,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 
 *Type*: `array`
@@ -579,7 +575,7 @@ client_certs:
 
 === `tls.client_certs[].cert`
 
-A plain text certificate to use.
+The plain text certificate to use.
 
 
 *Type*: `string`
@@ -588,11 +584,9 @@ A plain text certificate to use.
 
 === `tls.client_certs[].key`
 
-A plain text certificate key to use.
+The plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -620,7 +614,7 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks that may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -639,8 +633,9 @@ password: ${KEY_PASSWORD}
 
 === `extract_headers`
 
-Specify which response headers should be added to resulting synchronous response messages as metadata. Header keys are lowercased before matching, so ensure that your patterns target lowercased versions of the header keys that you expect. This field is not applicable unless `propagate_response` is set to `true`.
+Specify which response headers to add to the resulting synchronous response messages as metadata. Header keys are automatically converted to lowercase before matching, so make sure that your patterns target the lowercase versions of the expected header keys.
 
+This field is only applicable when `propagate_response` is set to `true`.
 
 *Type*: `object`
 
@@ -658,8 +653,8 @@ Provide a list of explicit metadata key prefixes to match against.
 # Examples
 
 include_prefixes:
-  - foo_
-  - bar_
+  - content-
+  - user_
 
 include_prefixes:
   - kafka_
@@ -689,7 +684,7 @@ include_patterns:
 
 === `rate_limit`
 
-An optional xref:components:rate_limits/about.adoc[rate limit] to throttle requests by.
+A xref:components:rate_limits/about.adoc[rate limit] to throttle requests by (optional).
 
 
 *Type*: `string`
@@ -706,12 +701,12 @@ A static timeout to apply to requests.
 
 === `retry_period`
 
-The base period to wait between failed requests.
+The initial period to wait between failed requests before retrying.
 
 
 *Type*: `string`
 
-*Default*: `"1s"`
+*Default*: `1s`
 
 === `max_retry_backoff`
 
@@ -720,7 +715,7 @@ The maximum period to wait between failed requests.
 
 *Type*: `string`
 
-*Default*: `"300s"`
+*Default*: `300s`
 
 === `retries`
 
@@ -733,7 +728,7 @@ The maximum number of retry attempts to make.
 
 === `backoff_on`
 
-A list of status codes whereby the request should be considered to have failed and retries should be attempted, but the period between them should be increased gradually.
+A list of status codes that indicate a request failure and trigger retries with an increasing backoff period between attempts.
 
 
 *Type*: `array`
@@ -742,7 +737,9 @@ A list of status codes whereby the request should be considered to have failed a
 
 === `drop_on`
 
-A list of status codes whereby the request should be considered to have failed but retries should not be attempted. This is useful for preventing wasted retries for requests that will never succeed. Note that with these status codes the _request_ is dropped, but _message_ that caused the request will not be dropped.
+A list of status codes that indicate a request failure where the input should not attempt retries. This helps avoid unnecessary retries for requests that are unlikely to succeed.
+
+NOTE: In these cases, the _request_ is dropped, but the _message_ that triggered the request is retained.
 
 
 *Type*: `array`
@@ -751,8 +748,9 @@ A list of status codes whereby the request should be considered to have failed b
 
 === `successful_on`
 
-A list of status codes whereby the attempt should be considered successful, this is useful for dropping requests that return non-2XX codes indicating that the message has been dealt with, such as a 303 See Other or a 409 Conflict. All 2XX codes are considered successful unless they are present within `backoff_on` or `drop_on`, regardless of this field.
+A list of HTTP status codes that should be considered as successful, even if they are not 2XX codes. This is useful for handling cases where non-2XX codes indicate that the request was processed successfully, such as `303 See Other` or `409 Conflict`. 
 
+By default, all 2XX codes are considered successful unless they are specified in `backoff_on` or `drop_on` fields.
 
 *Type*: `array`
 
@@ -760,7 +758,7 @@ A list of status codes whereby the attempt should be considered successful, this
 
 === `proxy_url`
 
-An optional HTTP proxy URL.
+A HTTP proxy URL (optional).
 
 
 *Type*: `string`
@@ -768,7 +766,9 @@ An optional HTTP proxy URL.
 
 === `batch_as_multipart`
 
-Send message batches as a single request using https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^]. If disabled messages in batches will be sent as individual requests.
+When set to `true`, sends all message in a batch as a single request using https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^]. 
+
+When set to `false`, sends messages in a batch as individual requests.
 
 
 *Type*: `bool`
@@ -777,7 +777,7 @@ Send message batches as a single request using https://www.w3.org/Protocols/rfc1
 
 === `propagate_response`
 
-Whether responses from the server should be xref:guides:sync_responses.adoc[propagated back] to the input.
+Whether to xref:guides:sync_responses.adoc[propagate server responses back] to the input.
 
 
 *Type*: `bool`
@@ -786,8 +786,7 @@ Whether responses from the server should be xref:guides:sync_responses.adoc[prop
 
 === `max_in_flight`
 
-The maximum number of parallel message batches to have in flight at any given time.
-
+The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
 
 *Type*: `int`
 
@@ -821,8 +820,7 @@ batching:
 
 === `batching.count`
 
-A number of messages at which the batch should be flushed. If `0` disables count based batching.
-
+The number of messages after which the batch is flushed. Set to `0` to disable count-based batching.
 
 *Type*: `int`
 
@@ -830,7 +828,7 @@ A number of messages at which the batch should be flushed. If `0` disables count
 
 === `batching.byte_size`
 
-An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
+The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 
 *Type*: `int`
@@ -839,7 +837,7 @@ An amount of bytes at which the batch should be flushed. If `0` disables size ba
 
 === `batching.period`
 
-A period in which an incomplete batch should be flushed regardless of its size.
+The period after which an incomplete batch is flushed regardless of its size.
 
 
 *Type*: `string`
@@ -873,11 +871,9 @@ check: this.type == "end_of_transaction"
 
 === `batching.processors`
 
-A list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
-
+For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches.
 
 *Type*: `array`
-
 
 ```yml
 # Examples
@@ -897,8 +893,9 @@ processors:
 
 === `multipart`
 
-EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to the request, each part specified consists of content headers and a data field that can be populated dynamically. If this field is populated it will override the default request creation behavior.
+EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to a request. Each part consists of content headers and a data field, which can be populated dynamically. 
 
+If populated, this field overrides the <<message_sends, default request creation behavior>>. 
 
 *Type*: `array`
 
@@ -910,9 +907,7 @@ endif::[]
 
 === `multipart[].content_type`
 
-The content type of the individual message part.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The content type of the individual message part. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -926,9 +921,7 @@ content_type: application/bin
 
 === `multipart[].content_disposition`
 
-The content disposition of the individual message part.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition?utm_source=chatgpt.com#as_a_header_for_a_multipart_body[content disposition^] of the individual message part. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]. For more information, see 
 
 *Type*: `string`
 
@@ -942,9 +935,7 @@ content_disposition: form-data; name="bin"; filename='${! @AttachmentName }
 
 === `multipart[].body`
 
-The body of the individual message part.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The body of the individual message part. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -753,7 +753,7 @@ include_patterns:
   - _timestamp_unix$
 ```
 
-endif[]
+endif::[]
 
 === `rate_limit`
 
@@ -859,7 +859,7 @@ Whether to xref:guides:sync_responses.adoc[propagate server responses back] to t
 
 *Default*: `false`
 
-endif[]
+endif::[]
 
 === `max_in_flight`
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -193,7 +193,7 @@ ifndef::env-cloud[]
 
 To propagate HTTP responses back to the input source, set the <<propagate_response,`propagate_response`>> field to `true` . This feature is only available for inputs that support xref:guides:sync_responses.adoc[synchronous responses].
 
-endif[]
+endif::[]
 
 == Performance
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -33,8 +33,8 @@ output:
     batching:
       count: 0
       byte_size: 0
-      period: "" # No default (optional)
-      check: "" # No default (optional)
+      period: "" # Optional
+      check: "" # Optional
 ```
 
 --
@@ -53,28 +53,28 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
-    dump_request_log_level: "" # No default (optional)
+    dump_request_log_level: "" # Optional
     oauth:
       enabled: false
-      consumer_key: "" # No default (optional)
-      consumer_secret: "" # No default (optional)
-      access_token: "" # No default (optional)
-      access_token_secret: "" # No default (optional)
+      consumer_key: "" # Optional
+      consumer_secret: "" # Optional
+      access_token: "" # Optional
+      access_token_secret: "" # Optional
     oauth2:
       enabled: false
-      client_key: "" # No default (optional)
-      client_secret: "" # No default (optional)
-      token_url: "" # No default (optional)
+      client_key: "" # Optional
+      client_secret: "" # Optional
+      token_url: "" # Optional
       scopes: []
       endpoint_params: {}
     basic_auth:
       enabled: false
-      username: "" # No default (optional)
-      password: "" # No default (optional)
+      username: "" # Optional
+      password: "" # Optional
     jwt:
       enabled: false
-      private_key_file: "" # No default (optional)
-      signing_method: "" # No default (optional)
+      private_key_file: "" # Optional
+      signing_method: "" # Optional
       claims: {}
       headers: {}
     tls:
@@ -103,8 +103,8 @@ output:
     batching:
       count: 0
       byte_size: 0
-      period: "" # No default (optional)
-      check: "" # No default (optional)
+      period: "" # Optional
+      check: "" # Optional
       processors: [] # No default (optional)
     multipart: []
 ```

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -42,6 +42,7 @@ Advanced::
 +
 --
 
+ifndef::env-cloud[]
 ```yml
 # All configuration fields, showing default values
 output:
@@ -108,7 +109,71 @@ output:
       processors: [] # No default (optional)
     multipart: []
 ```
-
+endif::[]
+ifdef::env-cloud[]
+```yml
+# All configuration fields, showing default values
+output:
+  label: ""
+  http_client:
+    url: "" # No default (required)
+    verb: POST
+    headers: {}
+    metadata:
+      include_prefixes: []
+      include_patterns: []
+    dump_request_log_level: "" # Optional
+    oauth:
+      enabled: false
+      consumer_key: "" # Optional
+      consumer_secret: "" # Optional
+      access_token: "" # Optional
+      access_token_secret: "" # Optional
+    oauth2:
+      enabled: false
+      client_key: "" # Optional
+      client_secret: "" # Optional
+      token_url: "" # Optional
+      scopes: []
+      endpoint_params: {}
+    basic_auth:
+      enabled: false
+      username: "" # Optional
+      password: "" # Optional
+    jwt:
+      enabled: false
+      private_key_file: "" # Optional
+      signing_method: "" # Optional
+      claims: {}
+      headers: {}
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: ""
+      root_cas_file: ""
+      client_certs: []
+    rate_limit: "" # No default (optional)
+    timeout: 5s
+    retry_period: 1s
+    max_retry_backoff: 300s
+    retries: 3
+    backoff_on:
+      - 429
+    drop_on: []
+    successful_on: []
+    proxy_url: "" # No default (optional)
+    batch_as_multipart: false
+    max_in_flight: 64
+    batching:
+      count: 0
+      byte_size: 0
+      period: "" # Optional
+      check: "" # Optional
+      processors: [] # No default (optional)
+    multipart: []
+```
+endif::[]
 --
 ======
 
@@ -121,6 +186,7 @@ When message retries are exhausted, this output rejects a message. Typically, a 
 == Dynamic URL and header settings
 
 You can set the <<url,`url`>> and <<headers,`headers`>> values dynamically using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
+
 
 == Propagate responses
 
@@ -631,6 +697,8 @@ password: foo
 password: ${KEY_PASSWORD}
 ```
 
+ifndef::env-cloud[]
+
 === `extract_headers`
 
 Specify which response headers to add to the resulting synchronous response messages as metadata. Header keys are automatically converted to lowercase before matching, so make sure that your patterns target the lowercase versions of the expected header keys.
@@ -681,6 +749,8 @@ include_patterns:
 include_patterns:
   - _timestamp_unix$
 ```
+
+endif[]
 
 === `rate_limit`
 
@@ -775,6 +845,8 @@ When set to `false`, sends messages in a batch as individual requests.
 
 *Default*: `false`
 
+
+ifndef::env-cloud[]
 === `propagate_response`
 
 Whether to xref:guides:sync_responses.adoc[propagate server responses back] to the input.
@@ -783,6 +855,8 @@ Whether to xref:guides:sync_responses.adoc[propagate server responses back] to t
 *Type*: `bool`
 
 *Default*: `false`
+
+endif[]
 
 === `max_in_flight`
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -188,9 +188,12 @@ When message retries are exhausted, this output rejects a message. Typically, a 
 You can set the <<url,`url`>> and <<headers,`headers`>> values dynamically using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
 
 
+ifndef::env-cloud[]
 == Propagate responses
 
 To propagate HTTP responses back to the input source, set the <<propagate_response,`propagate_response`>> field to `true` . This feature is only available for inputs that support xref:guides:sync_responses.adoc[synchronous responses].
+
+endif[]
 
 == Performance
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -895,7 +895,7 @@ processors:
 
 EXPERIMENTAL: Create explicit multipart HTTP requests by specifying an array of parts to add to a request. Each part consists of content headers and a data field, which can be populated dynamically. 
 
-If populated, this field overrides the <<message_sends, default request creation behavior>>. 
+If populated, this field overrides the <<message-sends, default request creation behavior>>. 
 
 *Type*: `array`
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -697,7 +697,7 @@ A static timeout to apply to requests.
 
 *Type*: `string`
 
-*Default*: `"5s"`
+*Default*: `5s`
 
 === `retry_period`
 

--- a/modules/components/pages/outputs/websocket.adoc
+++ b/modules/components/pages/outputs/websocket.adoc
@@ -240,7 +240,7 @@ password: ${KEY_PASSWORD}
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -337,7 +337,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 
 *Type*: `object`
@@ -354,7 +354,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -363,7 +363,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -381,7 +381,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`

--- a/modules/components/pages/processors/http.adoc
+++ b/modules/components/pages/processors/http.adoc
@@ -46,36 +46,36 @@ http:
   metadata:
     include_prefixes: []
     include_patterns: []
-  dump_request_log_level: "" # No default (optional)
+  dump_request_log_level: "" # Optional
   oauth:
     enabled: false
-    consumer_key: "" # No default (optional)
-    consumer_secret: "" # No default (optional)
-    access_token: "" # No default (optional)
-    access_token_secret: "" # No default (optional)
+    consumer_key: "" # Optional
+    consumer_secret: "" # Optional
+    access_token: "" # Optional
+    access_token_secret: "" # Optional
   oauth2:
     enabled: false
-    client_key: "" # No default (optional)
-    client_secret: "" # No default (optional)
-    token_url: "" # No default (optional)
+    client_key: "" # Optional
+    client_secret: "" # Optional
+    token_url: "" # Optional
     scopes: []
     endpoint_params: {}
   basic_auth:
     enabled: false
-    username: "" # No default (optional)
-    password: "" # No default (optional)
+    username: "" # Optional
+    password: "" # Optional
   jwt:
     enabled: false
-    private_key_file: "" # No default (optional)
-    signing_method: "" # No default (optional)
+    private_key_file: "" # Optional
+    signing_method: "" # Optional
     claims: {}
     headers: {}
   tls:
     enabled: false
     skip_cert_verify: false
     enable_renegotiation: false
-    root_cas: "" # No default (optional)
-    root_cas_file: "" # No default (optional)
+    root_cas: "" # Optional
+    root_cas_file: "" # Optional
     client_certs: []
   extract_headers:
     include_prefixes: []

--- a/modules/components/pages/processors/http.adoc
+++ b/modules/components/pages/processors/http.adoc
@@ -138,11 +138,11 @@ If a request returns a response code that matches an entry in:
 
 - The <<drop_on,`drop_on` field>>, the request is immediately treated as a failure.
 
-== Add metadata
+== Add metadata to errors
 
 If a request returns an error response code, this processor sets a  `http_status_code` metadata field in the resulting message.
 
-TIP: You can use the <`extract_headers`> field to define rules for copying headers into messages generated from the response.
+TIP: You can use the <<extract_headers, `extract_headers`>> field to define rules for copying headers into messages generated from the response.
 
 == Error handling
 
@@ -155,6 +155,8 @@ When all retry attempts for a message are exhausted, this processor cancels the 
 The URL to connect to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
+
+*Default*: `""`
 
 === `verb`
 
@@ -370,7 +372,7 @@ endif::[]
 
 === `oauth2.endpoint_params`
 
-A list of optional endpoint parameters specified as arrays of strings (optional).
+A list of endpoint parameters specified as arrays of strings (optional).
 
 
 *Type*: `object`

--- a/modules/components/pages/processors/http.adoc
+++ b/modules/components/pages/processors/http.adoc
@@ -10,7 +10,7 @@
 component_type_dropdown::[]
 
 
-Performs an HTTP request using a message batch as the request body, and replaces the original message parts with the body of the response.
+Performs a HTTP request using a message batch as the request body, and replaces the original message parts with the body of the response.
 
 
 [tabs]
@@ -46,36 +46,36 @@ http:
   metadata:
     include_prefixes: []
     include_patterns: []
-  dump_request_log_level: ""
+  dump_request_log_level: "" # No default (optional)
   oauth:
     enabled: false
-    consumer_key: ""
-    consumer_secret: ""
-    access_token: ""
-    access_token_secret: ""
+    consumer_key: "" # No default (optional)
+    consumer_secret: "" # No default (optional)
+    access_token: "" # No default (optional)
+    access_token_secret: "" # No default (optional)
   oauth2:
     enabled: false
-    client_key: ""
-    client_secret: ""
-    token_url: ""
+    client_key: "" # No default (optional)
+    client_secret: "" # No default (optional)
+    token_url: "" # No default (optional)
     scopes: []
     endpoint_params: {}
   basic_auth:
     enabled: false
-    username: ""
-    password: ""
+    username: "" # No default (optional)
+    password: "" # No default (optional)
   jwt:
     enabled: false
-    private_key_file: ""
-    signing_method: ""
+    private_key_file: "" # No default (optional)
+    signing_method: "" # No default (optional)
     claims: {}
     headers: {}
   tls:
     enabled: false
     skip_cert_verify: false
     enable_renegotiation: false
-    root_cas: ""
-    root_cas_file: ""
+    root_cas: "" # No default (optional)
+    root_cas_file: "" # No default (optional)
     client_certs: []
   extract_headers:
     include_prefixes: []
@@ -98,43 +98,19 @@ http:
 --
 ======
 
-The `rate_limit` field can be used to specify a rate limit xref:components:rate_limits/about.adoc[resource] to cap the rate of requests across all parallel components service wide.
+== Rate limit requests
 
-The URL and header values of this type can be dynamically set using function interpolations described xref:configuration:interpolation.adoc#bloblang-queries[here].
+You can use the `rate_limit` field to specify a xref:components:rate_limits/about.adoc[rate limit resource], which restricts the number of requests processed service-wide, regardless of how many components you run in parallel.
 
-In order to map or encode the payload to a specific request body, and map the response back into the original payload instead of replacing it entirely, you can use the xref:components:processors/branch.adoc[`branch` processor].
+== Dynamic URL and header settings
 
-== Response codes
+You can set the <<url,`url`>> and <<headers,`headers`>> values dynamically using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
 
-HTTP response codes in the 200-299 range indicate a successful response. You can use the <<successful_on,`successful_on`>> field to add more success status codes.
+== Map payloads with the branch processor
 
-HTTP status codes in the 300-399 range are redirects. The <<follow_redirects,`follow_redirects` field>> determines how these responses are handled.
+You can use the xref:components:processors/branch.adoc[`branch` processor] to transform or encode the payload into a specific request body format, and map the response back into the original payload instead of replacing it entirely.
 
-If a request returns a response code that matches an entry in:
-
-- The <<backoff_on,`backoff_on` field>>, the request is retried after increasing intervals.
-
-- The <<drop_on,`drop_on` field>>, the request is immediately treated as a failure.
-
-== Add metadata
-
-If the request returns an error response code this processor sets a metadata field `http_status_code` on the resulting message.
-
-Use the field `extract_headers` to specify rules for which other headers should be copied into the resulting message from the response.
-
-== Error handling
-
-When all retry attempts for a message are exhausted the processor cancels the attempt. These failed messages will continue through the pipeline unchanged, but can be dropped or placed in a dead letter queue according to your config, you can read about xref:configuration:error_handling.adoc[these patterns].
-
-== Examples
-
-[tabs]
-======
-Branched Request::
-+
---
-
-This example uses a xref:components:processors/branch.adoc[`branch` processor] to strip the request message into an empty body, grab an HTTP payload, and place the result back into the original message at the path `repo.status`:
+This example uses a xref:components:processors/branch.adoc[`branch` processor] to strip the request message into an empty body (`request_map: 'root = ""'`), grab an HTTP payload, and place the result back into the original message at the path `repo.status`:
 
 ```yaml
 pipeline:
@@ -150,28 +126,43 @@ pipeline:
         result_map: 'root.repo.status = this'
 ```
 
---
-======
+== Response codes
+
+HTTP response codes in the 200-299 range indicate a successful response. You can use the <<successful_on,`successful_on`>> field to add more success status codes.
+
+HTTP status codes in the 300-399 range are redirects. The <<follow_redirects,`follow_redirects` field>> determines how these responses are handled.
+
+If a request returns a response code that matches an entry in:
+
+- The <<backoff_on,`backoff_on` field>>, the request is retried after increasing intervals.
+
+- The <<drop_on,`drop_on` field>>, the request is immediately treated as a failure.
+
+== Add metadata
+
+If a request returns an error response code, this processor sets a  `http_status_code` metadata field in the resulting message.
+
+TIP: You can use the <`extract_headers`> field to define rules for copying headers into messages generated from the response.
+
+== Error handling
+
+When all retry attempts for a message are exhausted, this processor cancels the attempt. By default, the failed message continues through the pipeline unchanged unless you configure other error-handling. For example, you might want to drop failed messages or route them to a dead letter queue. For more information, see xref:configuration:error_handling.adoc[Error Handling].
 
 == Fields
 
 === `url`
 
-The URL to connect to.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The URL to connect to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
-
 
 === `verb`
 
-A verb to connect with
-
+A verb to connect with.
 
 *Type*: `string`
 
-*Default*: `"POST"`
+*Default*: `POST`
 
 ```yml
 # Examples
@@ -185,9 +176,7 @@ verb: DELETE
 
 === `headers`
 
-A map of headers to add to the request.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+A map of headers to add to the request. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `object`
 
@@ -203,11 +192,9 @@ headers:
 
 === `metadata`
 
-Specify optional matching rules to determine which metadata keys should be added to the HTTP request as headers.
-
+Specify matching rules that determine which metadata keys should be added to the HTTP request as headers.
 
 *Type*: `object`
-
 
 === `metadata.include_prefixes`
 
@@ -222,14 +209,11 @@ Provide a list of explicit metadata key prefixes to match against.
 # Examples
 
 include_prefixes:
-  - foo_
-  - bar_
-
-include_prefixes:
   - kafka_
 
 include_prefixes:
   - content-
+  - user_
 ```
 
 === `metadata.include_patterns`
@@ -253,7 +237,7 @@ include_patterns:
 
 === `dump_request_log_level`
 
-EXPERIMENTAL: Optionally set a level at which the request and response payload of each request made will be logged.
+EXPERIMENTAL: Set the logging level for the request and response payloads of each HTTP request.
 
 
 *Type*: `string`
@@ -271,12 +255,10 @@ Options:
 , `WARN`
 , `ERROR`
 , `FATAL`
-, ``
-.
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -312,8 +294,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth.access_token`
 
-A value used to gain access to the protected resources on behalf of the user.
-
+The value used to gain access to the protected resources on behalf of the user.
 
 *Type*: `string`
 
@@ -321,7 +302,7 @@ A value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-A secret provided in order to establish ownership of a given access token.
+The secret that establishes ownership of the `oauth.access_token`.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -331,8 +312,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `oauth2`
 
-Allows you to specify open authentication via OAuth version 2 using the client credentials token flow.
-
+Allows you to specify open authentication via OAuth version 2 and the client credentials token flow.
 
 *Type*: `object`
 
@@ -357,7 +337,7 @@ A value used to identify the client to the token provider.
 
 === `oauth2.client_secret`
 
-A secret used to establish ownership of the client key.
+The secret used to establish ownership of the client key.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -377,7 +357,7 @@ The URL of the token provider.
 
 === `oauth2.scopes`
 
-A list of optional requested permissions.
+A list of requested permissions (optional).
 
 
 *Type*: `array`
@@ -390,7 +370,7 @@ endif::[]
 
 === `oauth2.endpoint_params`
 
-A list of optional endpoint parameters, values should be arrays of strings.
+A list of optional endpoint parameters specified as arrays of strings (optional).
 
 
 *Type*: `object`
@@ -405,11 +385,11 @@ endif::[]
 # Examples
 
 endpoint_params:
-  bar:
-    - woof
-  foo:
-    - meow
-    - quack
+  grant_type:
+    - client_credentials
+  audience:
+    - https://api.example.com/
+    - https://api.example.com/resource
 ```
 
 === `basic_auth`
@@ -452,7 +432,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 
 *Type*: `object`
@@ -469,7 +449,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -478,7 +458,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -496,7 +476,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`
@@ -505,7 +485,7 @@ Add optional key/value headers to the JWT.
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
+Override system defaults with custom TLS settings.
 
 
 *Type*: `object`
@@ -522,7 +502,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -544,11 +524,9 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -565,8 +543,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
-
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -580,8 +557,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
-
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 *Type*: `array`
 
@@ -601,7 +577,7 @@ client_certs:
 
 === `tls.client_certs[].cert`
 
-A plain text certificate to use.
+The plain text certificate to use.
 
 
 *Type*: `string`
@@ -610,7 +586,7 @@ A plain text certificate to use.
 
 === `tls.client_certs[].key`
 
-A plain text certificate key to use.
+The plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -642,7 +618,7 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks that may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -661,7 +637,7 @@ password: ${KEY_PASSWORD}
 
 === `extract_headers`
 
-Specify which response headers should be added to resulting messages as metadata. Header keys are lowercased before matching, so ensure that your patterns target lowercased versions of the header keys that you expect.
+Specify which response headers to add to the resulting messages as metadata. Header keys are automatically converted to lowercase before matching, so make sure that your patterns target the lowercase versions of the expected header keys.
 
 
 *Type*: `object`
@@ -711,7 +687,7 @@ include_patterns:
 
 === `rate_limit`
 
-An optional xref:components:rate_limits/about.adoc[rate limit] to throttle requests by.
+A xref:components:rate_limits/about.adoc[rate limit] to throttle requests by (optional).
 
 
 *Type*: `string`
@@ -728,7 +704,7 @@ A static timeout to apply to requests.
 
 === `retry_period`
 
-The base period to wait between failed requests.
+The initial period to wait between failed requests before retrying.
 
 
 *Type*: `string`
@@ -762,8 +738,7 @@ Whether to follow redirects, including all responses with HTTP status codes in t
 
 === `backoff_on`
 
-A list of status codes whereby the request should be considered to have failed and retries should be attempted, but the period between them should be increased gradually.
-
+A list of status codes that indicate a request failure, and trigger retries with an increasing backoff period between attempts.
 
 *Type*: `array`
 
@@ -771,7 +746,9 @@ A list of status codes whereby the request should be considered to have failed a
 
 === `drop_on`
 
-A list of status codes whereby the request should be considered to have failed but retries should not be attempted. This is useful for preventing wasted retries for requests that will never succeed. Note that with these status codes the _request_ is dropped, but _message_ that caused the request will not be dropped.
+A list of status codes that indicate a request failure, where the input should not attempt retries. This helps avoid unnecessary retries for requests that are unlikely to succeed.
+
+NOTE: In these cases, the _request_ is dropped, but the _message_ that triggered the request is retained.
 
 
 *Type*: `array`
@@ -780,7 +757,9 @@ A list of status codes whereby the request should be considered to have failed b
 
 === `successful_on`
 
-A list of status codes whereby the attempt should be considered successful, this is useful for dropping requests that return non-2XX codes indicating that the message has been dealt with, such as a 303 See Other or a 409 Conflict. All 2XX codes are considered successful unless they are present within `backoff_on` or `drop_on`, regardless of this field.
+A list of HTTP status codes that should be considered as successful, even if they are not 2XX codes. This is useful for handling cases where non-2XX codes indicate that the request was processed successfully, such as `303 See Other` or `409 Conflict`. 
+
+By default, all 2XX codes are considered successful unless they are specified in `backoff_on` or `drop_on` fields.
 
 
 *Type*: `array`
@@ -789,7 +768,7 @@ A list of status codes whereby the attempt should be considered successful, this
 
 === `proxy_url`
 
-An optional HTTP proxy URL.
+A HTTP proxy URL (optional).
 
 
 *Type*: `string`
@@ -797,8 +776,9 @@ An optional HTTP proxy URL.
 
 === `batch_as_multipart`
 
-Send message batches as a single request using https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^].
+When set to `true`, sends all message in a batch as a single request using https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html[RFC1341^]. 
 
+When set to `false`, sends messages in a batch as individual requests.
 
 *Type*: `bool`
 
@@ -806,7 +786,7 @@ Send message batches as a single request using https://www.w3.org/Protocols/rfc1
 
 === `parallel`
 
-When processing batched messages, whether to send messages of the batch in parallel, otherwise they are sent serially.
+When processing batched messages, this field determines whether messages in the batch are sent in parallel. If set to `false`, messages are sent serially.
 
 
 *Type*: `bool`

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -152,7 +152,7 @@ The base URL of the schema registry service.
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -185,8 +185,6 @@ A secret used to establish ownership of the consumer key.
 
 include::components:partial$secret_warning.adoc[]
 
-
-
 *Type*: `string`
 
 *Default*: `""`
@@ -194,7 +192,6 @@ include::components:partial$secret_warning.adoc[]
 === `oauth.access_token`
 
 A value used to gain access to the protected resources on behalf of the user.
-
 
 *Type*: `string`
 
@@ -206,8 +203,6 @@ A secret provided in order to establish ownership of a given access token.
 
 include::components:partial$secret_warning.adoc[]
 
-
-
 *Type*: `string`
 
 *Default*: `""`
@@ -215,7 +210,6 @@ include::components:partial$secret_warning.adoc[]
 === `basic_auth`
 
 Allows you to specify basic authentication.
-
 
 *Type*: `object`
 
@@ -227,7 +221,6 @@ endif::[]
 
 Whether to use basic authentication in requests.
 
-
 *Type*: `bool`
 
 *Default*: `false`
@@ -235,7 +228,6 @@ Whether to use basic authentication in requests.
 === `basic_auth.username`
 
 A username to authenticate as.
-
 
 *Type*: `string`
 
@@ -247,16 +239,13 @@ A password to authenticate with.
 
 include::components:partial$secret_warning.adoc[]
 
-
-
 *Type*: `string`
 
 *Default*: `""`
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
-
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 *Type*: `object`
 
@@ -275,7 +264,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -284,7 +273,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -302,7 +291,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`

--- a/modules/components/pages/processors/schema_registry_encode.adoc
+++ b/modules/components/pages/processors/schema_registry_encode.adoc
@@ -185,7 +185,7 @@ endif::[]
 
 === `oauth`
 
-Allows you to specify open authentication via OAuth version 1.
+Allows you to specify open authentication using OAuth version 1.
 
 
 *Type*: `object`
@@ -288,8 +288,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `jwt`
 
-BETA: Allows you to specify JWT authentication.
-
+BETA: Allows you to specify JSON Web Token (JWT) authentication.
 
 *Type*: `object`
 
@@ -308,7 +307,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded via PKCS1 or PKCS8 as private key.
+A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 
 *Type*: `string`
@@ -317,7 +316,7 @@ A file with the PEM encoded via PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
+A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 
 *Type*: `string`
@@ -335,7 +334,7 @@ A value used to identify the claims that issued the JWT.
 
 === `jwt.headers`
 
-Add optional key/value headers to the JWT.
+Add key/value headers to the JWT (optional).
 
 
 *Type*: `object`


### PR DESCRIPTION
## Description

Resolves [DOC-768](https://redpandadata.atlassian.net/browse/DOC-768)
Review deadline: 5th March

With related PR adds http components to cloud docs, and brings docs in line with style guide.

Related PR to add these docs to the Cloud docs set: [https://github.com/redpanda-data/cloud-docs/pull/209](https://github.com/redpanda-data/cloud-docs/pull/209)

This pull request includes a number of changes to improve the clarity and consistency of the documentation for the http_client input, output and http processor and related files. The most important changes involve rephrasing sentences for better readability, specifying optional fields, and improving the precision of descriptions.

Documentation improvements:

* Updated various descriptions to be more concise and clear, such as changing "Connects to a server and continuously performs requests for a single message" to "Connects to a server and continuously requests single messages."
* Specified optional fields in the configuration sections, adding comments like "# Optional" to fields such as `dump_request_log_level`, `consumer_key`, `client_key`, etc.
* Improved the explanation of dynamic URL and header settings, including examples and tips for more complex pagination logic.
* Clarified the descriptions of OAuth and OAuth2 fields, such as changing "A secret used to establish ownership of the consumer key" to "The secret used to establish ownership of the consumer key." [[1]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265L301-R310) [[2]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265L367-R336)
* Enhanced the descriptions of TLS settings, including specifying the path to a root certificate authority file and explaining the vulnerability of the `pbeWithMD5AndDES-CBC` algorithm. [[1]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265L554-L559) [[2]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265L671-R636)

## Page previews

Main page updates

- [`http_client` input](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/inputs/http_client/)
- [`http_client` output](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/outputs/http_client/)
- [`http` processor](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/processors/http/)

Updates for consistency

- [`websocket` output](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/outputs/websocket/)
- [`websocket` input](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/inputs/websocket/)
- [`schema_registry_decode` processor](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_decode/)
- [`schema_registry_encode` processor](https://deploy-preview-176--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_encode/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-768]: https://redpandadata.atlassian.net/browse/DOC-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ