### PR TITLE
DOC-1123 Add is_high_watermark field and metadata

### DIFF
--- a/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator_offsets.adoc
@@ -80,6 +80,7 @@ This input adds the following metadata fields to each message:
 - `kafka_offset_partition`
 - `kafka_offset_commit_timestamp`
 - `kafka_offset_metadata`
+- `kafka_is_high_watermark`
 
 == Fields
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -11,11 +11,11 @@
 
 component_type_dropdown::[]
 
-
-Use the `redpanda_migrator_offsets` output in conjunction with a `kafka_franz` input that is configured to read the `__consumer_offsets` topic.
-This output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
+Migrates offset data to a Redpanda cluster. To achieve this, pair the `redpanda_migrator_offsets` output with a `kafka_franz` input that is configured to consume the `__consumer_offsets` topic.
 
 Alternatively, use the `redpanda_migrator_bundle` xref:components:inputs/redpanda_migrator_bundle.adoc[input] and xref:components:outputs/redpanda_migrator_bundle.adoc[output] to complete the migration of topics, messages, and schemas to a Redpanda cluster.
+
+This output uses the https://github.com/twmb/franz-go[Franz Kafka client library^].
 
 
 ifndef::env-cloud[]
@@ -39,6 +39,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
+    is_high_watermark: ${! @kafka_is_high_watermark }
 ```
 
 --
@@ -57,9 +58,9 @@ output:
       enabled: false
       skip_cert_verify: false
       enable_renegotiation: false
-      root_cas: ""
-      root_cas_file: ""
-      client_certs: []
+      root_cas: "" # Optional
+      root_cas_file: "" # Optional
+      client_certs: [] # Optional
     sasl: [] # No default (optional)
     metadata_max_age: 5m
     offset_topic: ${! @kafka_offset_topic }
@@ -67,6 +68,7 @@ output:
     offset_partition: ${! @kafka_offset_partition }
     offset_commit_timestamp: ${! @kafka_offset_commit_timestamp }
     offset_metadata: ${! @kafka_offset_metadata }
+    is_high_watermark: ${! @kafka_is_high_watermark }
     timeout: 10s
     max_message_bytes: 1MiB
     broker_write_max_bytes: 100MiB
@@ -301,7 +303,7 @@ The SASL mechanism to use.
 | `SCRAM-SHA-512`
 | SCRAM-based authentication as specified in RFC 5802.
 | `none`
-| Disable SASL authentication
+| Disable SASL authentication.
 
 |===
 
@@ -443,7 +445,7 @@ An external ID to provide when assuming a role.
 *Default*: `""`
 
 
-=== metadata_max_age
+=== `metadata_max_age`
 
 The maximum period of time after which metadata is refreshed.
 
@@ -451,7 +453,7 @@ The maximum period of time after which metadata is refreshed.
 
 *Default*: `5m`
 
-=== offset_topic
+=== `offset_topic`
 
 The name of the Kafka offset topic to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
@@ -459,7 +461,7 @@ The name of the Kafka offset topic to process. This field supports xref:configur
 
 *Default*: `${! @kafka_offset_topic }`
 
-=== offset_group
+=== `offset_group`
 
 The name of the Kafka offset consumer group to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
@@ -467,7 +469,7 @@ The name of the Kafka offset consumer group to process. This field supports xref
 
 *Default*: `${! @kafka_offset_group }`
 
-=== offset_partition
+=== `offset_partition`
 
 The Kafka offset partition ID to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
@@ -475,7 +477,7 @@ The Kafka offset partition ID to process. This field supports xref:configuration
 
 *Default*: `${! @kafka_offset_partition }`
 
-=== offset_commit_timestamp
+=== `offset_commit_timestamp`
 
 The Kafka offset commit timestamp to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
@@ -483,13 +485,14 @@ The Kafka offset commit timestamp to process. This field supports xref:configura
 
 *Default*: `${! @kafka_offset_commit_timestamp }`
 
-=== offset_metadata
+=== `is_high_watermark`
 
-The Kafka offset metadata value to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+Indicates whether the processed message is the high watermark, which is the offset of the last fully replicated message in the Kafka topic partition. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
-*Default*: `${! @kafka_offset_metadata }`
+*Default*: `${! @kafka_is_high_watermark }`
+
 
 === `timeout`
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -11,7 +11,7 @@
 
 component_type_dropdown::[]
 
-Migrates offset data to a Redpanda cluster. To achieve this, pair the `redpanda_migrator_offsets` output with a `kafka_franz` input that is configured to consume the `__consumer_offsets` topic.
+Migrates offset data to a Redpanda cluster. To achieve this, pair the `redpanda_migrator_offsets` output with a matching xref:components:outputs/redpanda_migrator_bundle.adoc[`redpanda_migrator_bundle` input].
 
 Alternatively, use the `redpanda_migrator_bundle` xref:components:inputs/redpanda_migrator_bundle.adoc[input] and xref:components:outputs/redpanda_migrator_bundle.adoc[output] to complete the migration of topics, messages, and schemas to a Redpanda cluster.
 

--- a/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_offsets.adoc
@@ -485,6 +485,14 @@ The Kafka offset commit timestamp to process. This field supports xref:configura
 
 *Default*: `${! @kafka_offset_commit_timestamp }`
 
+=== `offset_metadata`
+
+The Kafka offset metadata value to process. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `${! @kafka_offset_metadata }`
+
 === `is_high_watermark`
 
 Indicates whether the processed message is the high watermark, which is the offset of the last fully replicated message in the Kafka topic partition. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].


### PR DESCRIPTION
## Description

Resolves: [DOC-1123](https://redpandadata.atlassian.net/browse/DOC-1123)
Review deadline: 20th March

This pull request includes changes to the `redpanda_migrator_offsets` input and output documentation to add new metadata fields and improve clarity. The most important changes include adding a new metadata field, updating descriptions, and marking certain fields as optional.

### Metadata field additions:
* Added `kafka_is_high_watermark` to the list of metadata fields in the `redpanda_migrator_offsets` input documentation.
* Added `is_high_watermark` to the output configuration example in the `redpanda_migrator_offsets` output documentation.

### Documentation improvements:
* Revised the description for using the `redpanda_migrator_offsets` output with the `kafka_franz` input for clarity.
* Marked `root_cas`, `root_cas_file`, and `client_certs` as optional fields in the output configuration example.
* Updated the formatting of field names and descriptions to improve readability and consistency. [[1]](diffhunk://#diff-419b0aec5610b85f140a930da793ea0d3f2f3c4971045256974d9ca7bf74b6fcL446-R495) [[2]](diffhunk://#diff-419b0aec5610b85f140a930da793ea0d3f2f3c4971045256974d9ca7bf74b6fcL304-R306)

## Page previews

- [`redpanda_migrator_offsets` input](https://deploy-preview-193--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator_offsets/)
- [`redpanda_migrator_offsets` output](https://deploy-preview-193--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_offsets/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1123]: https://redpandadata.atlassian.net/browse/DOC-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ