### PR TITLE
DOC-1065 Enabling connectivity for cloud-based external systems

### DIFF
--- a/modules/components/pages/inputs/timeplus.adoc
+++ b/modules/components/pages/inputs/timeplus.adoc
@@ -97,6 +97,8 @@ Replace the following placeholders with your own values:
 --
 ======
 
+include::components:partial$external_connectivity_inputs.adoc[]
+
 == Fields
 
 === `query`

--- a/modules/components/pages/outputs/elasticsearch.adoc
+++ b/modules/components/pages/outputs/elasticsearch.adoc
@@ -98,6 +98,8 @@ output:
 
 Both the `id` and `index` fields can be dynamically set using function interpolations described in xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries]. When sending batched messages these interpolations are performed per message part.
 
+include::components:partial$external_connectivity_outputs.adoc[]
+
 == AWS
 
 It's possible to enable AWS connectivity with this output using the `aws` fields. However, you may need to set `sniff` and `healthcheck` to false for connections to succeed.

--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -84,6 +84,7 @@ output:
 --
 ======
 
+include::components:partial$external_connectivity_outputs.adoc[]
 
 == Performance
 

--- a/modules/components/pages/outputs/snowflake_put.adoc
+++ b/modules/components/pages/outputs/snowflake_put.adoc
@@ -103,6 +103,8 @@ xref:configuration:interpolation.adoc#bloblang-queries[Bloblang queries]. When u
 stage and Snowpipe and are streamed to individual files in their corresponding stage and, optionally, a Snowpipe
 `insertFiles` REST API call will be made for each individual file.
 
+include::components:partial$external_connectivity_outputs.adoc[]
+
 == Credentials
 
 Two authentication mechanisms are supported:

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -90,6 +90,8 @@ output:
 --
 ======
 
+include::components:partial$external_connectivity_outputs.adoc[]
+
 == Supported data formats for Snowflake columns
 
 The message data from your output must match the columns in the Snowflake table that you want to write data to. The following table shows you the https://docs.snowflake.com/en/sql-reference/intro-summary-data-types[column data types supported by Snowflake^] and how they correspond to the xref:guides:bloblang/methods.adoc#type[Bloblang data types] in Redpanda Connect.

--- a/modules/components/partials/external_connectivity_inputs.adoc
+++ b/modules/components/partials/external_connectivity_inputs.adoc
@@ -1,0 +1,15 @@
+ifndef::env-cloud[]
+
+== Enable connectivity from cloud-based data sources
+
+To establish a secure connection between a cloud-based data source and Redpanda Connect, you must add the IP addresses of your Redpanda Connect instances to your firewall rules.
+
+endif::[]
+
+ifdef::env-cloud[]
+
+== Enable connectivity from cloud-based data sources (BYOC only)
+
+To establish a secure connection between a cloud-based data source and Redpanda Connect, you must add the NAT Gateway IP address of your Redpanda cluster to the allowlist of your data source.
+
+endif::[]

--- a/modules/components/partials/external_connectivity_outputs.adoc
+++ b/modules/components/partials/external_connectivity_outputs.adoc
@@ -1,0 +1,15 @@
+ifndef::env-cloud[]
+
+== Enable connectivity to cloud-based data sinks
+
+To establish a secure connection between Redpanda Connect and a cloud-based target system, you must add the IP addresses of your Redpanda Connect instances to your firewall rules.
+
+endif::[]
+
+ifdef::env-cloud[]
+
+== Enable connectivity to cloud-based data sinks (BYOC only)
+
+To establish a secure connection between Redpanda Connect and a cloud-based target system, you must add the NAT Gateway IP address of your Redpanda cluster to the allowlist of your data sink.
+
+endif::[]


### PR DESCRIPTION
## Description

Resolves [DOC-1065](https://redpandadata.atlassian.net/browse/DOC-1065)
Review deadline: 10th March

Interim solution: Adding a message to alert users that they need to enable connectivity.

This pull request introduces changes to improve the documentation for external connectivity in various input and output components. The key changes include adding partials for external connectivity instructions and including these partials in the relevant documentation files.

Documentation improvements:

* [`modules/components/pages/inputs/timeplus.adoc`](diffhunk://#diff-2eff3a6b8d469fc27cf9778e4a2eeeb9c2041820ec3e78920b8dbdcfc9798d5dR100-R101): Included the external connectivity instructions for inputs.
* [`modules/components/pages/outputs/elasticsearch.adoc`](diffhunk://#diff-98a5b873e8173fbce44c7c19c8371a5b789a84abba7090c18a021d19d03f058eR101-R102): Included the external connectivity instructions for outputs.
* [`modules/components/pages/outputs/mongodb.adoc`](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748R87): Included the external connectivity instructions for outputs.
* [`modules/components/pages/outputs/snowflake_put.adoc`](diffhunk://#diff-887b6e562e8e3a390f6f6867a40eee0abac7ccca86d6873994ecaf4583afa228R106-R107): Included the external connectivity instructions for outputs.
* [`modules/components/pages/outputs/snowflake_streaming.adoc`](diffhunk://#diff-9434ac7730044d18599791222d3586f570c7fd47822805f631eb6c46c4b3b4ffR93-R94): Included the external connectivity instructions for outputs.

Addition of external connectivity partials:

* [`modules/components/partials/external_connectivity_inputs.adoc`](diffhunk://#diff-fd0d1148a65b72ecf506958908c033cf0fe4c8ba89e9f6887454ab3ce0f3e1e9R1-R15): Added instructions for enabling connectivity from cloud-based data sources, with different instructions for cloud and BYOC environments.
* [`modules/components/partials/external_connectivity_outputs.adoc`](diffhunk://#diff-b0eba698f4e66036dd6788cb8f738c01d6a3fbf95549abf6735924132a5c0782R1-R15): Added instructions for enabling connectivity to cloud-based data sinks, with different instructions for cloud and BYOC environments.

## Page previews

Inputs

- timeplus ([self-managed](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-connect/components/inputs/timeplus/#enable-connectivity-from-cloud-based-data-sources), [cloud](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-cloud/develop/connect/components/inputs/timeplus/#enable-connectivity-from-cloud-based-data-sources-byoc-only))

Outputs

- elasticsearch ([self-managed](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-connect/components/outputs/elasticsearch/#enable-connectivity-to-cloud-based-data-sinks))
- mongodb ([self-managed](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-connect/components/outputs/mongodb/#enable-connectivity-to-cloud-based-data-sinks))
- snowflake_put ([self-managed](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_put/#enable-connectivity-to-cloud-based-data-sinks), [cloud](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-cloud/develop/connect/components/outputs/snowflake_put/#enable-connectivity-to-cloud-based-data-sinks-byoc-only))
- snowflake_streaming ([self-managed](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/#enable-connectivity-to-cloud-based-data-sinks), [cloud](https://deploy-preview-185--redpanda-connect.netlify.app/redpanda-cloud/develop/connect/components/outputs/snowflake_streaming/#enable-connectivity-to-cloud-based-data-sinks-byoc-only))

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1065]: https://redpandadata.atlassian.net/browse/DOC-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ