### PR TITLE
DOC-1119 Add new metrics for snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -157,16 +157,16 @@ This output emits the following metrics.
 | The time taken to convert messages into the Snowflake column data types.
 
 | `snowflake_serialize_latency_ns`
-| The time taken to serialize the converted columnar data into a Parquet file to upload to Snowflake.
+| The time taken to serialize the converted columnar data into a file for upload to Snowflake.
 
 | `snowflake_build_output_latency_ns`
-| The time taken to build the Parquet file that is uploaded to Snowflake. This metric is the sum of `snowflake_convert_latency_ns` + `snowflake_serialize_latency_ns`. 
+| The time taken to build the file that is uploaded to Snowflake. This metric is the sum of `snowflake_convert_latency_ns` + `snowflake_serialize_latency_ns`. 
 
 | `snowflake_upload_latency_ns`
-| The time taken to upload the output Parquet file to Snowflake.
+| The time taken to upload the output file to Snowflake.
 
 | `snowflake_register_latency_ns`
-| The time taken to register the uploaded Parquet file with Snowflake.
+| The time taken to register the uploaded output file with Snowflake.
 
 | `snowflake_commit_latency_ns`
 | The time taken to commit the uploaded data updates to the target Snowflake table.

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -150,20 +150,26 @@ This output emits the following metrics.
 |===
 | Metric name | Description
 
+| `snowflake_compressed_output_size_bytes`
+| The size in bytes of each message batch uploaded to Snowflake.
+
 | `snowflake_convert_latency_ns`
 | The time taken to convert messages into the Snowflake column data types.
 
 | `snowflake_serialize_latency_ns`
-| The time taken to serialize the converted columnar data into a file to send to Snowflake.
+| The time taken to serialize the converted columnar data into a Parquet file to upload to Snowflake.
 
 | `snowflake_build_output_latency_ns`
-| The time taken to build the output file that is sent to Snowflake. This metric is the sum of `snowflake_convert_latency_ns` + `snowflake_serialize_latency_ns`. 
+| The time taken to build the Parquet file that is uploaded to Snowflake. This metric is the sum of `snowflake_convert_latency_ns` + `snowflake_serialize_latency_ns`. 
 
 | `snowflake_upload_latency_ns`
-| The time taken to upload the output file to Snowflake.
+| The time taken to upload the output Parquet file to Snowflake.
 
-| `snowflake_compressed_output_size_bytes`
-| The size in bytes of each message batch sent to Snowflake.
+| `snowflake_register_latency_ns`
+| The time taken to register the uploaded Parquet file with Snowflake.
+
+| `snowflake_commit_latency_ns`
+| The time taken to commit the uploaded data updates to the target Snowflake table.
 
 |===
 


### PR DESCRIPTION
## Description

Resolves [DOC-1119](https://redpandadata.atlassian.net/browse/DOC-1119)
Review deadline: 21 March

This pull request updates the documentation for Snowflake streaming output metrics in the `modules/components/pages/outputs/snowflake_streaming.adoc` file.

## Page previews

[`snowflake_streaming` output](https://deploy-preview-194--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1119]: https://redpandadata.atlassian.net/browse/DOC-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ