### PR TITLE
DOC-1125 Add note about replication slot prefix

### DIFF
--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -329,7 +329,9 @@ If the pipeline is restarted, another data snapshot is taken before data updates
 
 The name of the PostgreSQL logical replication slot to use. If not provided, a random name is generated unless you create a replication slot manually before starting replication.
 
-NOTE: Starting from version 4.48.1, replication slot names are no longer created with the prefix `rs_`. To continue to use a replication slot created by an earlier version of Redpanda Connect, add the `rs_` prefix to the slot name.
+ifndef::env-cloud[]
+NOTE: Starting from version 4.48.1, Redpanda Connect no longer adds the prefix `rs_` to replication slot names. To continue to use an existing replication slot after upgrading, manually add the `rs_` prefix to the slot name.
+endif::[]
 
 *Type*: `string`
 

--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -330,7 +330,7 @@ If the pipeline is restarted, another data snapshot is taken before data updates
 The name of the PostgreSQL logical replication slot to use. If not provided, a random name is generated unless you create a replication slot manually before starting replication.
 
 ifndef::env-cloud[]
-NOTE: Starting from version 4.48.1, Redpanda Connect no longer adds the prefix `rs_` to the names of replication slots it creates. To continue to use an existing replication slot after upgrading, manually add the `rs_` prefix to the slot name.
+NOTE: Starting from version 4.48.1, Redpanda Connect no longer adds the prefix `rs_` to the names of replication slots it creates. To continue using an existing replication slot after upgrading, manually add the `rs_` prefix to the slot name.
 endif::[]
 
 *Type*: `string`

--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -329,6 +329,8 @@ If the pipeline is restarted, another data snapshot is taken before data updates
 
 The name of the PostgreSQL logical replication slot to use. If not provided, a random name is generated unless you create a replication slot manually before starting replication.
 
+NOTE: Starting from version 4.48.1, replication slot names are no longer created with the prefix `rs_`. To continue to use a replication slot created by an earlier version of Redpanda Connect, add the `rs_` prefix to the slot name.
+
 *Type*: `string`
 
 *Default*: `""`

--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -330,7 +330,7 @@ If the pipeline is restarted, another data snapshot is taken before data updates
 The name of the PostgreSQL logical replication slot to use. If not provided, a random name is generated unless you create a replication slot manually before starting replication.
 
 ifndef::env-cloud[]
-NOTE: Starting from version 4.48.1, Redpanda Connect no longer adds the prefix `rs_` to replication slot names. To continue to use an existing replication slot after upgrading, manually add the `rs_` prefix to the slot name.
+NOTE: Starting from version 4.48.1, Redpanda Connect no longer adds the prefix `rs_` to the names of replication slots it creates. To continue to use an existing replication slot after upgrading, manually add the `rs_` prefix to the slot name.
 endif::[]
 
 *Type*: `string`


### PR DESCRIPTION
## Description

Resolves [DOC-1125](https://redpandadata.atlassian.net/browse/DOC-1125)
Review deadline: 21 March

The change is related to a breaking change in the naming convention for PostgreSQL logical replication slots in Redpanda Connect.

Documentation update:

* Added a note indicating that starting from version 4.48.1, replication slot names are no longer created with the prefix `rs_`. Users who want to continue using a replication slot created by an earlier version should manually add the `rs_` prefix to the slot name.

## Page previews

[`postgres_cdc` input](https://deploy-preview-200--redpanda-connect.netlify.app/redpanda-connect/components/inputs/postgres_cdc/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1125]: https://redpandadata.atlassian.net/browse/DOC-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ