### PR TITLE
DOC-1116 Load license enterprise license key from environment variable

### DIFF
--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -59,5 +59,5 @@ You can view the license key’s expiration date at any time in the Redpanda Con
 
 ```
 INFO Running main config from specified file       @service=benthos benthos_version=4.50.0 path=connect_2.yaml
-INFO Successfully loaded Redpanda license          @service=benthos expires_at="2025-04-18T15:41:56+01:00" license_org=67XXX license_type="free trial"
+INFO Successfully loaded Redpanda license          @service=benthos expires_at="2025-04-18T15:41:56+01:00" license_org=67XXX license_type="enterprise"
 ```

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -33,23 +33,31 @@ When you have downloaded the license key, you can apply it in the following ways
 If you have a license key file, either:
 
 - Save the license key to the following directory: `/etc/redpanda/redpanda.license`. 
-- Set the environment variable: `$\{REDPANDA_LICENSE_FILEPATH}` to point to the file where the license key is stored.
+- Set the environment variable `REDPANDA_LICENSE_FILEPATH` to point to the file where the license key is stored.
 
-=== Apply the license using an inline license string
+=== Apply the license using a license string
 
-If you do not have a license key file, run the following command using the full license string.
+If you do not have a license key file, either:
 
+- Set the environment variable `REDPANDA_LICENSE` to the value of the full license string.
+- Run the following command using the full license string.
++
 ```bash
 rpk connect run --redpanda-license <license-string> ./<connect-configuration>.yaml
 ```
-
++
 Replace the following placeholders: 
 
-- `<license-string>`: The full license key string.
-- `<connect-configuration>`: The name of your Redpanda Connect configuration file.
+  ** `<license-string>`: The full license key string.
+  ** `<connect-configuration>`: The name of your Redpanda Connect configuration file.
 
 == Verify a license
 
 Redpanda Connect checks the license key status at runtime. If the license key is unavailable or has expired, you are blocked from using enterprise connectors.
 
-You can view the license key’s expiration date at any time in the Redpanda Connect logs.
+You can view the license key’s expiration date at any time in the Redpanda Connect logs:
+
+```
+INFO Running main config from specified file       @service=benthos benthos_version=4.50.0 path=connect_2.yaml
+INFO Successfully loaded Redpanda license          @service=benthos expires_at="2025-04-18T15:41:56+01:00" license_org=67XXX license_type="free trial"
+```


### PR DESCRIPTION
## Description

Resolves [DOC-1116](https://redpandadata.atlassian.net/browse/DOC-1116)
Review deadline: 21 March

This pull request includes updates to the licensing documentation to improve clarity and provide additional instructions for applying and verifying a Redpanda license.

Documentation improvements:

* Clarified the instructions for setting the `REDPANDA_LICENSE_FILEPATH` environment variable by removing unnecessary syntax.
* Updated the section title from "Apply the license using an inline license string" to "Apply the license using a license string" for better readability.
* Added an alternative method for applying a license if a license key file is not available, including setting the `REDPANDA_LICENSE` environment variable.
* Provided an example log output to help users verify the license key’s expiration date in the Redpanda Connect logs.

## Page previews

[Enterprise Licensing](https://deploy-preview-204--redpanda-connect.netlify.app/redpanda-connect/get-started/licensing/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1116]: https://redpandadata.atlassian.net/browse/DOC-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ