### PR TITLE
DOC-1111 Remove link from note on elasticsearch_v8 output

### DIFF
--- a/modules/components/pages/outputs/elasticsearch_v8.adoc
+++ b/modules/components/pages/outputs/elasticsearch_v8.adoc
@@ -12,7 +12,7 @@ component_type_dropdown::[]
 
 Publishes messages into an https://www.elastic.co/guide/en/elasticsearch/reference/current/documents-indices.html[Elasticsearch index^]. If the index does not exist, this output creates it using dynamic mapping.
 
-NOTE: The xref:components:outputs/elasticsearch_v8.adoc[`elasticsearch_v8` output] is based on the the https://github.com/elastic/go-elasticsearch?tab=readme-ov-file[go-elasticsearch/v8] library. For full information about breaking changes from previous versions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking_80_rest_api_changes[Elastic's Migrating to 8.0 guide^]. 
+NOTE: The `elasticsearch_v8` output is based on the the https://github.com/elastic/go-elasticsearch?tab=readme-ov-file[go-elasticsearch/v8] library. For full information about breaking changes from previous versions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking_80_rest_api_changes[Elastic's Migrating to 8.0 guide^]. 
 
 To help configure your own `elasticsearch_v8` output, this page includes <<example-pipelines, example pipeline configurations>>.
 


### PR DESCRIPTION
## Description

Resolves [DOC-1111](https://redpandadata.atlassian.net/browse/DOC-1111)
Review deadline: 12th March

## Page previews

[elasticsearch_v8 output](https://deploy-preview-191--redpanda-connect.netlify.app/redpanda-connect/components/outputs/elasticsearch_v8/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1111]: https://redpandadata.atlassian.net/browse/DOC-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ