### PR TITLE
DOC-514 Add mongodb_cdc_connector

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -64,6 +64,7 @@
 *** xref:components:inputs/kafka.adoc[]
 *** xref:components:inputs/kafka_franz.adoc[]
 *** xref:components:inputs/mongodb.adoc[]
+*** xref:components:inputs/mongodb_cdc.adoc[]
 *** xref:components:inputs/mqtt.adoc[]
 *** xref:components:inputs/mysql_cdc.adoc[]
 *** xref:components:inputs/nanomsg.adoc[]

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -314,7 +314,7 @@ The mode in which MongoDB emits document changes to Redpanda Connect, specifical
 
 [cols="1,2"]
 |===
-| Option | Description the document mode
+| Option | Description
 
 | `update_lookup`
 a| Emits full documents for insert, replace, and update operations, but only the `_id` field for delete operations.  

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -354,7 +354,7 @@ For more information, see the https://www.mongodb.com/docs/manual/changeStreams/
 
 === `json_marshal_mode`
 
-Controls how MongoDB formats messages sent to Redpanda Connect.
+Controls the format of the message output to Redpanda Connect.
 
 *Type*: `string`
 
@@ -364,7 +364,7 @@ Controls how MongoDB formats messages sent to Redpanda Connect.
 | Option | Description
 
 | `canonical`
-| A string format that preserves type information at the expense of readability and interoperability. Conversion from canonical to Binary JSON (BSON) generally retains type information, except in specific cases.
+| A string format that preserves the exact data types of values stored in MongoDB at the expense of readability and interoperability. Conversion from canonical to Binary JSON (BSON) generally retains type information, except in specific cases.
 | `relaxed`
 | A string format that is human-readable and compatible with most JSON parsers but may lose type fidelity. Conversion from relaxed format to BSON can lose type information.
 

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -120,7 +120,7 @@ If you set the <<stream_snapshot,`stream_snapshot` field>> to `true`, Redpanda C
 . Records the latest oplog position.
 . Determines the strategy for splitting the snapshot data down into shards or chunks for more efficient processing:
 .. If <<snapshot_auto_bucket_sharding,`snapshot_auto_bucket_sharding`>> is set to `false`, the internal `$splitVector` command is used to compute shards.  
-.. If <<snapshot_auto_bucket_sharding,`snapshot_auto_bucket_sharding`>> is set to `true`, the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command is used instead. This setting is for environments, such as MongoDB Atlas, where privileged access is restricted.
+.. If <<snapshot_auto_bucket_sharding,`snapshot_auto_bucket_sharding`>> is set to `true`, the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command is used instead. This setting is for environments, such as MongoDB Atlas, where the `$splitVector` command is not available.
 . This input then uses the number of connections specified in <<snapshot_parallelism,`snapshot-parallelism`>> to read the selected collections.
 +
 NOTE: If the pipeline restarts during this process, Redpanda Connect must start the snapshot capture from scratch to store the current oplog position in the <<checkpoint_cache,`checkpoint_cache`>>.
@@ -201,7 +201,7 @@ collections:
 
 === `checkpoint_cache`
 
-Specify a `cache` resource to store the oplog position for the most recent data update streamed to Redpanda Connect. After a restart, Redpanda Connect can continue processing changes from this position, avoiding the need to reprocess all collection updates.
+Specify a xref:components:caches/about.adoc[`cache` resource] to store the oplog position for the most recent data update streamed to Redpanda Connect. After a restart, Redpanda Connect can continue processing changes from this position, avoiding the need to reprocess all collection updates.
 
 *Type*: `string`
 
@@ -294,7 +294,7 @@ This field is only applicable when `stream_snapshot` is set to `true`.
 
 === `snapshot_auto_bucket_sharding`
 
-Uses the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command instead of the default, `$splitVector`, to split the snapshot data into chunks for processing. This is required for environments, such as MongoDB Atlas, where privileged access is restricted. To enable parallel processing in these environments:
+Uses the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command instead of the default, `$splitVector`, to split the snapshot data into chunks for processing. This is required for environments, such as MongoDB Atlas, where the `$splitVector` command is not available. To enable parallel processing in these environments:
 
 - Set this field to to `true`.
 - Set `stream_snapshot` to `true`.

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -1,7 +1,7 @@
 = mongodb_cdc
+:page-beta: true
 // tag::single-source[]
 :type: input
-:page-beta: true
 :categories: ["Services"]
 
 component_type_dropdown::[]

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -80,7 +80,9 @@ endif::[]
 ifdef::env-cloud[]
 - Network access from the cluster where your Redpanda Connect pipeline is running to the source database environment. For detailed networking information, including how to set up a VPC peering connection, see xref:networking:index.adoc[Redpanda Cloud Networking].
 endif::[]
-- A sharded MongoDB database or MongoDB cluster running as a replica set
+- A MongoDB database running as a https://www.mongodb.com/docs/manual/replication/#replication-in-mongodb[replica set^] or in a https://www.mongodb.com/docs/manual/sharding/[sharded cluster^] using replica set https://www.mongodb.com/docs/manual/reference/replica-configuration/#rsconf.protocolVersion[protocol version 1].
+- A MongoDB database using the https://www.mongodb.com/docs/manual/core/wiredtiger/#storage-wiredtiger[WiredTiger] storage engine.
+
 
 ifndef::env-cloud[]
 == Enable connectivity from cloud-based data sources
@@ -99,7 +101,7 @@ endif::[]
 
 == Data capture method
 
-The `mongodb_cdc` input uses https://www.mongodb.com/docs/manual/changeStreams/[change streams^] to capture data changes, which does not propagate _all_ changes to Redpanda Connect. To capture all changes in a MongoDB cluster, including deletions, enable pre- and post-image saving for the cluster and <<database-collections, required collections>>. For more information, see <<document-mode, `document_mode` options>> and the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation].
+The `mongodb_cdc` input uses https://www.mongodb.com/docs/manual/changeStreams/[change streams^] to capture data changes, which does not propagate _all_ changes to Redpanda Connect. To capture all changes in a MongoDB cluster, including deletions, enable pre- and post-image saving for the cluster and <<collections,required collections>>. For more information, see <<document_mode,`document_mode` options>> and the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation].
 
 
 == Data replication
@@ -115,29 +117,18 @@ You can also run the `mongodb_cdc` input in one of two modes, depending on wheth
 
 If you set the <<stream_snapshot,`stream_snapshot` field>> to `true`, Redpanda Connect connects to your MongoDB database and does the following to capture a snapshot of all data in the selected collections:
 
-//TODO should include parallel processing of snapshots and document_mode
-
+. Records the latest oplog position.
+. Determines the strategy for splitting the snapshot data down into shards or chunks for more efficient processing:
+.. If <<snapshot_auto_bucket_sharding,`snapshot_auto_bucket_sharding`>> is set to `false`, the internal `$splitVector` command is used to compute shards.  
+.. If <<snapshot_auto_bucket_sharding,`snapshot_auto_bucket_sharding`>> is set to `true`, the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command is used instead. This setting is for environments, such as MongoDB Atlas, where privileged access is restricted.
+. This input then uses the number of connections specified in <<snapshot_parallelism,`snapshot-parallelism`>> to read the selected collections.
++
 NOTE: If the pipeline restarts during this process, Redpanda Connect must start the snapshot capture from scratch to store the current oplog position in the <<checkpoint_cache,`checkpoint_cache`>>.
-
-//TODO
-
-Finally, the input uses the stored oplog position to catch up with changes that occurred during snapshot processing.
+. Finally, the input uses the stored oplog position to catch up with changes that occurred during snapshot processing.
 
 === Streaming mode
 
 If you set the <<stream_snapshot,`stream_snapshot` field>> to `false`, Redpanda Connect connects to your MongoDB database and starts processing data changes from the latest oplog position. If the pipeline restarts, Redpanda Connect resumes processing updates from the last oplog position written to the <<checkpoint_cache,`checkpoint_cache`>>.
-
-== Data mappings
-
-The following table shows how selected MongoDB data types are mapped to data types supported in Redpanda Connect. All other data types are mapped to string values.
-
-|===
-| MongoDB data type | Bloblang value
-
-| Placeholder
-| Placeholder
-
-|===
 
 == Metadata
 
@@ -145,7 +136,7 @@ This input adds the following metadata fields to each message:
 
 - `operation`: The type of data change that generated the message: `read`, `create`, `update`, `replace`, `delete`, `update`. A `read` operation occurs when the initial snapshot of the database is processed.
 - `collection`: The name of the collection from which the message originated.
-- `operation_time`: The time the data change was written to the https://www.mongodb.com/docs/manual/core/replica-set-oplog/[operations log (oplog)^].
+- `operation_time`: The time the data change was written to the https://www.mongodb.com/docs/manual/core/replica-set-oplog/[operations log (oplog)^] in the form of a Binary JSON (BSON) timestamp: `{"t": <unix seconds>, "i": <sequence number>}`.
 
 == Fields
 
@@ -250,7 +241,7 @@ The interval between writing checkpoints to the cache.
 
 === `checkpoint_limit`
 
-The maximum number of messages that this input can process at a given time. Increasing this limit enables parallel processing, and batching at the output level. To preserve at-least-once guarantees, any given oplog position is not acknowledged until all messages under that offset are delivered.
+The maximum number of in-flight messages emitted from this input. Increasing this limit enables parallel processing, and batching at the output level. To preserve at-least-once guarantees, any given oplog position is not acknowledged until all messages under that offset are delivered.
 
 *Type*: `int`
 
@@ -269,7 +260,7 @@ The number of documents to fetch in each message batch from MongoDB.
 
 === `read_max_wait`
 
-The maximum duration MongoDB waits to accumulate the <<read-batch-size, `read_batch_size`>> documents on a change stream before returning the batch to Redpanda Connect.
+The maximum duration MongoDB waits to accumulate the <<read_batch_size,`read_batch_size`>> documents on a change stream before returning the batch to Redpanda Connect.
 
 *Type*: `string`
 
@@ -291,9 +282,11 @@ stream_snapshot: true
 
 === `snapshot_parallelism`
 
-Specifies the number of connections to use when reading the initial snapshot from one or more collections. Increase this number to enable parallel processing of the snapshot.
+Specifies the number of connections to use when reading the initial snapshot from one or more collections. Increase this number to enable parallel processing of the snapshot. 
 
 This feature uses the `$splitVector` command to split snapshot data into chunks for more efficient processing.
+
+This field is only applicable when `stream_snapshot` is set to `true`. 
 
 *Type*: `int`
 
@@ -303,7 +296,8 @@ This feature uses the `$splitVector` command to split snapshot data into chunks 
 
 Uses the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command instead of the default, `$splitVector`, to split the snapshot data into chunks for processing. This is required for environments, such as MongoDB Atlas, where privileged access is restricted. To enable parallel processing in these environments:
 
-- Set `snapshot_auto_bucket_sharding` to `true`.
+- Set this field to to `true`.
+- Set `stream_snapshot` to `true`.
 - Increase `snapshot_parallelism` to a value greater than `1`.
 
 *Type*: `bool`
@@ -314,9 +308,23 @@ Uses the https://www.mongodb.com/docs/manual/reference/operator/aggregation/buck
 
 The mode in which MongoDB emits document changes to Redpanda Connect, specifically updates and deletes.
 
+*Type*: `string`
+
+*Default*: `update_lookup`
+
 [cols="1,2"]
 |===
-| Option | Mode description
+| Option | Description the document mode
+
+| `update_lookup`
+a| Emits full documents for insert, replace, and update operations, but only the `_id` field for delete operations.  
+This corresponds to the `updateLookup` option.  
+For more information, see the https://www.mongodb.com/docs/manual/changeStreams/#std-label-change-streams-updateLookup[MongoDB documentation^].
+
+| `pre_and_post_images`
+a| Emits full documents for update and delete operations by using pre- and post-image collections.  
+For setup and configuration details, see the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation^].
+
 
 | `partial_update`
 a| Update operations contain only a description of the changes made to the document, using the following schema:
@@ -341,20 +349,11 @@ a| Update operations contain only a description of the changes made to the docum
 }
 ----
 
-| `pre_and_post_images`
-a| Emits full documents for update and delete operations by using pre- and post-image collections.  
-For setup and configuration details, see the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation^].
-
-| `update_lookup`
-a| Emits full documents for insert, replace, and update operations, but only the `_id` field for delete operations.  
-This corresponds to the `updateLookup` option.  
-For more information, see the https://www.mongodb.com/docs/manual/changeStreams/#std-label-change-streams-updateLookup[MongoDB documentation^].
-
 |===
 
 === `json_marshal_mode`
 
-Controls the format of the message output to Redpanda Connect.
+Controls the format used to convert a message from BSON to JSON when it is received by Redpanda Connect.
 
 *Type*: `string`
 
@@ -364,9 +363,9 @@ Controls the format of the message output to Redpanda Connect.
 | Option | Description
 
 | `canonical`
-| A string format that preserves the exact data types of values stored in MongoDB at the expense of readability and interoperability. Conversion from canonical to Binary JSON (BSON) generally retains type information, except in specific cases.
+| A string format that preserves the exact data types of values stored in MongoDB at the expense of readability and interoperability. Conversion from `canonical` to JSON generally preserves type information.
 | `relaxed`
-| A string format that is human-readable and compatible with most JSON parsers but may lose type fidelity. Conversion from relaxed format to BSON can lose type information.
+| A string format that is human-readable and compatible with most JSON parsers but may lose type fidelity. Conversion from `relaxed` format to JSON can lose type information.
 
 |===
 

--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -1,0 +1,393 @@
+= mongodb_cdc
+// tag::single-source[]
+:type: input
+:page-beta: true
+:categories: ["Services"]
+
+component_type_dropdown::[]
+
+Streams data changes from a MongoDB replica set, using MongoDB's https://www.mongodb.com/docs/manual/changeStreams/[change streams^] to capture data updates.
+
+ifndef::env-cloud[]
+Introduced in version 4.48.1.
+endif::[]
+
+[tabs]
+======
+Common::
++
+--
+
+```yml
+# Configuration fields, showing default values
+input:
+  label: ""
+  mongodb_cdc:
+    url: mongodb://localhost:27017 # No default (required)
+    database: "" # No default (required)
+    username: "" # Optional
+    password: "" # Optional
+    collections: [] # No default (required)
+    checkpoint_cache: "" # No default (required)
+    checkpoint_key: mongodb_cdc_checkpoint
+    checkpoint_interval: 5s
+    checkpoint_limit: 1000
+    read_batch_size: 1000
+    read_max_wait: 1s
+    stream_snapshot: false
+    snapshot_parallelism: 1
+    auto_replay_nacks: true
+```
+
+--
+Advanced::
++
+--
+
+```yml
+# All configuration fields, showing default values
+input:
+  label: ""
+  mongodb_cdc:
+    url: mongodb://localhost:27017 # No default (required)
+    database: "" # No default (required)
+    username: ""
+    password: ""
+    collections: [] # No default (required)
+    checkpoint_cache: "" # No default (required)
+    checkpoint_key: mongodb_cdc_checkpoint
+    checkpoint_interval: 5s
+    checkpoint_limit: 1000
+    read_batch_size: 1000
+    read_max_wait: 1s
+    stream_snapshot: false
+    snapshot_parallelism: 1
+    snapshot_auto_bucket_sharding: false
+    document_mode: update_lookup
+    json_marshal_mode: canonical
+    app_name: benthos
+    auto_replay_nacks: true
+```
+--
+======
+
+== Prerequisites
+
+- MongoDB version 6 or later
+ifndef::env-cloud[]
+- Network access from the cluster where your Redpanda Connect pipeline is running to the source database environment.
+endif::[]
+ifdef::env-cloud[]
+- Network access from the cluster where your Redpanda Connect pipeline is running to the source database environment. For detailed networking information, including how to set up a VPC peering connection, see xref:networking:index.adoc[Redpanda Cloud Networking].
+endif::[]
+- A sharded MongoDB database or MongoDB cluster running as a replica set
+
+ifndef::env-cloud[]
+== Enable connectivity from cloud-based data sources
+
+To establish a secure connection between a cloud-based data source and Redpanda Connect, you must add the IP addresses of your Redpanda Connect instances to your firewall rules.
+
+endif::[]
+
+ifdef::env-cloud[]
+
+== Enable connectivity from cloud-based data sources (BYOC)
+
+To establish a secure connection between a cloud-based data source and Redpanda Connect, you must add the NAT Gateway IP address of your Redpanda cluster to the allowlist of your data source.
+
+endif::[]
+
+== Data capture method
+
+The `mongodb_cdc` input uses https://www.mongodb.com/docs/manual/changeStreams/[change streams^] to capture data changes, which does not propagate _all_ changes to Redpanda Connect. To capture all changes in a MongoDB cluster, including deletions, enable pre- and post-image saving for the cluster and <<database-collections, required collections>>. For more information, see <<document-mode, `document_mode` options>> and the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation].
+
+
+== Data replication
+
+Redpanda Connect allows you to specify which <<collections,database collections>> in your source database to receive changes from.
+
+You can also run the `mongodb_cdc` input in one of two modes, depending on whether you need a snapshot of existing data before streaming updates.
+
+- Snapshot mode: Redpanda Connect first captures a snapshot of all data in the selected collections and streams the contents before processing changes from the last recorded https://www.mongodb.com/docs/manual/core/replica-set-oplog/[operations log (oplog)^] position.
+- Streaming mode: Redpanda Connect skips the snapshot and processes only the most recent data changes, starting from the latest oplog position.
+
+=== Snapshot mode
+
+If you set the <<stream_snapshot,`stream_snapshot` field>> to `true`, Redpanda Connect connects to your MongoDB database and does the following to capture a snapshot of all data in the selected collections:
+
+//TODO should include parallel processing of snapshots and document_mode
+
+NOTE: If the pipeline restarts during this process, Redpanda Connect must start the snapshot capture from scratch to store the current oplog position in the <<checkpoint_cache,`checkpoint_cache`>>.
+
+//TODO
+
+Finally, the input uses the stored oplog position to catch up with changes that occurred during snapshot processing.
+
+=== Streaming mode
+
+If you set the <<stream_snapshot,`stream_snapshot` field>> to `false`, Redpanda Connect connects to your MongoDB database and starts processing data changes from the latest oplog position. If the pipeline restarts, Redpanda Connect resumes processing updates from the last oplog position written to the <<checkpoint_cache,`checkpoint_cache`>>.
+
+== Data mappings
+
+The following table shows how selected MongoDB data types are mapped to data types supported in Redpanda Connect. All other data types are mapped to string values.
+
+|===
+| MongoDB data type | Bloblang value
+
+| Placeholder
+| Placeholder
+
+|===
+
+== Metadata
+
+This input adds the following metadata fields to each message:
+
+- `operation`: The type of data change that generated the message: `read`, `create`, `update`, `replace`, `delete`, `update`. A `read` operation occurs when the initial snapshot of the database is processed.
+- `collection`: The name of the collection from which the message originated.
+- `operation_time`: The time the data change was written to the https://www.mongodb.com/docs/manual/core/replica-set-oplog/[operations log (oplog)^].
+
+== Fields
+
+=== `url`
+
+The URL of the target MongoDB server.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+url: mongodb://localhost:27017
+```
+
+=== `database`
+
+The name of the MongoDB database to stream changes from.
+
+*Type*: `string`
+
+*Default*: `""`
+
+
+=== `username`
+
+The username to connect to the database.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `password`
+
+The password to connect to the database.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+
+=== `collections`
+
+A list of collections to stream changes from. Specify each collection name as a separate item.
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+collections:
+  - orders
+  - customers
+  - inventory
+```
+
+=== `checkpoint_cache`
+
+Specify a `cache` resource to store the oplog position for the most recent data update streamed to Redpanda Connect. After a restart, Redpanda Connect can continue processing changes from this position, avoiding the need to reprocess all collection updates.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+input:
+  mongodb_cdc:
+    url: mongodb://localhost:27017
+    collections: [my_collection]
+    checkpoint_cache: "my_cdc_cache"
+cache_resources:
+  - label: "my_cdc_cache"
+    redis:
+      url: redis://:6379
+```
+
+=== `checkpoint_key`
+
+The key identifier used to store the oplog position in <<checkpoint_cache,`checkpoint_cache`>>. If you have multiple `mongodb_cdc` inputs sharing the same cache, you can provide an alternative key.
+
+
+*Type*: `string`
+
+*Default*: `mongodb_cdc_checkpoint`
+
+
+=== `checkpoint_interval`
+
+The interval between writing checkpoints to the cache.
+
+*Type*: `string`
+
+*Default*: `5s`
+
+=== `checkpoint_limit`
+
+The maximum number of messages that this input can process at a given time. Increasing this limit enables parallel processing, and batching at the output level. To preserve at-least-once guarantees, any given oplog position is not acknowledged until all messages under that offset are delivered.
+
+*Type*: `int`
+
+*Default*: `1000`
+
+
+=== `read_batch_size`
+
+The number of documents to fetch in each message batch from MongoDB.
+
+
+*Type*: `int`
+
+*Default*: `1000`
+
+
+=== `read_max_wait`
+
+The maximum duration MongoDB waits to accumulate the <<read-batch-size, `read_batch_size`>> documents on a change stream before returning the batch to Redpanda Connect.
+
+*Type*: `string`
+
+*Default*: `1s`
+
+=== `stream_snapshot`
+
+When set to `true`, this input streams a snapshot of all existing data in the source collections before streaming data changes.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+```yml
+# Examples
+
+stream_snapshot: true
+```
+
+=== `snapshot_parallelism`
+
+Specifies the number of connections to use when reading the initial snapshot from one or more collections. Increase this number to enable parallel processing of the snapshot.
+
+This feature uses the `$splitVector` command to split snapshot data into chunks for more efficient processing.
+
+*Type*: `int`
+
+*Default*: `1`
+
+=== `snapshot_auto_bucket_sharding`
+
+Uses the https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/[`$bucketAuto`^] command instead of the default, `$splitVector`, to split the snapshot data into chunks for processing. This is required for environments, such as MongoDB Atlas, where privileged access is restricted. To enable parallel processing in these environments:
+
+- Set `snapshot_auto_bucket_sharding` to `true`.
+- Increase `snapshot_parallelism` to a value greater than `1`.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `document_mode`
+
+The mode in which MongoDB emits document changes to Redpanda Connect, specifically updates and deletes.
+
+[cols="1,2"]
+|===
+| Option | Mode description
+
+| `partial_update`
+a| Update operations contain only a description of the changes made to the document, using the following schema:
+
+[,bash,role="no-placeholders"]
+----
+{
+  "_id": "<document_id>",
+  "operations": [
+    # type == set: Indicates that a value was updated. For example:
+    # root.name."address.city" = "New York"
+    {"path": ["name", "address.city"], "type": "set", "value": "New York"},
+
+    # type == unset: Indicates that a value was deleted. For example:
+    # root.phone = deleted()
+    {"path": ["phone"], "type": "unset", "value": null},
+
+    # type == truncatedArray: Indicates that an array was truncated to a specified number of elements. For example:
+    # root.items = this.items.slice(2)
+    {"path": ["items"], "type": "truncatedArray", "value": 2}
+  ]
+}
+----
+
+| `pre_and_post_images`
+a| Emits full documents for update and delete operations by using pre- and post-image collections.  
+For setup and configuration details, see the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images[MongoDB documentation^].
+
+| `update_lookup`
+a| Emits full documents for insert, replace, and update operations, but only the `_id` field for delete operations.  
+This corresponds to the `updateLookup` option.  
+For more information, see the https://www.mongodb.com/docs/manual/changeStreams/#std-label-change-streams-updateLookup[MongoDB documentation^].
+
+|===
+
+=== `json_marshal_mode`
+
+Controls how MongoDB formats messages sent to Redpanda Connect.
+
+*Type*: `string`
+
+*Default*: `canonical`
+
+|===
+| Option | Description
+
+| `canonical`
+| A string format that preserves type information at the expense of readability and interoperability. Conversion from canonical to Binary JSON (BSON) generally retains type information, except in specific cases.
+| `relaxed`
+| A string format that is human-readable and compatible with most JSON parsers but may lose type fidelity. Conversion from relaxed format to BSON can lose type information.
+
+|===
+
+=== `app_name`
+
+The client application name.
+
+*Type*: `string`
+
+*Default*: `benthos`
+
+
+=== `auto_replay_nacks`
+
+Whether to automatically replay rejected messages (negative acknowledgements) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.
+
+Set `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams as the original shape of the data is discarded immediately upon consumption and mutation.
+
+
+*Type*: `bool`
+
+*Default*: `true`
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves [DOC-514](https://redpandadata.atlassian.net/browse/DOC-514)
Review deadline: 7th March

Related PR to enable connector in cloud-docs: https://github.com/redpanda-data/cloud-docs/pull/227

This pull request introduces a new MongoDB CDC (Change Data Capture) input component to the documentation. The most important changes include updating the navigation to include the new component and adding comprehensive documentation for configuring and using the `mongodb_cdc` input.

Updates to documentation:

* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R67): Added a reference to the new MongoDB CDC input component in the navigation.
* [`modules/components/pages/inputs/mongodb_cdc.adoc`](diffhunk://#diff-826031304e0d00bc21e9c843f7f631ff2a5d78a926ec751e5ab4a605dabc104bR1-R393): Added detailed documentation for the `mongodb_cdc` input, including configuration fields, prerequisites, data capture methods, data replication modes, data mappings, metadata, and field descriptions.

## Page previews

[mongo_cdc connector](https://deploy-preview-186--redpanda-connect.netlify.app/redpanda-connect/components/inputs/mongodb_cdc/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-514]: https://redpandadata.atlassian.net/browse/DOC-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ