### PR TITLE
DOC-1049 Add uuid_v7 bloblang function

### DIFF
--- a/modules/guides/pages/bloblang/functions.adoc
+++ b/modules/guides/pages/bloblang/functions.adoc
@@ -334,6 +334,26 @@ Generates a new RFC-4122 UUID each time it is invoked and prints a string repres
 root.id = uuid_v4()
 ```
 
+=== `uuid_v7`
+
+Generates a new time-ordered UUID each time it is invoked and prints a string representation. This function is useful when the exact timing of events is important, such as during data migration or replication.
+
+==== Parameters
+
+- *`time`* &lt;(optional) timestamp&gt; The timestamp to use for the time-ordered portion of the UUID. If not specified, the current time is used.
+
+==== Examples
+
+```coffeescript
+root.id = uuid_v7()
+```
+
+You can also specify the timestamp for the `uuid_v7`.
+
+```coffeescript
+root.id = uuid_v7(now().ts_sub_iso8601("PT1M"))
+```
+
 == Message Info
 
 === `batch_index`


### PR DESCRIPTION
## Description

Resolves [DOC-149](https://redpandadata.atlassian.net/browse/DOC-1049)
Review deadline: March 3rd

This pull request adds the `uuid_v7` function to the `modules/guides/pages/bloblang/functions.adoc` file.
New function added:

* [`uuid_v7`](diffhunk://#diff-1c116661660983b92bc8100b36d7c5d44f57104c9add3a0c048d2e461748ef02R337-R356): Generates a new time-ordered UUID each time it is invoked and prints a string representation. This function is useful for scenarios where the exact timing of events is important, such as during data migration or replication. It includes an optional `time` parameter to specify the timestamp used for the UUID.

## Page previews

[Bloglang functions](https://deploy-preview-181--redpanda-connect.netlify.app/redpanda-connect/guides/bloblang/functions/#uuid_v7)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-149]: https://redpandadata.atlassian.net/browse/DOC-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ