### PR TITLE
DOC-1030 Fix table name in Snowflake cookbook

### DIFF
--- a/modules/cookbooks/pages/snowflake_ingestion.adoc
+++ b/modules/cookbooks/pages/snowflake_ingestion.adoc
@@ -185,7 +185,7 @@ output:
     role: REDPANDA_CONNECT
     database: STREAMING_DB
     schema: STREAMING_SCHEMA
-    table: STREAMING_TABLE
+    table: STREAMING_DATA
     # Inject your private key and password
     private_key_file: rsa_key.p8
     private_key_pass: "${SNOWFLAKE_KEY_PASS}"
@@ -243,7 +243,7 @@ output:
     role: REDPANDA_CONNECT
     database: STREAMING_DB
     schema: STREAMING_SCHEMA
-    table: STREAMING_TABLE
+    table: STREAMING_DATA
     # Inject your private key and password
     private_key_file: "${secrets.SNOWFLAKE_KEY}"
     private_key_pass: "${secrets.SNOWFLAKE_KEY_PASS}"


### PR DESCRIPTION
## Description

Resolves [DOC-1030](https://redpandadata.atlassian.net/browse/DOC-1030)
Review deadline: 25th February

This pull request includes changes to the `modules/cookbooks/pages/snowflake_ingestion.adoc` file to update the table name used in the Snowflake ingestion configuration.

* Updated the table name from `STREAMING_TABLE` to `STREAMING_DATA` in the Snowflake ingestion configuration. [[1]](diffhunk://#diff-6d8fe9e8bcd006de6be2bb305663c62a2fada4ddf4c9e93ac10a2aae99440c33L188-R188) [[2]](diffhunk://#diff-6d8fe9e8bcd006de6be2bb305663c62a2fada4ddf4c9e93ac10a2aae99440c33L246-R246)

## Previews

[Ingest data into Snowflake](https://deploy-preview-177--redpanda-connect.netlify.app/redpanda-connect/cookbooks/snowflake_ingestion/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1030]: https://redpandadata.atlassian.net/browse/DOC-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ