### PR TITLE
DOC-1130 Remove beta tag from postgres_cdc connector

### DIFF
--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -2,7 +2,6 @@
 :page-aliases: components:inputs/pg_stream.adoc
 // tag::single-source[]
 :type: input
-:page-beta: true
 :categories: ["Services"]
 
 component_type_dropdown::[]


### PR DESCRIPTION
## Description

Resolves [DOC-1130](https://redpandadata.atlassian.net/browse/DOC-1130)
Review deadline: 19 March

The change removes the `:page-beta:` attribute to indicate that the page is no longer in beta.

Related PR to remove beta tag from cloud-docs: [https://github.com/redpanda-data/cloud-docs/pull/236](https://github.com/redpanda-data/cloud-docs/pull/236)

## Page previews

[`postgres_cdc` input](https://deploy-preview-199--redpanda-connect.netlify.app/redpanda-connect/components/inputs/postgres_cdc/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1130]: https://redpandadata.atlassian.net/browse/DOC-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ