### PR TITLE
DOC-1215 Add translate ID fields to migrator and schema_registry outputs

### DIFF
--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -611,7 +611,7 @@ The replication factor for created topics. This is only used when `replication_f
 
 === `translate_schema_ids`
 
-When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry. The updated message is then written to the destination schema registry.
+When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -72,7 +72,7 @@ output:
     input_resource: redpanda_migrator_input
     replication_factor_override: true
     replication_factor: 3
-    translate_schema_ids: true
+    translate_schema_ids: false
     schema_registry_output_resource: schema_registry_output
     idempotent_write: true
     compression: "" # No default (optional)
@@ -611,11 +611,11 @@ The replication factor for created topics. This is only used when `replication_f
 
 === `translate_schema_ids`
 
-When set to `true`, this field translates the schema ID in each message ready to write to the destination schema registry.
+When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry. The updated message is then written to the destination schema registry.
 
 *Type*: `bool`
 
-*Default*: `true`
+*Default*: `false`
 
 === `schema_registry_output_resource`
 

--- a/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
@@ -45,7 +45,12 @@ The xref:components:outputs/schema_registry.adoc[`schema_registry` output] confi
 
 === `translate_schema_ids`
 
-When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry. The updated message is then written to the destination schema registry.
+When set to `true`, this field enables:
+
+- The `translate_schema_ids` field in the specified xref:components:outputs/redpanda_migrator.adoc#translate_schema_ids[`redpanda_migrator` output].
+- The `translate_ids` field in the specified xref:components:outputs/schema_registry.adoc#translate_ids[`schema_registry` output].
+
+When set to `false`, both fields are disabled.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator_bundle.adoc
@@ -25,6 +25,7 @@ output:
   redpanda_migrator_bundle:
     redpanda_migrator: {} # No default (required)
     schema_registry: {} # No default (optional)
+    translate_schema_ids: false
 ```
 
 == Fields
@@ -40,7 +41,14 @@ The xref:components:outputs/redpanda_migrator.adoc[`redpanda_migrator` output] c
 
 The xref:components:outputs/schema_registry.adoc[`schema_registry` output] configuration. The `subject` field must be left empty.
 
-
 *Type*: `object`
+
+=== `translate_schema_ids`
+
+When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry. The updated message is then written to the destination schema registry.
+
+*Type*: `bool`
+
+*Default*: `false`
 
 // end::single-source[]

--- a/modules/components/pages/outputs/schema_registry.adoc
+++ b/modules/components/pages/outputs/schema_registry.adoc
@@ -46,6 +46,7 @@ output:
     url: "" # No default (required)
     subject: "" # No default (required)
     backfill_dependencies: true
+    translate_ids: false
     input_resource: schema_registry_input
     tls:
       enabled: false
@@ -127,6 +128,15 @@ Backfill missing schema references and previous schema versions. If set to `true
 *Type*: `bool`
 
 *Default*: `true`
+
+=== `translate_ids`
+
+When set to `true`, this field automatically translates the schema ID in each message to match the corresponding schema in the destination schema registry. The updated message is then written to the destination schema registry.
+
+*Type*: `bool`
+
+*Default*: `false`
+
 
 === `input_resource`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1215](https://redpandadata.atlassian.net/browse/DOC-1215)
Review deadline: 9th April

This pull request includes changes to the `redpanda_migrator`, `redpanda_migrator_bundle`, and `schema_registry` output configurations. The most important changes involve updating the `translate_schema_ids` and `translate_ids` fields to provide clearer descriptions and modify their default values.

Updates to `translate_schema_ids` field:

* [`modules/components/pages/outputs/redpanda_migrator.adoc`](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4L75-R75): Changed the `translate_schema_ids` field default value from `true` to `false` and updated the description to clarify its function. [[1]](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4L75-R75) [[2]](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4L614-R618)
* [`modules/components/pages/outputs/redpanda_migrator_bundle.adoc`](diffhunk://#diff-8ec5d7bb53ab4ac3cc0a168d1cb7970140b13020b8e50a7603c5cade29a4ba79R28): Added the `translate_schema_ids` field with a default value of `false` and included a detailed description. [[1]](diffhunk://#diff-8ec5d7bb53ab4ac3cc0a168d1cb7970140b13020b8e50a7603c5cade29a4ba79R28) [[2]](diffhunk://#diff-8ec5d7bb53ab4ac3cc0a168d1cb7970140b13020b8e50a7603c5cade29a4ba79L43-R53)

Addition of `translate_ids` field:

* [`modules/components/pages/outputs/schema_registry.adoc`](diffhunk://#diff-ef649b2c97df5ddffda85c88a365e28eb28fd118ec8c3b9a78e38bc8fec38371R49): Added the `translate_ids` field with a default value of `false` and provided a description to explain its purpose. [[1]](diffhunk://#diff-ef649b2c97df5ddffda85c88a365e28eb28fd118ec8c3b9a78e38bc8fec38371R49) [[2]](diffhunk://#diff-ef649b2c97df5ddffda85c88a365e28eb28fd118ec8c3b9a78e38bc8fec38371R132-R140)

## Page previews

Outputs:
- [redpanda_migrator](https://deploy-preview-215--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/)
- [redpanda_migrator_bundle](https://deploy-preview-215--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator_bundle/)
- [schema_registry](https://deploy-preview-215--redpanda-connect.netlify.app/redpanda-connect/components/outputs/schema_registry/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1215]: https://redpandadata.atlassian.net/browse/DOC-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ