### PR TITLE
DOC-1131 Update description of ACL migration for redpanda_migrator output

### DIFF
--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -84,7 +84,7 @@ output:
 --
 ======
 
-By default, the <<input_resource,`input_resource`>> from which topics and access control lists (ACLs) are read, is set to `redpanda_migrator_input`. If your input uses a custom label, you must update this value. 
+The default source for reading topics and access control lists (ACLs) is the <<input_resource,`input_resource`>>, which is set to `redpanda_migrator_input`. If your input uses a custom label, you must update this value.
 
 When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. If the destination broker does not contain the topic in the current message, this output attempts to create the topic along with its ACLs. If the topic already exists on the broker, only missing ACLs are migrated.
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -84,7 +84,11 @@ output:
 --
 ======
 
-You must specify the label of the associated xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] in the <<input_resource,`input_resource` field>>. When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. If the broker does not contain the current message topic, this output attempts to create the topic along with its ACLs.
+You must specify the label of the associated xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] in the <<input_resource,`input_resource` field>>. When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. 
+
+== Topic and ACL creation
+
+If the destination broker does not contain the topic in the current message, this output attempts to create the topic along with its access control lists (ACLs). If the topic already exists on the broker, only missing ACLs are migrated.
 
 ACL migration adheres to the following principles:
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -86,8 +86,6 @@ output:
 
 You must specify the label of the associated xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] in the <<input_resource,`input_resource` field>>. When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. 
 
-== Topic and ACL creation
-
 If the destination broker does not contain the topic in the current message, this output attempts to create the topic along with its access control lists (ACLs). If the topic already exists on the broker, only missing ACLs are migrated.
 
 ACL migration adheres to the following principles:

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -84,9 +84,9 @@ output:
 --
 ======
 
-You must specify the label of the associated xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] in the <<input_resource,`input_resource` field>>. When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. 
+By default, the <<input_resource,`input_resource`>> from which topics and access control lists (ACLs) are read, is set to `redpanda_migrator_input`. If your input uses a custom label, you must update this value. 
 
-If the destination broker does not contain the topic in the current message, this output attempts to create the topic along with its access control lists (ACLs). If the topic already exists on the broker, only missing ACLs are migrated.
+When connected, this output queries the `redpanda_migrator` input for topic and ACL configurations. If the destination broker does not contain the topic in the current message, this output attempts to create the topic along with its ACLs. If the topic already exists on the broker, only missing ACLs are migrated.
 
 ACL migration adheres to the following principles:
 
@@ -586,7 +586,7 @@ The maximum number of batches to send in parallel at any given time.
 
 === `input_resource`
 
-The label of the xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] from which to read the configurations of topics and ACLs for creation.
+The xref:components:inputs/redpanda_migrator.adoc[`redpanda_migrator` input] used to read topics and ACLs. If your input has a custom label, update this field to match the custom label value.
 
 *Type*: `string`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1131](https://redpandadata.atlassian.net/browse/DOC-1131)
Review deadline: 21 March

This pull request includes a change to the `modules/components/pages/outputs/redpanda_migrator.adoc` file to clarify the behavior of the `redpanda_migrator` output when handling topics and ACLs.

Documentation update:

* [`modules/components/pages/outputs/redpanda_migrator.adoc`](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4L87-R89): Clarified that if the destination broker already has the topic, only the missing ACLs are migrated, and if the topic does not exist, it is created along with its ACLs.

## Page previews

[`redpanda_migrator` output](https://deploy-preview-203--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1131]: https://redpandadata.atlassian.net/browse/DOC-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ