### PR TITLE
DOC-1122 Add url field to snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -199,7 +199,7 @@ account: ORG-ACCOUNT
 
 === `url`
 
-Specify a custom URL to connect to Snowflake, which overrides the default URL: `\https://ORG-ACCOUNT.snowflakecomputing.com`.
+Specify a custom URL to connect to Snowflake. This parameter overrides the default URL, which is automatically generated from the value of `output.snowflake_streaming.account`. By default, the URL is constructed as follows: `https://<output.snowflake_streaming.account>.snowflakecomputing.com`.
 
 *Type*: `string`
 

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -58,6 +58,7 @@ output:
   label: ""
   snowflake_streaming:
     account: ORG-ACCOUNT # No default (required)
+    url: https://org-account.privatelink.snowflakecomputing.com # No default (optional)
     user: "" # No default (required)
     role: ACCOUNTADMIN # No default (required)
     database: MYDATABASE # No default (required)
@@ -194,6 +195,19 @@ WHERE VALUE:type = 'SNOWFLAKE_DEPLOYMENT_REGIONLESS';
 # Examples
 
 account: ORG-ACCOUNT
+```
+
+=== `url`
+
+For private link deployments, specify a custom URL to connect to Snowflake, which overrides the default URL: `\https://ORG-ACCOUNT.snowflakecomputing.com`.
+
+*Type*: `string`
+
+```yml
+# Examples
+
+url: https://org-account.privatelink.snowflakecomputing.com
+
 ```
 
 === `user`

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -199,7 +199,7 @@ account: ORG-ACCOUNT
 
 === `url`
 
-For private link deployments, specify a custom URL to connect to Snowflake, which overrides the default URL: `\https://ORG-ACCOUNT.snowflakecomputing.com`.
+Specify a custom URL to connect to Snowflake, which overrides the default URL: `\https://ORG-ACCOUNT.snowflakecomputing.com`.
 
 *Type*: `string`
 


### PR DESCRIPTION
## Description

Resolves: [DOC-1122 ](https://redpandadata.atlassian.net/browse/DOC-1122)
Review deadline: 24 March

This pull request includes updates to the `snowflake_streaming` output documentation to add support for private link deployments by specifying a custom URL. 

## Page previews

[snowflake_streaming output](https://deploy-preview-197--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/#url)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)