### PR TITLE
DOC-1048 Add crash processor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -135,6 +135,7 @@
 *** xref:components:processors/command.adoc[]
 *** xref:components:processors/compress.adoc[]
 *** xref:components:processors/couchbase.adoc[]
+*** xref:components:processors/crash.adoc[]
 *** xref:components:processors/decompress.adoc[]
 *** xref:components:processors/dedupe.adoc[]
 *** xref:components:processors/for_each.adoc[]

--- a/modules/components/pages/processors/crash.adoc
+++ b/modules/components/pages/processors/crash.adoc
@@ -9,11 +9,17 @@ Stops the current pipeline process with a fatal log message. You can use xref:co
 label: ""
 crash: "" # No default (required)
 ```
+This processor is useful for detecting unhandled errors during development and testing. For more information about common patterns for trapping errors, see xref:configuration:error_handling.adoc[Error-Handling].
 
-This processor is useful for halting pipeline execution in the event of critical failures. For example:
+== Fields
 
-- To detect silent or unrecoverable errors.
-- To prevent data corruption caused by unexpected data formats.
-- To notify observability tools, such as monitoring dashboards, for immediate action.
+=== `crash`
 
-For more information about catching fatal errors, see xref:configuration:error_handling.adoc[Error Handling].
+Define the fatal log message that is written when an unhandled error occurs. This field supports xref:configuration:interpolation.adoc#bloblang-queries[function interpolations].
+
+```
+# Examples
+
+crash: "Processor ${!error_source_label()} failed due to: ${!error()}"
+
+```

--- a/modules/components/pages/processors/crash.adoc
+++ b/modules/components/pages/processors/crash.adoc
@@ -1,0 +1,19 @@
+= crash
+:type: processor
+:categories: ["Utility"]
+
+Stops the current pipeline process with a fatal log message. You can use xref:configuration:interpolation.adoc#bloblang-queries[function interpolations] to define the log message, including the message contents and metadata that caused the fatal error.
+
+```yml
+# Configuration fields, showing default values
+label: ""
+crash: "" # No default (required)
+```
+
+This processor is useful for halting pipeline execution in the event of critical failures. For example:
+
+- To detect silent or unrecoverable errors.
+- To prevent data corruption caused by unexpected data formats.
+- To notify observability tools, such as monitoring dashboards, for immediate action.
+
+For more information about catching fatal errors, see xref:configuration:error_handling.adoc[Error Handling].

--- a/modules/components/pages/processors/crash.adoc
+++ b/modules/components/pages/processors/crash.adoc
@@ -9,7 +9,7 @@ Stops the current pipeline process with a fatal log message. You can use xref:co
 label: ""
 crash: "" # No default (required)
 ```
-This processor is useful for detecting unhandled errors during development and testing. For more information about common patterns for trapping errors, see xref:configuration:error_handling.adoc[Error-Handling].
+This processor is useful for detecting unhandled errors during development and testing. For more information about common patterns for trapping errors, see xref:configuration:error_handling.adoc[Error Handling].
 
 == Fields
 

--- a/modules/configuration/pages/error_handling.adoc
+++ b/modules/configuration/pages/error_handling.adoc
@@ -3,7 +3,12 @@
 
 Redpanda Connect supports a range of xref:components:processors/about.adoc[processors], such as `http` and `aws_lambda`, that may fail when retry attempts are exhausted. When a processor fails, the message data continues through the pipeline mostly unchanged, except for the addition of a metadata flag, which you can use for handling errors.
 
+ifndef::env-cloud[]
 This topic explains some common error-handling patterns, including dropping messages, recovering them with more processing, and routing them to a dead-letter queue. It also shows how to combine these approaches, where appropriate, and provides a method for <<logging-fatal-errors, trapping unhandled errors>>.
+endif::[]
+ifdef::env-cloud[]
+This topic explains some common error-handling patterns, including dropping messages, recovering them with more processing, and routing them to a dead-letter queue. It also shows how to combine these approaches, where appropriate.
+endif::[]
 
 == Abandon on failure
 
@@ -95,6 +100,7 @@ pipeline:
           root.meta.error = error()
 ----
 
+ifndef::env-cloud[]
 === Logging fatal errors
 
 During development and testing, you can use the xref:components:processors/crash.adoc[`crash` processor] to halt pipeline execution when an unhandled error occurs and log a fatal message. Use Bloblang functions to customize the message. For example:
@@ -110,6 +116,7 @@ pipeline:
     # Writes a custom fatal log message
     - crash: "Processor ${!error_source_label()} failed due to: ${!error()}"
 ----
+endif::[]
 
 == Attempt until success
 

--- a/modules/configuration/pages/error_handling.adoc
+++ b/modules/configuration/pages/error_handling.adoc
@@ -103,18 +103,16 @@ pipeline:
 ifndef::env-cloud[]
 === Logging fatal errors
 
-During development and testing, you can use the xref:components:processors/crash.adoc[`crash` processor] to halt pipeline execution when an unhandled error occurs and log a fatal message. Use Bloblang functions to customize the message. For example:
+During development and testing, you can use the xref:components:processors/crash.adoc[`crash` processor] to halt pipeline execution and log a fatal message when an unhandled error occurs. Use Bloblang functions to customize the message. For example:
 
 [source,yaml]
 ----
 pipeline:
   processors:
-    - try:
-      - resource: foo # Processor that might fail
-      - resource: bar # Processor that might fail
-      - resource: baz # Processor that might fail
+  - resource: processor_1 # Processor that might fail
+  - catch:
     # Writes a custom fatal log message
-    - crash: "Processor ${!error_source_label()} failed due to: ${!error()}"
+    - crash: "Processing failed at ${!error_source_label()} due to: ${!error()}"
 ----
 endif::[]
 

--- a/modules/configuration/pages/error_handling.adoc
+++ b/modules/configuration/pages/error_handling.adoc
@@ -3,7 +3,7 @@
 
 Redpanda Connect supports a range of xref:components:processors/about.adoc[processors], such as `http` and `aws_lambda`, that may fail when retry attempts are exhausted. When a processor fails, the message data continues through the pipeline mostly unchanged, except for the addition of a metadata flag, which you can use for handling errors.
 
-This topic explains some common error-handling patterns, including dropping messages, recovering them with more processing, and routing them to a dead-letter queue. It also shows how to combine these approaches, where appropriate.
+This topic explains some common error-handling patterns, including dropping messages, recovering them with more processing, and routing them to a dead-letter queue. It also shows how to combine these approaches, where appropriate, and provides a method for <<logging-fatal-errors, trapping unhandled errors>>.
 
 == Abandon on failure
 
@@ -93,6 +93,22 @@ pipeline:
       - mapping: |
           root = this
           root.meta.error = error()
+----
+
+=== Logging fatal errors
+
+During development and testing, you can use the xref:components:processors/crash.adoc[`crash` processor] to halt pipeline execution when an unhandled error occurs and log a fatal message. Use Bloblang functions to customize the message. For example:
+
+[source,yaml]
+----
+pipeline:
+  processors:
+    - try:
+      - resource: foo # Processor that might fail
+      - resource: bar # Processor that might fail
+      - resource: baz # Processor that might fail
+    # Writes a custom fatal log message
+    - crash: "Processor ${!error_source_label()} failed due to: ${!error()}"
 ----
 
 == Attempt until success


### PR DESCRIPTION
## Description

Resolves [DOC-1048](https://redpandadata.atlassian.net/browse/DOC-1048)
Review deadline: 6th March

This pull request introduces a new processor called `crash` and updates the documentation to include this new processor and its usage. The changes are primarily focused on adding the `crash` processor to the list of available processors and providing detailed documentation on how to use it for error handling.

### Addition of `crash` Processor:

* [`modules/components/pages/processors/crash.adoc`](diffhunk://#diff-504a47729d9f2593da38b40360366ecdf22150adf52c5054f6c8c71ff7511ec0R1-R25): Added a new document describing the `crash` processor, its configuration fields, and usage examples. This processor stops the current pipeline process with a fatal log message and is useful for detecting unhandled errors during development and testing.
* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R138): Updated the navigation to include a link to the new `crash` processor documentation.

### Updates to Error Handling Documentation:

* [`modules/configuration/pages/error_handling.adoc`](diffhunk://#diff-86e1304c42e5df66bfe08f3231722f81a53c1767864e74ad430e7fd1ba8a1ecbR6-R11): Updated the error handling documentation to include a section on logging fatal errors using the `crash` processor. This section is conditionally included based on the environment. [[1]](diffhunk://#diff-86e1304c42e5df66bfe08f3231722f81a53c1767864e74ad430e7fd1ba8a1ecbR6-R11) [[2]](diffhunk://#diff-86e1304c42e5df66bfe08f3231722f81a53c1767864e74ad430e7fd1ba8a1ecbR103-R120)

## Page previews

[`crash` processor](https://deploy-preview-183--redpanda-connect.netlify.app/redpanda-connect/components/processors/crash/)
[Error Handling](https://deploy-preview-183--redpanda-connect.netlify.app/redpanda-connect/configuration/error_handling/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1048]: https://redpandadata.atlassian.net/browse/DOC-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ