### PR TITLE
DOC-1128 Remove beta flags mongodb_cdc and mysql_cdc connectors

### DIFF
--- a/modules/components/pages/inputs/mongodb_cdc.adoc
+++ b/modules/components/pages/inputs/mongodb_cdc.adoc
@@ -1,5 +1,4 @@
 = mongodb_cdc
-:page-beta: true
 // tag::single-source[]
 :type: input
 :categories: ["Services"]

--- a/modules/components/pages/inputs/mysql_cdc.adoc
+++ b/modules/components/pages/inputs/mysql_cdc.adoc
@@ -1,7 +1,6 @@
 = mysql_cdc
 // tag::single-source[]
 :type: input
-:page-beta: true
 :categories: ["Services"]
 
 component_type_dropdown::[]


### PR DESCRIPTION
## Description

Resolves [DOC-1128](https://redpandadata.atlassian.net/browse/DOC-1128)
Review deadline: 18 March

This pull request makes minor changes to the `mongodb_cdc` and `mysql_cdc` documentation to remove the beta status from both files.

Related cloud-docs PR: [https://github.com/redpanda-data/cloud-docs/pull/235](https://github.com/redpanda-data/cloud-docs/pull/235)

## Page previews

- [`mongodb_cdc` input](https://deploy-preview-195--redpanda-connect.netlify.app/redpanda-connect/components/inputs/mongodb_cdc/)
- [`mysql_cdc` input](https://deploy-preview-195--redpanda-connect.netlify.app/redpanda-connect/components/inputs/mysql_cdc/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1128]: https://redpandadata.atlassian.net/browse/DOC-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ