### PR TITLE
DOC-1233 Add private_key field to SFTP input and output

### DIFF
--- a/modules/components/pages/inputs/sftp.adoc
+++ b/modules/components/pages/inputs/sftp.adoc
@@ -23,16 +23,17 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   sftp:
     address: "" # No default (required)
     credentials:
-      username: ""
-      password: ""
-      private_key_file: ""
-      private_key_pass: ""
+      username: "" # No default (optional)
+      password: "" # No default (optional)
+      private_key_file: "" # No default (optional)
+      private_key: "" # No default (optional)
+      private_key_pass: "" # No default (optional)
     paths: [] # No default (required)
     auto_replay_nacks: true
     scanner:
@@ -41,7 +42,7 @@ input:
       enabled: false
       minimum_age: 1s
       poll_interval: 1s
-      cache: ""
+      cache: "" # No default (optional)
 ```
 
 --
@@ -50,16 +51,17 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   sftp:
     address: "" # No default (required)
     credentials:
-      username: ""
-      password: ""
-      private_key_file: ""
-      private_key_pass: ""
+      username: "" # No default (optional)
+      password: "" # No default (optional)
+      private_key_file: "" # No default (optional)
+      private_key: "" # No default (optional)
+      private_key_pass: "" # No default (optional)
     paths: [] # No default (required)
     auto_replay_nacks: true
     scanner:
@@ -69,7 +71,7 @@ input:
       enabled: false
       minimum_age: 1s
       poll_interval: 1s
-      cache: ""
+      cache: "" # No default (optional)
 ```
 
 --
@@ -87,15 +89,14 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 === `address`
 
-The address of the server to connect to.
-
+The address (hostname or IP address) of the SFTP server to connect to. 
 
 *Type*: `string`
 
 
 === `credentials`
 
-The credentials to use to log into the target server.
+The credentials required to log in to the SFTP server. This can include a username and password, or a private key for secure access.
 
 
 *Type*: `object`
@@ -103,7 +104,7 @@ The credentials to use to log into the target server.
 
 === `credentials.username`
 
-The username to connect to the SFTP server.
+The username required to authenticate with the SFTP server.
 
 
 *Type*: `string`
@@ -112,10 +113,9 @@ The username to connect to the SFTP server.
 
 === `credentials.password`
 
-The password for the username to connect to the SFTP server.
+The password for the username used to authenticate with the SFTP server.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -124,8 +124,17 @@ include::components:partial$secret_warning.adoc[]
 
 === `credentials.private_key_file`
 
-The private key for the username to connect to the SFTP server.
+The path to a private key file used to authenticate with the SFTP server. You can also provide a private key using the <<credentials-private_key,`private_key`>> field.
 
+*Type*: `string`
+
+*Default*: `""`
+
+=== `credentials.private_key`
+
+The private key used to authenticate with the SFTP server. This field provides an alternative to the <<credentials-private_key_file, `private_key_file`>>.
+
+include::components:partial$secret_warning.adoc[]
 
 *Type*: `string`
 
@@ -133,10 +142,9 @@ The private key for the username to connect to the SFTP server.
 
 === `credentials.private_key_pass`
 
-Optional passphrase for private key.
+A passphrase for the private key.
 
 include::components:partial$secret_warning.adoc[]
-
 
 *Type*: `string`
 
@@ -145,7 +153,6 @@ include::components:partial$secret_warning.adoc[]
 === `paths`
 
 A list of paths to consume sequentially. Glob patterns are supported.
-
 
 *Type*: `array`
 

--- a/modules/components/pages/outputs/sftp.adoc
+++ b/modules/components/pages/outputs/sftp.adoc
@@ -17,7 +17,7 @@ Introduced in version 3.39.0.
 endif::[]
 
 ```yml
-# Config fields, showing default values
+# Configuration fields, showing default values
 output:
   label: ""
   sftp:
@@ -25,10 +25,11 @@ output:
     path: "" # No default (required)
     codec: all-bytes
     credentials:
-      username: ""
-      password: ""
-      private_key_file: ""
-      private_key_pass: ""
+      username: "" # No default (optional)
+      password: "" # No default (optional)
+      private_key_file: "" # No default (optional)
+      private_key: "" # No default (optional)
+      private_key_pass: "" # No default (optional)
     max_in_flight: 64
 ```
 
@@ -42,16 +43,13 @@ This output benefits from sending multiple messages in flight in parallel for im
 
 === `address`
 
-The address of the server to connect to.
-
+The address (hostname or IP address) of the SFTP server to connect to.
 
 *Type*: `string`
 
-
 === `path`
 
-The file to save the messages to on the server.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+The file to save the messages to on the SFTP server. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 
 *Type*: `string`
@@ -92,15 +90,14 @@ codec: delim:foobar
 
 === `credentials`
 
-The credentials to use to log into the target server.
-
+The credentials required to log in to the SFTP server. This can include a username and password, or a private key for secure access.
 
 *Type*: `object`
 
 
 === `credentials.username`
 
-The username to connect to the SFTP server.
+The username required to authenticate with the SFTP server.
 
 
 *Type*: `string`
@@ -109,10 +106,9 @@ The username to connect to the SFTP server.
 
 === `credentials.password`
 
-The password for the username to connect to the SFTP server.
+The password for the username used to authenticate with the SFTP server.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -121,16 +117,25 @@ include::components:partial$secret_warning.adoc[]
 
 === `credentials.private_key_file`
 
-The private key for the username to connect to the SFTP server.
-
+The path to a private key file used to authenticate with the SFTP server. You can also provide a private key using the <<credentials-private_key,`private_key`>> field.
 
 *Type*: `string`
 
 *Default*: `""`
 
+=== `credentials.private_key`
+
+The private key used to authenticate with the SFTP server. This field provides an alternative to the <<`credentials-private_key_file`,`private_key_file`>>.
+
+include::components:partial$secret_warning.adoc[]
+
+
+*Type*: `string`
+
+
 === `credentials.private_key_pass`
 
-Optional passphrase for private key.
+A passphrase for private key.
 
 include::components:partial$secret_warning.adoc[]
 

--- a/modules/components/pages/outputs/sftp.adoc
+++ b/modules/components/pages/outputs/sftp.adoc
@@ -125,7 +125,7 @@ The path to a private key file used to authenticate with the SFTP server. You ca
 
 === `credentials.private_key`
 
-The private key used to authenticate with the SFTP server. This field provides an alternative to the <<`credentials-private_key_file`,`private_key_file`>>.
+The private key used to authenticate with the SFTP server. This field provides an alternative to the <<credentials-private_key_file, `private_key_file`>>.
 
 include::components:partial$secret_warning.adoc[]
 


### PR DESCRIPTION
## Description

Resolves [DOC-1233](https://redpandadata.atlassian.net/browse/DOC-1233)
Review deadline: 14th April

This pull request includes updates to the SFTP input and output documentation to improve clarity and provide additional details on configuration fields.

### Documentation Improvements:

* [`modules/components/pages/inputs/sftp.adoc`](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L26-R36): Updated descriptions for configuration fields, including specifying that certain fields like `username`, `password`, `private_key_file`, `private_key`, and `private_key_pass` are optional and have no defaults. Enhanced descriptions for `address` and `credentials` fields to provide more clarity. [[1]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L26-R36) [[2]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L44-R45) [[3]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L53-R64) [[4]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L72-R74) [[5]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L90-R107) [[6]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L115-L140) [[7]](diffhunk://#diff-756b688eae27f6173648729c5612ea14546edb32611c88f9732977fa3431dcd0L149)

* [`modules/components/pages/outputs/sftp.adoc`](diffhunk://#diff-39c20a6044cd2201969a2d1d1a77b5daf4e69c330bd0f16d7304fd42e9a0e5f8L20-R32): Similar updates as the inputs documentation, including specifying that certain fields are optional and have no defaults, and providing more detailed descriptions for `address`, `credentials`, and related fields. [[1]](diffhunk://#diff-39c20a6044cd2201969a2d1d1a77b5daf4e69c330bd0f16d7304fd42e9a0e5f8L20-R32) [[2]](diffhunk://#diff-39c20a6044cd2201969a2d1d1a77b5daf4e69c330bd0f16d7304fd42e9a0e5f8L45-R52) [[3]](diffhunk://#diff-39c20a6044cd2201969a2d1d1a77b5daf4e69c330bd0f16d7304fd42e9a0e5f8L95-R100) [[4]](diffhunk://#diff-39c20a6044cd2201969a2d1d1a77b5daf4e69c330bd0f16d7304fd42e9a0e5f8L112-R138)

## Page previews

[`sftp` input](https://deploy-preview-219--redpanda-connect.netlify.app/redpanda-connect/components/inputs/sftp/)
[`sftp` output](https://deploy-preview-219--redpanda-connect.netlify.app/redpanda-connect/components/outputs/sftp/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1233]: https://redpandadata.atlassian.net/browse/DOC-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ