### PR TITLE
DOC-1047 Add Avro mapping field

### DIFF
--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -43,6 +43,7 @@ schema_registry_decode:
   avro:
     raw_unions: false
     preserve_logical_types: false
+    mapping: | # No default (optional)
   url: "" # No default (required)
   oauth:
     enabled: false
@@ -141,6 +142,44 @@ Set to `true` to preserve logical types.
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `avro.mapping`
+
+Define a custom mapping to apply to the JSON representation of Avro schemas. You can use mappings to convert custom types emitted by other tools, such as Debezium, into standard Avro types.
+
+*Type*: `string`
+
+*Default*: `""`
+
+The following example converts custom Debezium timestamp types into standard Avro timestamp types.
+
+```yml
+# Examples
+
+mapping: |2
+  # Define a mapping to identify Debezium timestamp types
+  map isDebeziumTimestampType {
+    root = this.type == "long" && this."connect.name" == "io.debezium.time.Timestamp" && !this.exists("logicalType")
+  }
+  # Define a mapping to convert Debezium timestamp types to Avro timestamp types
+  map debeziumTimestampToAvroTimestamp {
+    # Recursively apply the mapping to each field in the record
+    let mapped_fields = this.fields.or([]).map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))
+    root = match {
+      # If the type is a record, apply the mapping to its fields
+      this.type == "record" => this.assign({"fields": $mapped_fields})
+      # If the type is an array, apply the mapping to each item in the array
+      this.type.type() == "array" => this.assign({"type": this.type.map_each(item -> item.apply("debeziumTimestampToAvroTimestamp"))})
+      # If the type is an object and matches the Debezium timestamp type, add a logical type to decode it as an Avro timestamp instead of a long
+      this.type.type() == "object" && this.type.apply("isDebeziumTimestampType") => this.merge({"type":{"logicalType": "timestamp-millis"}})
+      # Otherwise, return the type as is
+      _ => this
+    }
+  }
+  # Apply the Debezium to Avro timestamp mapping to the root
+  root = this.apply("debeziumTimestampToAvroTimestamp")
+
+```
 
 === `url`
 

--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -43,29 +43,29 @@ schema_registry_decode:
   avro:
     raw_unions: false
     preserve_logical_types: false
-    mapping: | # No default (optional)
+    mapping: "" # No default (optional)
   url: "" # No default (required)
   oauth:
     enabled: false
-    consumer_key: ""
-    consumer_secret: ""
-    access_token: ""
-    access_token_secret: ""
+    consumer_key: "" # Optional
+    consumer_secret: "" # Optional
+    access_token: "" # Optional
+    access_token_secret: "" # Optional
   basic_auth:
     enabled: false
-    username: ""
-    password: ""
+    username: "" # Optional
+    password: "" # Optional
   jwt:
     enabled: false
-    private_key_file: ""
-    signing_method: ""
+    private_key_file: "" # Optional
+    signing_method: "" # Optional
     claims: {}
     headers: {}
   tls:
     skip_cert_verify: false
     enable_renegotiation: false
-    root_cas: ""
-    root_cas_file: ""
+    root_cas: "" # Optional
+    root_cas_file: "" # Optional
     client_certs: []
 ```
 


### PR DESCRIPTION
## Description

Resolves [DOC-1047](https://redpandadata.atlassian.net/browse/DOC-1047)
Review deadline: 28th February

This pull request includes updates to the `schema_registry_decode` documentation to clarify the optional nature of several configuration fields and to introduce a new `mapping` field for custom Avro schema mappings.

Key changes:

Documentation updates:

* [`modules/components/pages/processors/schema_registry_decode.adoc`](diffhunk://#diff-fc62b03da657b2dfa3924d3a7d1f7cf3df3e46e4dbd38b4b5fa0ebc463c31d37R46-R68): Updated several fields (`consumer_key`, `consumer_secret`, `access_token`, `access_token_secret`, `username`, `password`, `private_key_file`, `signing_method`, `root_cas`, `root_cas_file`) to indicate they are optional.

New feature:

* [`modules/components/pages/processors/schema_registry_decode.adoc`](diffhunk://#diff-fc62b03da657b2dfa3924d3a7d1f7cf3df3e46e4dbd38b4b5fa0ebc463c31d37R146-R183): Added a new `avro.mapping` field to define custom mappings for the JSON representation of Avro schemas, including an example for converting Debezium timestamp types to Avro timestamp types.

## Page previews

[`schema_registry_decode` processor](https://deploy-preview-180--redpanda-connect.netlify.app/redpanda-connect/components/processors/schema_registry_decode/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1047]: https://redpandadata.atlassian.net/browse/DOC-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ