### PR TITLE
DOC-1046 Add arguments field to amqp_09 input and output

### DIFF
--- a/modules/components/pages/inputs/amqp_0_9.adoc
+++ b/modules/components/pages/inputs/amqp_0_9.adoc
@@ -21,13 +21,13 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   amqp_0_9:
     urls: [] # No default (required)
     queue: "" # No default (required)
-    consumer_tag: ""
+    consumer_tag: "" # Optional
     prefetch_count: 10
 ```
 
@@ -37,7 +37,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   amqp_0_9:
@@ -47,8 +47,9 @@ input:
       enabled: false
       durable: true
       auto_delete: false
+      arguments: {} # No default (optional)
     bindings_declare: [] # No default (optional)
-    consumer_tag: ""
+    consumer_tag: "" # Optional
     auto_ack: false
     nack_reject_patterns: []
     prefetch_count: 10
@@ -57,37 +58,37 @@ input:
       enabled: false
       skip_cert_verify: false
       enable_renegotiation: false
-      root_cas: ""
-      root_cas_file: ""
+      root_cas: "" # Optional
+      root_cas_file: "" # Optional
       client_certs: []
 ```
 
 --
 ======
 
-TLS is automatic when connecting to an `amqps` URL, but custom settings can be enabled in the `tls` section.
+TLS is automatically enabled when connecting to an `amqps` URL. However, you can customize <<tls, TLS settings>> if required.
 
 == Metadata
 
 This input adds the following metadata fields to each message:
 
-- amqp_content_type
-- amqp_content_encoding
-- amqp_delivery_mode
-- amqp_priority
-- amqp_correlation_id
-- amqp_reply_to
-- amqp_expiration
-- amqp_message_id
-- amqp_timestamp
-- amqp_type
-- amqp_user_id
-- amqp_app_id
-- amqp_consumer_tag
-- amqp_delivery_tag
-- amqp_redelivered
-- amqp_exchange
-- amqp_routing_key
+- `amqp_content_type`
+- `amqp_content_encoding`
+- `amqp_delivery_mode`
+- `amqp_priority`
+- `amqp_correlation_id`
+- `amqp_reply_to`
+- `amqp_expiration`
+- `amqp_message_id`
+- `amqp_timestamp`
+- `amqp_type`
+- `amqp_user_id`
+- `amqp_app_id`
+- `amqp_consumer_tag`
+- `amqp_delivery_tag`
+- `amqp_redelivered`
+- `amqp_exchange`
+- `amqp_routing_key`
 - All existing message headers, including nested headers prefixed with the key of their respective parent.
 
 You can access these metadata fields using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
@@ -96,8 +97,9 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 === `urls`
 
-A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.
+A list of URLs to connect to. This input attempts to connect to each URL in the list in order until a successful connection is established. It then continues to use that URL until the connection is closed.
 
+If an item in the list contains commas, it is split into multiple URLs.
 
 *Type*: `array`
 
@@ -129,16 +131,13 @@ An AMQP queue to consume from.
 
 === `queue_declare`
 
-Allows you to passively declare the target queue. If the queue already exists then the declaration passively verifies that they match the target fields.
-
+Passively declares the <<queue, target queue>> to make sure a queue with the specified name already exists and is configured correctly. If the queue already exists, then the passive declaration verifies that fields specified in this object match the its properties.
 
 *Type*: `object`
-
 
 === `queue_declare.enabled`
 
 Whether to enable queue declaration.
-
 
 *Type*: `bool`
 
@@ -148,34 +147,96 @@ Whether to enable queue declaration.
 
 Whether the declared queue is durable.
 
-
 *Type*: `bool`
 
 *Default*: `true`
 
 === `queue_declare.auto_delete`
 
-Whether the declared queue will auto-delete.
-
+Whether the declared queue auto-deletes when there are no active consumers.
 
 *Type*: `bool`
 
 *Default*: `false`
 
-=== `bindings_declare`
+=== `queue_declare.arguments`
 
-Allows you to passively declare bindings for the target queue.
+Arguments for server-specific implementations of the queue (optional). You can use arguments to configure additional parameters for queue types that require them. For more information about available arguments, see the https://github.com/rabbitmq/amqp091-go/blob/b3d409fe92c34bea04d8123a136384c85e8dc431/types.go#L282-L362[RabbitMQ Client Library^].
 
-
-*Type*: `array`
+*Type*: `object`
 
 
 ```yml
 # Examples
 
+arguments:
+  x-max-length: 1000
+  x-max-length-bytes: 4096
+  x-queue-type: quorum
+```
+
+
+|===
+| Argument | Description | Accepted values
+
+| `x-queue-type`
+| Declares the type of queue.
+| Options: `classic` (default), `quorum`, `stream`, `drop-head`, `reject-publish`, and `reject-publish-dlx`.
+
+| `x-max-length`
+| The maximum number of messages in the queue.
+| A non-negative integer.
+
+| `x-max-length-bytes`
+| The maximum size of messages (in bytes) in the queue.
+| A non-negative integer.
+
+| `x-overflow`
+| Sets the queue's overflow behavior.
+| Options: `drop-head` (default), `reject-publish`, `reject-publish-dlx`.
+
+| `x-message-ttl`
+| The duration (in milliseconds) that messages remain in the queue before they expire and are discarded.
+| A string that represents the number of milliseconds, for example, `60000` retains messages for one minute.
+
+| `x-expires`
+| The duration after which the queue automatically expires.
+| A positive integer.
+
+| `x-max-age`
+| The duration (in configurable units) that streamed messages are retained on disk before they are discarded. 
+| Options: `Y`, `M`, `D`, `h`, `m`, `s`, for example, `7D` retains messages for a week.
+
+| `x-stream-max-segment-size-bytes`
+| The maximum size (in bytes) of the segment files held on disk.
+| A positive integer. Default: `500000000` (approximately 500 MB).
+
+| `x-queue-version`
+| The version of the classic queue to use.
+| Options: `1` or `2`.
+
+| `x-consumer-timeout`
+| The duration (in milliseconds) that a consumer can remain idle before it is automatically canceled.
+| A positive integer that represents the number of milliseconds, for example, `60000` sets a timeout duration of one minute.
+
+| `x-single-active-consumer`
+| When set to `true`, a single consumer receives messages from the queue even when multiple consumers are subscribed to it.
+| A boolean.
+
+|===
+
+=== `bindings_declare`
+
+Passively declares the bindings of the target queue to make sure they already exist and are configured correctly. If the bindings already exist, then the passive declaration verifies that fields specified in this object match them.
+
+*Type*: `array`
+
+```yml
+# Examples
+
 bindings_declare:
-  - exchange: foo
-    key: bar
+  - exchange: my_exchange
+    key: my_routing_key
 ```
 
 === `bindings_declare[].exchange`
@@ -198,7 +259,7 @@ The key of the declared binding.
 
 === `consumer_tag`
 
-A consumer tag.
+A consumer tag to uniquely identify the consumer.
 
 
 *Type*: `string`
@@ -207,8 +268,7 @@ A consumer tag.
 
 === `auto_ack`
 
-Acknowledge messages automatically as they are consumed rather than waiting for acknowledgments from downstream. This can improve throughput and prevent the pipeline from blocking but at the cost of eliminating delivery guarantees.
-
+Set to `true` to automatically acknowledge messages as soon as they are consumed rather than waiting for acknowledgments from downstream. This can improve throughput and prevent the pipeline from becoming blocked, but delivery guarantees are lost.
 
 *Type*: `bool`
 
@@ -216,8 +276,9 @@ Acknowledge messages automatically as they are consumed rather than waiting for 
 
 === `nack_reject_patterns`
 
-A list of regular expression patterns whereby if a message that has failed to be delivered by Redpanda Connect has an error that matches it will be dropped (or delivered to a dead-letter queue if one exists). By default failed messages are nacked with requeue enabled.
+A list of regular expression patterns to match against errors in messages that Redpanda Connect fails to deliver. If a message has an error that matches a pattern, it is dropped or delivered to a dead-letter queue, if a queue has been configured.
 
+By default, failed messages are negatively acknowledged (nacked) and requeued.
 
 *Type*: `array`
 
@@ -236,8 +297,7 @@ nack_reject_patterns:
 
 === `prefetch_count`
 
-The maximum number of pending messages to have consumed at a time.
-
+The maximum number of pending messages at a given time.
 
 *Type*: `int`
 
@@ -245,7 +305,7 @@ The maximum number of pending messages to have consumed at a time.
 
 === `prefetch_size`
 
-The maximum amount of pending messages measured in bytes to have consumed at a time.
+The maximum size of pending messages (in bytes) at a given time.
 
 
 *Type*: `int`
@@ -254,11 +314,9 @@ The maximum amount of pending messages measured in bytes to have consumed at a t
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
-
+Override system defaults with custom TLS settings.
 
 *Type*: `object`
-
 
 === `tls.enabled`
 
@@ -271,7 +329,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -293,7 +351,7 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -313,8 +371,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
-
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -328,7 +385,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 
 *Type*: `array`
@@ -389,11 +446,9 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks which may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 

--- a/modules/components/pages/inputs/amqp_0_9.adoc
+++ b/modules/components/pages/inputs/amqp_0_9.adoc
@@ -97,7 +97,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 === `urls`
 
-A list of URLs to connect to. This input attempts to connect to each URL in the list in order until a successful connection is established. It then continues to use that URL until the connection is closed.
+A list of URLs to connect to. This input attempts to connect to each URL in the list, in order, until a successful connection is established. It then continues to use that URL until the connection is closed.
 
 If an item in the list contains commas, it is split into multiple URLs.
 
@@ -131,7 +131,7 @@ An AMQP queue to consume from.
 
 === `queue_declare`
 
-Passively declares the <<queue, target queue>> to make sure a queue with the specified name already exists and is configured correctly. If the queue already exists, then the passive declaration verifies that fields specified in this object match the its properties.
+Passively declares the <<queue, target queue>> to make sure a queue with the specified name exists and is configured correctly. If the queue exists, then the passive declaration verifies that fields specified in this object match the its properties.
 
 *Type*: `object`
 
@@ -197,7 +197,7 @@ arguments:
 
 | `x-message-ttl`
 | The duration (in milliseconds) that messages remain in the queue before they expire and are discarded.
-| A string that represents the number of milliseconds, for example, `60000` retains messages for one minute.
+| A string that represents the number of milliseconds. For example, `60000` retains messages for one minute.
 
 | `x-expires`
 | The duration after which the queue automatically expires.
@@ -205,7 +205,7 @@ arguments:
 
 | `x-max-age`
 | The duration (in configurable units) that streamed messages are retained on disk before they are discarded. 
-| Options: `Y`, `M`, `D`, `h`, `m`, `s`, for example, `7D` retains messages for a week.
+| Options: `Y`, `M`, `D`, `h`, `m`, `s`. For example, `7D` retains messages for a week.
 
 | `x-stream-max-segment-size-bytes`
 | The maximum size (in bytes) of the segment files held on disk.
@@ -217,7 +217,7 @@ arguments:
 
 | `x-consumer-timeout`
 | The duration (in milliseconds) that a consumer can remain idle before it is automatically canceled.
-| A positive integer that represents the number of milliseconds, for example, `60000` sets a timeout duration of one minute.
+| A positive integer that represents the number of milliseconds. For example, `60000` sets a timeout duration of one minute.
 
 | `x-single-active-consumer`
 | When set to `true`, a single consumer receives messages from the queue even when multiple consumers are subscribed to it.
@@ -227,7 +227,7 @@ arguments:
 
 === `bindings_declare`
 
-Passively declares the bindings of the target queue to make sure they already exist and are configured correctly. If the bindings already exist, then the passive declaration verifies that fields specified in this object match them.
+Passively declares the bindings of the target queue to make sure they exist and are configured correctly. If the bindings exist, then the passive declaration verifies that fields specified in this object match them.
 
 *Type*: `array`
 
@@ -276,7 +276,7 @@ Set to `true` to automatically acknowledge messages as soon as they are consumed
 
 === `nack_reject_patterns`
 
-A list of regular expression patterns to match against errors in messages that Redpanda Connect fails to deliver. If a message has an error that matches a pattern, it is dropped or delivered to a dead-letter queue, if a queue has been configured.
+A list of regular expression patterns to match against errors in messages that Redpanda Connect fails to deliver. When a message has an error that matches a pattern, it is dropped or delivered to a dead-letter queue (if a queue has been configured).
 
 By default, failed messages are negatively acknowledged (nacked) and requeued.
 
@@ -371,7 +371,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -385,7 +385,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 
 *Type*: `array`
@@ -446,7 +446,7 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks which may allow an attacker to recover the plain text password.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks, which may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
 

--- a/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/modules/components/pages/outputs/amqp_0_9.adoc
@@ -126,7 +126,7 @@ The AMQP exchange to publish messages to. This field supports xref:configuration
 
 === `exchange_declare`
 
-Passively declares the <<exchange, target exchange>> to check whether an exchange with the specified name already exists and is configured correctly. If the exchange already exists, then the passive declaration verifies that fields specified in this object match its properties. If the target exchange does not exist, this output creates it.
+Passively declares the <<exchange, target exchange>> to check whether an exchange with the specified name exists and is configured correctly. If the exchange exists, then the passive declaration verifies that fields specified in this object match its properties. If the target exchange does not exist, this output creates it.
 
 *Type*: `object`
 
@@ -304,7 +304,7 @@ Whether to store delivered messages on disk. By default, message delivery is tra
 
 === `mandatory`
 
-Whether to set the mandatory flag on published messages. When set to `true`, if a published message cannot be routed to any queues it is returned to the sender.
+Whether to set the mandatory flag on published messages. When set to `true`, a published message that cannot be routed to any queues it is returned to the sender.
 
 *Type*: `bool`
 
@@ -386,7 +386,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -400,7 +400,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `array`
 
@@ -456,7 +456,7 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks which may allow an attacker to recover the plain text password.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks, which may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
 

--- a/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/modules/components/pages/outputs/amqp_0_9.adoc
@@ -10,7 +10,6 @@
 
 component_type_dropdown::[]
 
-
 Sends messages to an AMQP (0.91) exchange. AMQP is a messaging protocol used by various message brokers, including RabbitMQ.
 
 
@@ -21,14 +20,14 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   amqp_0_9:
     urls: [] # No default (required)
     exchange: "" # No default (required)
-    key: ""
-    type: ""
+    key: "" # Optional
+    type: "" # Optional
     metadata:
       exclude_prefixes: []
     max_in_flight: 64
@@ -40,7 +39,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   amqp_0_9:
@@ -50,16 +49,17 @@ output:
       enabled: false
       type: direct
       durable: true
+      arguments: {} # No default (optional)
     key: ""
     type: ""
     content_type: application/octet-stream
-    content_encoding: ""
-    correlation_id: ""
-    reply_to: ""
-    expiration: ""
-    message_id: ""
-    user_id: ""
-    app_id: ""
+    content_encoding: "" # Optional
+    correlation_id: "" # Optional
+    reply_to: "" # Optional
+    expiration: "" # Optional
+    message_id: "" # Optional
+    user_id: "" # Optional
+    app_id: "" # Optional
     metadata:
       exclude_prefixes: []
     priority: ""
@@ -67,33 +67,32 @@ output:
     persistent: false
     mandatory: false
     immediate: false
-    timeout: ""
+    timeout: "" # Optional
     tls:
       enabled: false
       skip_cert_verify: false
       enable_renegotiation: false
-      root_cas: ""
-      root_cas_file: ""
+      root_cas: "" # Optional
+      root_cas_file: "" # Optional
       client_certs: []
 ```
 
 --
 ======
 
-The metadata from each message are delivered as headers.
+The metadata fields from each message are delivered as headers.
 
-It's possible for this output type to create the target exchange by setting `exchange_declare.enabled` to `true`, if the exchange already exists then the declaration passively verifies that the settings match.
+TLS is automatically enabled when connecting to an `amqps` URL. However, you can customize <<tls, TLS settings>> if required.
 
-TLS is automatic when connecting to an `amqps` URL, but custom settings can be enabled in the `tls` section.
-
-The fields 'key', 'exchange' and 'type' can be dynamically set using xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
+You can use xref:configuration:interpolation.adoc#bloblang-queries[function interpolations] to dynamically set values for the following fields: `key`, `exchange`, and `type`.
 
 == Fields
 
 === `urls`
 
-A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.
+A list of URLs to connect to. This input attempts to connect to each URL in the list, in order, until a successful connection is established. It then continues to use that URL until the connection is closed.
 
+If an item in the list contains commas, it is split into multiple URLs.
 
 *Type*: `array`
 
@@ -117,25 +116,23 @@ urls:
 
 === `exchange`
 
-An AMQP exchange to publish to.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The AMQP exchange to publish messages to. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
+*Default*: `""`
+
+*Type*: `string`
 
 === `exchange_declare`
 
-Optionally declare the target exchange (passive).
-
+Passively declares the <<exchange, target exchange>> to check whether an exchange with the specified name already exists and is configured correctly. If the exchange already exists, then the passive declaration verifies that fields specified in this object match its properties. If the target exchange does not exist, this output creates it.
 
 *Type*: `object`
 
-
 === `exchange_declare.enabled`
 
-Whether to declare the exchange.
-
+Whether to enable exchange declaration.
 
 *Type*: `bool`
 
@@ -143,34 +140,42 @@ Whether to declare the exchange.
 
 === `exchange_declare.type`
 
-The type of the exchange.
-
+The type of the exchange, which determines how messages are routed to queues.
 
 *Type*: `string`
 
-*Default*: `"direct"`
+*Default*: `direct`
 
 Options:
 `direct`
 , `fanout`
 , `topic`
 , `x-custom`
-.
 
 === `exchange_declare.durable`
 
-Whether the exchange should be durable.
-
+Whether the declared exchange is durable.
 
 *Type*: `bool`
 
 *Default*: `true`
 
+=== `exchange_declare.arguments`
+
+Arguments for server-specific implementations of the exchange (optional). You can use arguments to configure additional parameters for exchange types that require them.
+
+*Type*: `object`
+
+```yml
+# Examples
+
+arguments:
+  alternate-exchange: my-ae
+```
+
 === `key`
 
-The binding key to set for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The binding key to set for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -178,9 +183,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `type`
 
-The type property to set for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+A custom message type to set for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -188,19 +191,15 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `content_type`
 
-The content type attribute to set for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The MIME type of each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
-*Default*: `"application/octet-stream"`
+*Default*: `application/octet-stream`
 
 === `content_encoding`
 
-The content encoding attribute to set for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+The content encoding attribute of each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -208,9 +207,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `correlation_id`
 
-Set the correlation ID of each message with a dynamic interpolated expression.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set a unique correlation ID for each message using a dynamic interpolated expression to help match messages to responses. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -218,9 +215,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `reply_to`
 
-Carries response queue name - set with a dynamic interpolated expression.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set the name of the queue to which responses are sent using a dynamic interpolated expression. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -228,9 +223,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `expiration`
 
-Set the per-message TTL
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set the TTL of each message in milliseconds. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -238,9 +231,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `message_id`
 
-Set the message ID of each message with a dynamic interpolated expression.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set a message ID for each message using a dynamic interpolated expression. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -248,9 +239,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `user_id`
 
-Set the user ID to the name of the publisher.  If this property is set by a publisher, its value must be equal to the name of the user used to open the connection.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set the user ID to the name of the publisher. If this property is set by a publisher, its value must match the name of the user that opened the connection. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -258,8 +247,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `app_id`
 
-Set the application ID of each message with a dynamic interpolated expression.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+Set an application ID for each message using a dynamic interpolated expression. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
@@ -268,16 +256,13 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `metadata`
 
-Specify criteria for which metadata values are attached to messages as headers.
-
+Specify which (if any) metadata values are added to messages as headers.
 
 *Type*: `object`
 
-
 === `metadata.exclude_prefixes`
 
-Provide a list of explicit metadata key prefixes to be excluded when adding metadata to sent messages.
-
+Provide a list of explicit metadata key prefixes to exclude when adding metadata to sent messages.
 
 *Type*: `array`
 
@@ -285,9 +270,7 @@ Provide a list of explicit metadata key prefixes to be excluded when adding meta
 
 === `priority`
 
-Set the priority of each message with a dynamic interpolated expression.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
-
+Set the priority of each message using a dynamic interpolated expression. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -305,8 +288,7 @@ priority: ${! json("doc.priority") }
 
 === `max_in_flight`
 
-The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
-
+The maximum number of messages to have in flight at a given time. Increase this number to improve throughput.
 
 *Type*: `int`
 
@@ -314,8 +296,7 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 === `persistent`
 
-Whether message delivery should be persistent (transient by default).
-
+Whether to store delivered messages on disk. By default, message delivery is transient.
 
 *Type*: `bool`
 
@@ -323,8 +304,7 @@ Whether message delivery should be persistent (transient by default).
 
 === `mandatory`
 
-Whether to set the mandatory flag on published messages. When set if a published message is routed to zero queues it is returned.
-
+Whether to set the mandatory flag on published messages. When set to `true`, if a published message cannot be routed to any queues it is returned to the sender.
 
 *Type*: `bool`
 
@@ -332,8 +312,7 @@ Whether to set the mandatory flag on published messages. When set if a published
 
 === `immediate`
 
-Whether to set the immediate flag on published messages. When set if there are no ready consumers of a queue then the message is dropped instead of waiting.
-
+Whether to set the immediate flag on published messages. When set to `true`, if there are no active consumers for a queue, the message is dropped instead of waiting.
 
 *Type*: `bool`
 
@@ -341,8 +320,7 @@ Whether to set the immediate flag on published messages. When set if there are n
 
 === `timeout`
 
-The maximum period to wait before abandoning it and reattempting. If not set, wait indefinitely.
-
+The maximum period to wait for a message acknowledgment before abandoning it and attempting a resend. If this value is not set, the system waits indefinitely.
 
 *Type*: `string`
 
@@ -350,7 +328,7 @@ The maximum period to wait before abandoning it and reattempting. If not set, wa
 
 === `tls`
 
-Custom TLS settings can be used to override system defaults.
+Override system defaults with custom TLS settings.
 
 
 *Type*: `object`
@@ -367,7 +345,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.skip_cert_verify`
 
-Whether to skip server side certificate verification.
+Whether to skip server-side certificate verification.
 
 
 *Type*: `bool`
@@ -389,11 +367,9 @@ endif::[]
 
 === `tls.root_cas`
 
-An optional root certificate authority to use. This is a string, representing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 
@@ -410,8 +386,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
-
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 
@@ -425,8 +400,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.client_certs`
 
-A list of client certificates to use. For each certificate either the fields `cert` and `key`, or `cert_file` and `key_file` should be specified, but not both.
-
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
 
 *Type*: `array`
 
@@ -448,7 +422,6 @@ client_certs:
 
 A plain text certificate to use.
 
-
 *Type*: `string`
 
 *Default*: `""`
@@ -459,8 +432,6 @@ A plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
 
-
-
 *Type*: `string`
 
 *Default*: `""`
@@ -468,7 +439,6 @@ include::components:partial$secret_warning.adoc[]
 === `tls.client_certs[].cert_file`
 
 The path of a certificate to use.
-
 
 *Type*: `string`
 
@@ -478,7 +448,6 @@ The path of a certificate to use.
 
 The path of a certificate key to use.
 
-
 *Type*: `string`
 
 *Default*: `""`
@@ -487,11 +456,9 @@ The path of a certificate key to use.
 
 A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
 
-Because the obsolete pbeWithMD5AndDES-CBC algorithm does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks which may allow an attacker to recover the plain text password.
 
 include::components:partial$secret_warning.adoc[]
-
-
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/modules/components/pages/outputs/amqp_0_9.adoc
@@ -304,7 +304,7 @@ Whether to store delivered messages on disk. By default, message delivery is tra
 
 === `mandatory`
 
-Whether to set the mandatory flag on published messages. When set to `true`, a published message that cannot be routed to any queues it is returned to the sender.
+Whether to set the mandatory flag on published messages. When set to `true`, a published message that cannot be routed to any queues is returned to the sender.
 
 *Type*: `bool`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1046](https://redpandadata.atlassian.net/browse/DOC-1046)
Review deadline: 28th February

Adds arguments field to `ampq_09` input and output.

This pull request includes several documentation updates and improvements for the AMQP 0.9 input and output configuration files. The changes aim to clarify descriptions, add optional field indicators, and improve readability.

Documentation improvements:

* [`modules/components/pages/inputs/amqp_0_9.adoc`](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L24-R30): Updated descriptions for various fields, added optional indicators for fields like `consumer_tag`, `root_cas`, and `root_cas_file`, and improved explanations for `queue_declare`, `auto_ack`, and `nack_reject_patterns`. [[1]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L24-R30) [[2]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L40-R40) [[3]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1R50-R52) [[4]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L60-R91) [[5]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L99-R102) [[6]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L132-L142) [[7]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L151-R239) [[8]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L201-R262) [[9]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L210-R281) [[10]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L239-R308) [[11]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L257-L262) [[12]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L274-R332) [[13]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L296-R354) [[14]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L316-R374) [[15]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L331-R388) [[16]](diffhunk://#diff-fcfff71368d9393e99f3a23af22505cab6670eef51a841db69c283b36bb2e1d1L392-L397)

* [`modules/components/pages/outputs/amqp_0_9.adoc`](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91L13): Updated descriptions for various fields, added optional indicators for fields like `key`, `type`, `content_encoding`, and `timeout`, and improved explanations for `urls` and metadata delivery as headers. [[1]](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91L13) [[2]](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91L24-R30) [[3]](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91L43-R42) [[4]](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91R52-R95)

These updates enhance the clarity and usability of the documentation, making it easier for users to configure AMQP 0.9 inputs and outputs correctly.

## Page previews

- [`amqp_0_9` input](https://deploy-preview-178--redpanda-connect.netlify.app/redpanda-connect/components/inputs/amqp_0_9/)
- [`amqp_0_9` output](https://deploy-preview-178--redpanda-connect.netlify.app/redpanda-connect/components/inputs/amqp_0_9/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1046]: https://redpandadata.atlassian.net/browse/DOC-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ