### PR TITLE
DOC-1051 Replacement elasticsearchv8 output

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -225,6 +225,7 @@
 *** xref:components:outputs/drop_on.adoc[]
 *** xref:components:outputs/dynamic.adoc[]
 *** xref:components:outputs/elasticsearch.adoc[]
+*** xref:components:outputs/elasticsearchv8.adoc[]
 *** xref:components:outputs/fallback.adoc[]
 *** xref:components:outputs/file.adoc[]
 *** xref:components:outputs/gcp_bigquery.adoc[]

--- a/modules/components/pages/outputs/elasticsearchv8.adoc
+++ b/modules/components/pages/outputs/elasticsearchv8.adoc
@@ -13,7 +13,7 @@ component_type_dropdown::[]
 Publishes messages into an https://www.elastic.co/guide/en/elasticsearch/reference/current/documents-indices.html[Elasticsearch index^]. If the index does not exist, this output creates it using dynamic mapping.
 
 ifndef::env-cloud[]
-Introduced in version 3.43.0.
+Introduced in version 4.47g.0.
 endif::[]
 
 
@@ -486,7 +486,7 @@ output:
   processors:
     - mapping: |
         meta id = this.id
-        # Performs a partial update on the document.
+      # Performs a partial update on the document.
         root.doc = this
   elasticsearch_v8:
     urls: [localhost:9200]
@@ -502,7 +502,7 @@ output:
   processors:
     - mapping: |
         meta id = this.id
-        # Increments the counter field by 1 using a script.
+        # Increments the counter field by 1 using a script
         root.script.source = "ctx._source.counter += 1"
   elasticsearch_v8:
     urls: [localhost:9200]

--- a/modules/components/pages/outputs/elasticsearchv8.adoc
+++ b/modules/components/pages/outputs/elasticsearchv8.adoc
@@ -1,0 +1,588 @@
+= elasticsearch_v8
+// tag::single-source[]
+:type: output
+:status: stable
+:categories: ["Services"]
+
+// © 2024 Redpanda Data Inc.
+
+
+component_type_dropdown::[]
+
+
+Publishes messages into an https://www.elastic.co/guide/en/elasticsearch/reference/current/documents-indices.html[Elasticsearch index^]. If the index does not exist, this output creates it using dynamic mapping.
+
+ifndef::env-cloud[]
+Introduced in version 3.43.0.
+endif::[]
+
+
+[tabs]
+======
+Common::
++
+--
+
+```yml
+# Common configuration fields, showing default values
+output:
+  label: ""
+  elasticsearch_v8:
+    urls: [] # No default (required)
+    index: "" # No default (required)
+    action: "" # No default (required)
+    id: ${!counter()}-${!timestamp_unix()} # No default (required)
+    max_in_flight: 64
+    batching:
+      count: 0
+      byte_size: 0
+      period: "" # Optional
+      check: "" # Optional
+```
+
+--
+Advanced::
++
+--
+
+```yml
+# All configuration fields, showing default values
+output:
+  label: ""
+  elasticsearch_v8:
+    urls: [] # No default (required)
+    index: "" # No default (required)
+    action: index
+    id: ${!counter()}-${!timestamp_unix()} # No default (required)
+    pipeline: "" # Optional 
+    routing: "" # Optional
+    retry_on_conflict: 0
+    tls:
+      enabled: false
+      skip_cert_verify: false
+      enable_renegotiation: false
+      root_cas: "" # Optional
+      root_cas_file: "" # Optional
+      client_certs: []
+    max_in_flight: 64
+    basic_auth:
+      enabled: false
+      username: ""
+      password: ""
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
+      processors: [] # No default (optional)
+```
+
+--
+======
+
+Both the `id` and `index` fields can be dynamically set using function interpolations described in xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries]. When sending batched messages these interpolations are performed per message part.
+
+== Performance
+
+For improved performance, this output sends:
+
+- Multiple messages in parallel. Adjust the `max_in_flight` field value to tune the maximum number of in-flight messages (or message batches). 
+- Messages as batches. You can configure batches at both input and output level. For more information, see xref:configuration:batching.adoc[Message Batching].
+
+== Fields
+
+=== `urls`
+
+A list of URLs to connect to. This input attempts to connect to each URL in the list, in order, until a successful connection is established. It then continues to use that URL until the connection is closed.
+
+If an item in the list contains commas, it is split into multiple URLs.
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+urls:
+  - http://localhost:9200
+```
+
+=== `index`
+
+The Elasticsearch index where messages are published. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
+
+
+*Type*: `string`
+
+
+=== `action`
+
+The action to perform on each document. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+For more information on how the `update` action works, see XXXXXXXXXXX.
+
+*Type*: `string`
+
+*Default*: `index`
+
+Options:
+, `index`
+, `update`
+, `delete`
+
+=== `id`
+
+Define the ID for indexed messages. Use xref:configuration:interpolation.adoc#bloblang-queries[function interpolations] to dynamically create a unique ID for each message.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+${!counter()}-${!timestamp_unix()}
+```
+
+=== `pipeline`
+
+Specify the ID of a pipeline to preprocess incoming documents before they are published. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `routing`
+
+The routing key to use for the document. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `retry_on_conflict`
+
+The number of times to retry an update operation when a version conflict occurs.
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `tls`
+
+Override system defaults with custom TLS settings.
+
+*Type*: `object`
+
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server-side certificate verification.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 3.45.0 or newer
+endif::[]
+
+=== `tls.root_cas`
+
+Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+
+include::components:partial$secret_warning.adoc[]
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+A plain text certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+The plain text certificate key to use.
+
+include::components:partial$secret_warning.adoc[]
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path of a certificate to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+A plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format.
+
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks that may allow an attacker to recover the plain text password.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+=== `max_in_flight`
+
+The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
+
+
+*Type*: `int`
+
+*Default*: `64`
+
+=== `basic_auth`
+
+Allows you to specify basic authentication.
+
+*Type*: `object`
+
+=== `basic_auth.enabled`
+
+Whether to use basic authentication in requests.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `basic_auth.username`
+
+A username to authenticate as.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `basic_auth.password`
+
+A password to authenticate with.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `batching`
+
+Allows you to configure a xref:configuration:batching.adoc[batching policy].
+
+
+*Type*: `object`
+
+
+```yml
+# Examples
+
+batching:
+  byte_size: 5000
+  count: 0
+  period: 1s
+
+batching:
+  count: 10
+  period: 1s
+
+batching:
+  check: this.contains("END BATCH")
+  count: 0
+  period: 1m
+```
+
+=== `batching.count`
+
+The number of messages after which the batch is flushed. Set to `0` to disable count-based batching.
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `batching.byte_size`
+
+The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `batching.period`
+
+The period after which an incomplete batch is flushed regardless of its size.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+period: 1s
+
+period: 1m
+
+period: 500ms
+```
+
+=== `batching.check`
+
+A xref:guides:bloblang/about.adoc[Bloblang query] that should return a boolean value indicating whether a message should end a batch.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+check: this.type == "end_of_transaction"
+```
+
+=== `batching.processors`
+
+For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches.
+
+
+*Type*: `array`
+
+
+```yml
+# Examples
+
+processors:
+  - archive:
+      format: concatenate
+
+processors:
+  - archive:
+      format: lines
+
+processors:
+  - archive:
+      format: json_array
+```
+
+== Example pipelines
+
+[tabs]
+======
+Updating documents::
++
+--
+
+To update documents in the target index, the top level of the request body must include at least one of the following fields:
+
+- `doc`: Performs partial updates on a document.
+- `upsert`: Updates an existing document or inserts a document if it doesn't exist.
+- `script`: Performs an update using a scripting language, such as Elasticsearch's Painless scripting language. 
+
+You can achieve this using mapping processors.
+  
+Example 1: Partial document update
+
+```yaml
+output:
+  processors:
+    - mapping: |
+        meta id = this.id
+        # Performs a partial update on the document.
+        root.doc = this
+  elasticsearch_v8:
+    urls: [localhost:9200]
+    index: my_target_index
+    id: ${! @id }
+    action: update
+```
+
+Example 2: Scripted update
+
+```yaml
+output:
+  processors:
+    - mapping: |
+        meta id = this.id
+        # Increments the counter field by 1 using a script.
+        root.script.source = "ctx._source.counter += 1"
+  elasticsearch_v8:
+    urls: [localhost:9200]
+    index: my_target_index
+    id: ${! @id }
+    action: update
+```
+
+Example 3: Upsert
+
+```yaml
+output:
+  processors:
+    - mapping: |
+        meta id = this.id
+        # If the document with the specified ID exists, update its product_price to 100.
+        # If the document does not exist, insert a new document with product_price set to 50.
+        # of 50 will be inserted.
+        root.doc.product_price = 50
+        root.upsert.product_price = 100
+  elasticsearch_v8:
+    urls: [localhost:9200]
+    index: my_target_index
+    id: ${! @id }
+    action: update
+```
+
+For more information on the structures and behaviors of `doc`, `upsert`, and `script` fields, see the https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html[Elasticsearch Update API^].
+
+
+--
+Indexing documents from Redpanda::
++
+--
+
+Reads messages from a Redpanda cluster and writes them to an Elasticsearch index using a field from the message as the document ID.
+
+```yaml
+input:
+  redpanda:
+    seed_brokers: [localhost:19092]
+    topics: ["product_code"]
+    consumer_group: "rpcn3"
+  processors:
+    - mapping: |
+        meta id = this.id
+        root = this
+output:
+  elasticsearch_v8:
+    urls: ['http://localhost:9200']
+    index: "product_code"
+    action: "index"
+    # Dynamically sets the document ID to the value of the metadata ID field 
+    id: ${! meta("id") }
+```
+
+--
+Indexing documents from S3::
++
+--
+
+Here we read messages from a AWS S3 bucket and write them to an Elasticsearch index using the S3 key as the ID for the Elasticsearch document.
+
+```yaml
+input:
+  aws_s3:
+    bucket: "my_bucket"
+    prefix: "prod_inventory/"
+    scanner:
+      to_the_end: {}
+output:
+  elasticsearch_v8:
+    urls: ['http://localhost:9200']
+    index: "current_prod_inventory"
+    action: "index"
+    id: ${! meta("s3_key") }
+```
+
+--
+======
+
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)