### PR TITLE
DOC-1121 Remove snapshot_memory_safety_factor in postgres_cdc connector

### DIFF
--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -21,8 +21,7 @@ input:
     dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable # No default (required)
     include_transaction_markers: true
     stream_snapshot: false
-    snapshot_memory_safety_factor: 1
-    snapshot_batch_size: 0
+    snapshot_batch_size: 1000
     schema: public # No default (required)
     tables: [] # No default (required)
     checkpoint_limit: 1024
@@ -246,32 +245,15 @@ When set to `true`, this input streams a snapshot of all existing data in the so
 stream_snapshot: true
 ```
 
-=== `snapshot_memory_safety_factor`
-
-The fraction of available memory to use for streaming the database snapshot. Decimal values between `0` and `1` represent the percentage of memory to use. For example, `0.3` would allocate 30% of the available memory. Lower values make initial streaming slower, but help prevent out-of-memory errors.
-
-This option is only available when `stream_snapshot` is set to `true`. You can use either `snapshot_memory_safety_factor` or `snapshot_batch_size`, not both. 
-
-
-*Type*: `float`
-
-*Default*: `1`
-
-```yml
-# Examples
-
-snapshot_memory_safety_factor: 0.2
-```
-
 === `snapshot_batch_size`
 
-The number of table rows to fetch in each batch when querying the snapshot. Leave at `0` to allow the input to determine the batch size based on the `snapshot_memory_safety_factor` value.
+The number of table rows to fetch in each batch when querying the snapshot.
 
-This option is only available when `stream_snapshot` is set to `true`. You can use either `snapshot_batch_size` or `snapshot_memory_safety_factor`, not both. 
+This option is only available when `stream_snapshot` is set to `true`.
 
 *Type*: `int`
 
-*Default*: `0`
+*Default*: `1000`
 
 ```yml
 # Examples


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)