### PR TITLE
Fix docs for the ockam_kafka input

### DIFF
--- a/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/modules/components/pages/inputs/ockam_kafka.adoc
@@ -362,7 +362,7 @@ Whether to consume from the oldest available offset. Otherwise, messages are con
 
 *Default*: `true`
 
-=== `fetch_max_bytes`
+=== `kafka.fetch_max_bytes`
 
 The maximum size of a message batch (in bytes) that a broker tries to send during a client fetch. If individual records exceed the `fetch_max_bytes` value, brokers will still send them.
 
@@ -371,7 +371,7 @@ The maximum size of a message batch (in bytes) that a broker tries to send durin
 
 *Default*: `50MiB`
 
-=== `fetch_max_wait`
+=== `kafka.fetch_max_wait`
 
 The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`).
 
@@ -379,7 +379,7 @@ The maximum period of time a broker can wait for a fetch response to reach the r
 
 *Default*: `5s`
 
-=== `fetch_min_bytes`
+=== `kafka.fetch_min_bytes`
 
 The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`.
 
@@ -387,7 +387,7 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 *Default*: `1B`
 
-=== `fetch_max_partition_bytes`
+=== `kafka.fetch_max_partition_bytes`
 
 The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.
 

--- a/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/modules/components/pages/inputs/ockam_kafka.adoc
@@ -39,6 +39,7 @@ input:
     allow_producer: self
     relay: "" # No default (optional)
     node_address: 127.0.0.1:6262
+    encrypted_fields: []
 ```
 --
 Advanced::
@@ -80,15 +81,15 @@ input:
         period: "" # No default (optional)
         check: "" # No default (optional)
         processors: [] # No default (optional)
-      disable_content_encryption: false
-      enrollment_ticket: "" # No default (optional)
-      identity_name: "" # No default (optional)
-      allow: self
-      route_to_kafka_outlet: self
-      allow_producer: self
-      relay: "" # No default (optional)
-      node_address: 127.0.0.1:6262
-      encrypted_fields: []
+    disable_content_encryption: false
+    enrollment_ticket: "" # No default (optional)
+    identity_name: "" # No default (optional)
+    allow: self
+    route_to_kafka_outlet: self
+    allow_producer: self
+    relay: "" # No default (optional)
+    node_address: 127.0.0.1:6262
+    encrypted_fields: []
 ```
 --
 ======


### PR DESCRIPTION
See details here: https://github.com/redpanda-data/connect/blob/main/docs/modules/components/pages/inputs/ockam_kafka.adoc

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)