### PR TITLE
DOC-1050 Add disable_http2 field

### DIFF
--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -762,7 +762,7 @@ A HTTP proxy URL (optional).
 
 === `disable_http2`
 
-Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+Whether to disable HTTP/2. By default, HTTP/2 is enabled.
 
 *Type*: `bool`
 

--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -769,7 +769,7 @@ Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
 *Default*: `false`
 
 ifndef::env-cloud[]
-Requires version 4.44.0 or later
+Requires version 4.47.0 or later
 endif::[]
 
 

--- a/modules/components/pages/inputs/http_client.adoc
+++ b/modules/components/pages/inputs/http_client.adoc
@@ -93,6 +93,7 @@ input:
     drop_on: []
     successful_on: []
     proxy_url: "" # No default (optional)
+    disable_http2: false
     payload: "" # No default (optional)
     drop_empty_bodies: true
     stream:
@@ -749,7 +750,6 @@ A list of HTTP status codes that should be considered as successful, even if the
 
 By default, all 2XX codes are considered successful unless they are specified in `backoff_on` or `drop_on` fields.
 
-
 *Type*: `array`
 
 *Default*: `[]`
@@ -759,6 +759,18 @@ By default, all 2XX codes are considered successful unless they are specified in
 A HTTP proxy URL (optional).
 
 *Type*: `string`
+
+=== `disable_http2`
+
+Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 4.44.0 or later
+endif::[]
 
 
 === `payload`

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -846,7 +846,7 @@ Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
 *Default*: `false`
 
 ifndef::env-cloud[]
-Requires version 4.44.0 or later
+Requires version 4.47.0 or later
 endif::[]
 
 

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -98,6 +98,7 @@ output:
     drop_on: []
     successful_on: []
     proxy_url: "" # No default (optional)
+    disable_http2: false
     batch_as_multipart: false
     propagate_response: false
     max_in_flight: 64
@@ -835,6 +836,18 @@ A HTTP proxy URL (optional).
 
 
 *Type*: `string`
+
+=== `disable_http2`
+
+Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 4.44.0 or later
+endif::[]
 
 
 === `batch_as_multipart`

--- a/modules/components/pages/outputs/http_client.adoc
+++ b/modules/components/pages/outputs/http_client.adoc
@@ -839,7 +839,7 @@ A HTTP proxy URL (optional).
 
 === `disable_http2`
 
-Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+Whether to disable HTTP/2. By default, HTTP/2 is enabled.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/http.adoc
+++ b/modules/components/pages/processors/http.adoc
@@ -776,7 +776,7 @@ A HTTP proxy URL (optional).
 
 === `disable_http2`
 
-Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+Whether to disable HTTP/2. By default, HTTP/2 is enabled.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/http.adoc
+++ b/modules/components/pages/processors/http.adoc
@@ -91,6 +91,7 @@ http:
   drop_on: []
   successful_on: []
   proxy_url: "" # No default (optional)
+  disable_http2: false
   batch_as_multipart: false
   parallel: false
 ```
@@ -592,8 +593,6 @@ The plain text certificate key to use.
 
 include::components:partial$secret_warning.adoc[]
 
-
-
 *Type*: `string`
 
 *Default*: `""`
@@ -774,6 +773,18 @@ A HTTP proxy URL (optional).
 
 
 *Type*: `string`
+
+=== `disable_http2`
+
+Whether to disable disable HTTP/2. By default, HTTP/2 is enabled.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 4.47.0 or later
+endif::[]
 
 
 === `batch_as_multipart`


### PR DESCRIPTION
## Description

Resolves [DOC-1050](https://redpandadata.atlassian.net/browse/DOC-1050)
Review deadline: 6th March

This pull request adds a new configuration option to disable HTTP/2 in the HTTP client, processor, and output components. The most important changes include the addition of the `disable_http2` option and the corresponding documentation updates.

### New Configuration Option:

* Added `disable_http2` option to the HTTP client input configuration. This option allows users to disable HTTP/2, with a default value of `false`. [[1]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265R96) [[2]](diffhunk://#diff-7dc1d29f11c2fd03a73194a4abb259246a809a392b1f5e0125bb3dec571ed265R763-R774)
* Added `disable_http2` option to the HTTP client output configuration. This option allows users to disable HTTP/2, with a default value of `false`. [[1]](diffhunk://#diff-70c42db53b74b8421e62c095cd417901946b97880e36a4b5d620ffc7972a3502R101) [[2]](diffhunk://#diff-70c42db53b74b8421e62c095cd417901946b97880e36a4b5d620ffc7972a3502R840-R851)
* Added `disable_http2` option to the HTTP processor configuration. This option allows users to disable HTTP/2, with a default value of `false`. [[1]](diffhunk://#diff-e8cf0de92658866ca014378eed19700c6a24b082e20a5ff5f243d9164322ba2aR94) [[2]](diffhunk://#diff-e8cf0de92658866ca014378eed19700c6a24b082e20a5ff5f243d9164322ba2aR777-R788)

### Documentation Updates:

* Updated documentation in `modules/components/pages/inputs/http_client.adoc` to include the `disable_http2` option.
* Updated documentation in `modules/components/pages/outputs/http_client.adoc` to include the `disable_http2` option.
* Updated documentation in `modules/components/pages/processors/http.adoc` to include the `disable_http2` option.

## Page previews

- [`http_client` input](https://deploy-preview-184--redpanda-connect.netlify.app/redpanda-connect/components/inputs/http_client/)
- [`http_client` output](https://deploy-preview-184--redpanda-connect.netlify.app/redpanda-connect/components/outputs/http_client/)
- [`http` processor](https://deploy-preview-184--redpanda-connect.netlify.app/redpanda-connect/components/processors/http/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1050]: https://redpandadata.atlassian.net/browse/DOC-1050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ