### PR TITLE
DOC-1118 Add commit_timeout field to snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -85,6 +85,7 @@ output:
     channel_prefix: channel-${HOST} # No default (optional)
     channel_name: partition-${!@kafka_partition} # No default (optional)
     offset_token: offset-${!"%016X".format(@kafka_offset)} # No default (optional)
+    commit_timeout: 60s
 ```
 
 --
@@ -517,6 +518,23 @@ For more information about offset tokens, see https://docs.snowflake.com/en/user
 offset_token: offset-${!"%016X".format(@kafka_offset)}
 
 offset_token: postgres-${!@lsn}
+```
+
+=== `commit_timeout`
+
+The maximum duration to wait while data updates from a message batch are asynchronously committed to Snowflake.
+
+*Type*: `string`
+
+*Default*: `60s`
+
+```yml
+
+# Examples
+
+commit_timeout: 10s
+
+commit_timeout: 10m
 ```
 
 == Example pipelines


### PR DESCRIPTION
## Description

Resolves [DOC-1118](https://redpandadata.atlassian.net/browse/DOC-1118)
Review deadline: 21 March

## Page previews

[`snowflake_streaming` output](https://deploy-preview-196--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1118]: https://redpandadata.atlassian.net/browse/DOC-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ