### PR TITLE
DOC-1124 Add heartbeat_interval field to postgres_cdc

### DIFF
--- a/modules/components/pages/inputs/postgres_cdc.adoc
+++ b/modules/components/pages/inputs/postgres_cdc.adoc
@@ -27,11 +27,12 @@ input:
     tables: [] # No default (required)
     checkpoint_limit: 1024
     temporary_slot: false
-    slot_name: "" # No default (optional)
+    slot_name: my_test_slot # No default (required)
     pg_standby_timeout: 10s
     pg_wal_monitor_interval: 3s
     max_parallel_snapshot_tables: 1
     unchanged_toast_value: null
+    heartbeat_interval: 1h
     auto_replay_nacks: true
     batching:
       count: 0
@@ -390,6 +391,26 @@ Specify the value to emit when unchanged <<receive-toast-and-deleted-values, TOA
 unchanged_toast_value: __redpanda_connect_unchanged_toast_value__ 
 
 unchanged_toast_value: {"$": "unchanged_toast_value"}
+```
+
+=== `heartbeat_interval`
+
+The interval between heartbeat messages, which Redpanda Connect writes to the WAL using the `pg_logical_emit_message` function. 
+
+Heartbeat messages are useful when you subscribe to data changes from tables with low activity, while other tables in the database have higher-frequency updates. Heartbeat messages allow Redpanda Connect to periodically acknowledge new messages even when no data updates occur. Each acknowledgement advances the committed point in the WAL, which ensures that PostgreSQL can safely reclaim older log segments, preventing excessive disk space usage.
+
+Set `heartbeat_interval` to `0s` to disable heartbeats.
+
+*Type*: `string`
+
+*Default*: `1h`
+
+```yml
+# Examples
+
+heartbeat_interval: 0s
+
+heartbeat_interval: 24h
 ```
 
 === `auto_replay_nacks`


### PR DESCRIPTION
## Description

Resolves DOC-1124
Review deadline: 21 March

## Page previews

`postgres_cdc` input

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)