### PR TITLE
docs: `result_map` writes to document `fake_news_score`

### DIFF
--- a/modules/cookbooks/pages/enrichments.adoc
+++ b/modules/cookbooks/pages/enrichments.adoc
@@ -236,7 +236,7 @@ If we were to execute all three enrichments in a sequence we'll end up with a do
     "id": "123foo",
     "title": "Dogs Stop Barking",
     "content": "The world was shocked this morning to find that all dogs have stopped barking.",
-    "fake_news_rank": 0.76
+    "fake_news_score": 0.76
   },
   "tmp": {
     "hyperbole_rank": 0.34,


### PR DESCRIPTION
## Description

Review deadline: None

Fix minor typo after reading docs to learn more about Redpanda Connect. Note I've not actually run this pipeline, just researching at the moment.

To reflect what's written in https://github.com/redpanda-data/rp-connect-docs/pull/190/files#diff-ac328a354b8ea434d71a388fd8634f4c580394eeccb6a45d1534565346f05465R224

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)