### PR TITLE
DOC-1171 Add FIPS compliant install

### DIFF
--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -18,6 +18,9 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 | xref:configuration:secrets.adoc#look-up-secrets-on-a-remote-system-at-runtime[Secrets management]
 | Retrieve secrets values from a remote system, such as a secret management solution, without setting environment variables.
 
+| xref:get-started:quickstarts/rpk.adoc#fips-compliance[FIPS compliance]
+| Run Redpanda Connect using a FIPS-compliant version of `rpk`, the Redpanda command-line interface (CLI).
+
 |===
 
 == Get an enterprise license

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -12,14 +12,14 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 | https://docs.redpanda.com/redpanda-connect/components/catalog/?support=enterprise[Enterprise connectors]
 | Additional inputs, outputs, and processors available only to enterprise customers.
 
+| xref:get-started:quickstarts/rpk.adoc#fips-compliance[FIPS compliance]
+| Run Redpanda Connect using a FIPS-compliant version of `rpk`, the Redpanda command-line interface (CLI).
+
 | xref:components:redpanda/about.adoc[Redpanda Connect configuration service]
 | A configuration block that you can use to send logs and status events to a topic on a Redpanda cluster.
 
 | xref:configuration:secrets.adoc#look-up-secrets-on-a-remote-system-at-runtime[Secrets management]
 | Retrieve secrets values from a remote system, such as a secret management solution, without setting environment variables.
-
-| xref:get-started:quickstarts/rpk.adoc#fips-compliance[FIPS compliance]
-| Run Redpanda Connect using a FIPS-compliant version of `rpk`, the Redpanda command-line interface (CLI).
 
 |===
 

--- a/modules/get-started/pages/quickstarts/rpk.adoc
+++ b/modules/get-started/pages/quickstarts/rpk.adoc
@@ -2,7 +2,7 @@
 :description: pass:q[Deploy your first pipelines using Redpanda Connect and `rpk`.]
 :page-aliases: getting_started:overview.adoc, ROOT:install.adoc, guides:getting_started.adoc
 
-This guide explains how to get started with Redpanda Connect using `rpk`, the Redpanda command-line interface (CLI).
+This guide explains how to get started with Redpanda Connect using `rpk`, the Redpanda command-line interface (CLI). You can also install and run `rpk` in <<fips-compliance,FIPS compliance mode>>.
 
 == Install
 
@@ -19,6 +19,106 @@ If you want to use `rpk` to also communicate with a Redpanda cluster, ensure the
 === Linux
 
 include::ROOT:get-started:partial$install-rpk-linux.adoc[]
+
+==== FIPS compliance
+
+To use a FIPS-compliant version of `rpk` only, you must install the `redpanda-fips` and `redpanda-rpk-fips` packages, which are separate from but dependent on the  `redpanda` package. You must also install the `redpanda-tuners` package, and the Redpanda Connect binary.
+
+For full information about the contents of FIPS packages, see xref:ROOT:deploy:deployment-option/self-hosted/manual/production/dev-deployment.adoc#install-redpanda-for-fips-compliance[Install Redpanda for FIPS compliance].
+
+[tabs]
+=====
+RHEL::
++
+--
+Replace all `<version>` placeholders with the full version number, for example: `4.50.0`.
+
+. To make sure your distribution is up to date, run:
++
+[,bash]
+----
+sudo dnf upgrade
+----
+. Add `redpanda` to your `dnf` list of repositories. 
++
+[,bash]
+----
+curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | \
+sudo -E bash
+----
+. Install Redpanda packages for FIPS compliance.
++
+[,bash]
+----
+sudo dnf install -y redpanda redpanda-tuner redpanda-fips redpanda-rpk-fips 
+----
+. Download the Redpanda Connect binary.
++
+[,bash]
+----
+curl -LO https://github.com/redpanda-data/connect/releases/download/v<version>/redpanda-connect-fips-<version>-1.x86_64.rpm
+----
+
+. Install the downloaded binary.
++
+[,bash]
+----
+sudo dnf install ./redpanda-connect-fips-<version>-1.x86_64.rpm
+----
+. Verify your installation.
++
+[,bash]
+----
+rpk connect --version
+----
+
+--
+Debian/Ubuntu::
++
+--
+Replace all `<version>` placeholders with the full version number, for example: `4.50.0`.
+
+. To make sure your distribution is up to date, run:
++
+[,bash]
+----
+sudo apt upgrade 
+----
+. Add `redpanda` to your `apt` list of repositories. 
++
+[,bash]
+----
+curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | sudo -E bash 
+----
+. Install Redpanda packages for FIPS compliance.
++
+[,bash]
+----
+sudo apt install -y redpanda redpanda-tuner redpanda-fips redpanda-rpk-fips 
+----
+. Download the Redpanda Connect binary.
++
+[,bash]
+----
+curl -LO https://github.com/redpanda-data/connect/releases/download/v<version>/redpanda-connect-fips_<version>_amd64.deb
+----
+
+. Install the downloaded binary.
++
+[,bash]
+----
+sudo dpkg -i redpanda-connect-fips_<version>_amd64.deb
+----
+
+. Verify your installation:
++
+[,bash]
+----
+rpk connect --version
+----
+
+--
+=====
 
 === MacOS
 

--- a/modules/get-started/pages/quickstarts/rpk.adoc
+++ b/modules/get-started/pages/quickstarts/rpk.adoc
@@ -24,17 +24,9 @@ include::ROOT:get-started:partial$install-rpk-linux.adoc[]
 
 include::components:partial$enterprise_feature_note.adoc[]
 
-To install `rpk` to run the latest version of Redpanda Connect in FIPS-compliant mode, you must install the `redpanda-rpk-fips` and `redpanda-connect-fips` packages.
+To install `rpk` to run the latest version of Redpanda Connect in FIPS-compliant mode, you must install the `redpanda-rpk-fips` and `redpanda-connect-fips` packages. Both packages are built using the https://github.com/microsoft/go[Microsoft GoLang compiler^] and the https://github.com/microsoft/go-crypto-openssl[Microsoft’s Go Crypto OpenSSL package^], which uses the FIPS-approved version of OpenSSL.
 
-`redpanda-rpk-fips`
-
-Contains a version of `rpk` built with the https://github.com/microsoft/go[Microsoft GoLang compiler^] and https://github.com/microsoft/go-crypto-openssl[Microsoft’s Go Crypto OpenSSL package^] to which `rpk` is linked, and uses the FIPS-approved version of OpenSSL.
-
-`redpanda-connect-fips`
-
-TODO
-
-IMPORTANT: The package for FIPS-compliant `rpk` (`redpanda-rpk-fips`) and Redpanda `rpk` (`redpanda-rpk`) are mutually exclusive, and so cannot be installed in the same environment.
+IMPORTANT: The packages for FIPS-compliant `rpk` (`redpanda-rpk-fips`) and Redpanda `rpk` (`redpanda-rpk`) are mutually exclusive, and so cannot be installed in the same environment.
 
 [tabs]
 =====
@@ -68,6 +60,13 @@ sudo dnf install -y redpanda-rpk-fips redpanda-connect-fips
 rpk connect --version
 ----
 
+To keep up-to-date with Redpanda Connect releases, run the following command:
+
+[,bash]
+----
+sudo dnf update
+----
+
 --
 Debian/Ubuntu::
 +
@@ -95,6 +94,13 @@ sudo apt install -y redpanda-rpk-fips redpanda-connect-fips
 [,bash]
 ----
 rpk connect --version
+----
+
+To keep up-to-date with the Redpanda Connect releases, run the following command:
+
+[,bash]
+----
+sudo apt update
 ----
 
 --

--- a/modules/get-started/pages/quickstarts/rpk.adoc
+++ b/modules/get-started/pages/quickstarts/rpk.adoc
@@ -22,17 +22,25 @@ include::ROOT:get-started:partial$install-rpk-linux.adoc[]
 
 ==== FIPS compliance
 
-To use a FIPS-compliant version of `rpk` only, you must install the `redpanda-fips` and `redpanda-rpk-fips` packages, which are separate from but dependent on the  `redpanda` package. You must also install the `redpanda-tuners` package, and the Redpanda Connect binary.
+include::components:partial$enterprise_feature_note.adoc[]
 
-For full information about the contents of FIPS packages, see xref:ROOT:deploy:deployment-option/self-hosted/manual/production/dev-deployment.adoc#install-redpanda-for-fips-compliance[Install Redpanda for FIPS compliance].
+To install `rpk` to run the latest version of Redpanda Connect in FIPS-compliant mode, you must install the `redpanda-rpk-fips` and `redpanda-connect-fips` packages.
+
+`redpanda-rpk-fips`
+
+Contains a version of `rpk` built with the https://github.com/microsoft/go[Microsoft GoLang compiler^] and https://github.com/microsoft/go-crypto-openssl[Microsoft’s Go Crypto OpenSSL package^] to which `rpk` is linked, and uses the FIPS-approved version of OpenSSL.
+
+`redpanda-connect-fips`
+
+TODO
+
+IMPORTANT: The package for FIPS-compliant `rpk` (`redpanda-rpk-fips`) and Redpanda `rpk` (`redpanda-rpk`) are mutually exclusive, and so cannot be installed in the same environment.
 
 [tabs]
 =====
 RHEL::
 +
 --
-Replace all `<version>` placeholders with the full version number, for example: `4.50.0`.
-
 . To make sure your distribution is up to date, run:
 +
 [,bash]
@@ -50,21 +58,9 @@ sudo -E bash
 +
 [,bash]
 ----
-sudo dnf install -y redpanda redpanda-tuner redpanda-fips redpanda-rpk-fips 
-----
-. Download the Redpanda Connect binary.
-+
-[,bash]
-----
-curl -LO https://github.com/redpanda-data/connect/releases/download/v<version>/redpanda-connect-fips-<version>-1.x86_64.rpm
+sudo dnf install -y redpanda-rpk-fips redpanda-connect-fips
 ----
 
-. Install the downloaded binary.
-+
-[,bash]
-----
-sudo dnf install ./redpanda-connect-fips-<version>-1.x86_64.rpm
-----
 . Verify your installation.
 +
 [,bash]
@@ -76,8 +72,6 @@ rpk connect --version
 Debian/Ubuntu::
 +
 --
-Replace all `<version>` placeholders with the full version number, for example: `4.50.0`.
-
 . To make sure your distribution is up to date, run:
 +
 [,bash]
@@ -94,23 +88,9 @@ curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb
 +
 [,bash]
 ----
-sudo apt install -y redpanda redpanda-tuner redpanda-fips redpanda-rpk-fips 
+sudo apt install -y redpanda-rpk-fips redpanda-connect-fips 
 ----
-. Download the Redpanda Connect binary.
-+
-[,bash]
-----
-curl -LO https://github.com/redpanda-data/connect/releases/download/v<version>/redpanda-connect-fips_<version>_amd64.deb
-----
-
-. Install the downloaded binary.
-+
-[,bash]
-----
-sudo dpkg -i redpanda-connect-fips_<version>_amd64.deb
-----
-
-. Verify your installation:
+. Verify your installation.
 +
 [,bash]
 ----


### PR DESCRIPTION
## Description

Resolves [DOC-1171](https://redpandadata.atlassian.net/browse/DOC-1171)
Review deadline: 15th April

Related PR: [https://github.com/redpanda-data/docs/pull/1072](https://github.com/redpanda-data/docs/pull/1072)

This pull request includes updates to the documentation for Redpanda Connect, focusing on FIPS compliance. The changes add new information about installing and running `rpk` in FIPS-compliant mode.

Documentation updates:

* [`modules/get-started/pages/licensing.adoc`](diffhunk://#diff-957cb35762068e6af2e15629ce74d3142be85fc53665c9effe13e263d1c94351R21-R23): Added a reference to FIPS compliance in the enterprise features section.
* [`modules/get-started/pages/quickstarts/rpk.adoc`](diffhunk://#diff-59440aa7b0032e1e9f98d026e0685b11fa9aa60605bcf8d85d352175d7b97f6fL5-R5): Updated the guide to include instructions for installing and running `rpk` in FIPS-compliant mode. [[1]](diffhunk://#diff-59440aa7b0032e1e9f98d026e0685b11fa9aa60605bcf8d85d352175d7b97f6fL5-R5) [[2]](diffhunk://#diff-59440aa7b0032e1e9f98d026e0685b11fa9aa60605bcf8d85d352175d7b97f6fR23-R102)

## Page previews

[Get Started with Redpanda Connect using rpk](https://deploy-preview-217--redpanda-connect.netlify.app/redpanda-connect/get-started/quickstarts/rpk/#fips-compliance)

[Enterprise Licensing](https://deploy-preview-217--redpanda-connect.netlify.app/redpanda-connect/get-started/licensing/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1171]: https://redpandadata.atlassian.net/browse/DOC-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about FIPS compliance as a new enterprise feature for Redpanda Connect.
  - Updated quickstart instructions to include steps for installing and running the `rpk` CLI in FIPS compliance mode on Linux.
  - Improved formatting of license application command examples for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->