### PR TITLE
DOC-1190 Extend support for FLOAT values in snowflake_streaming output

### DIFF
--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -210,7 +210,7 @@ The message data from your output must match the columns in the Snowflake table 
 | NUMBER
 | `number`, or `string` where the `string` is parsed into a `number`
 
-| FLOAT, including special values such as `NaN` (Not a Number), `-inf` (negative infinity), and `inf` (positive infinity)
+| FLOAT, including special values, such as `NaN` (Not a Number), `-inf` (negative infinity), and `inf` (positive infinity)
 | `number`
 
 | BOOLEAN

--- a/modules/components/pages/outputs/snowflake_streaming.adoc
+++ b/modules/components/pages/outputs/snowflake_streaming.adoc
@@ -210,7 +210,7 @@ The message data from your output must match the columns in the Snowflake table 
 | NUMBER
 | `number`, or `string` where the `string` is parsed into a `number`
 
-| FLOAT 
+| FLOAT, including special values such as `NaN` (Not a Number), `-inf` (negative infinity), and `inf` (positive infinity)
 | `number`
 
 | BOOLEAN


### PR DESCRIPTION
## Description

Resolves DOC-1190
Review deadline: 8th April

This pull request includes an update to the documentation for Snowflake streaming outputs. The change clarifies the handling of special values for the `FLOAT` data type.

Documentation update:

* [`modules/components/pages/outputs/snowflake_streaming.adoc`](diffhunk://#diff-9434ac7730044d18599791222d3586f570c7fd47822805f631eb6c46c4b3b4ffL213-R213): Updated the `FLOAT` data type description to include special values such as `NaN` (Not a Number), `-inf` (negative infinity), and `inf` (positive infinity).

## Page previews

[`snowflake_streaming` output](https://deploy-preview-214--redpanda-connect.netlify.app/redpanda-connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)