### PR TITLE
DOC-1185 Add transaction_isolation_level field to kafka_franz inputs

### DIFF
--- a/modules/components/pages/inputs/kafka_franz.adoc
+++ b/modules/components/pages/inputs/kafka_franz.adoc
@@ -30,6 +30,7 @@ input:
     seed_brokers: [] # No default (required)
     topics: [] # No default (required)
     regexp_topics: false
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     auto_replay_nacks: true
 ```
@@ -67,6 +68,7 @@ input:
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     checkpoint_limit: 1024
     commit_period: 5s
@@ -620,6 +622,28 @@ If a single batch is larger than the `fetch_max_partition_bytes` value, the batc
 *Type*: `string`
 
 *Default*: `1MiB`
+
+=== `transaction_isolation_level`
+
+Defines how transactional messages are handled.
+
+*Type*: `string`
+
+*Default*: `read_uncommitted`
+
+Options:
+
+|===
+| Option | Description
+
+| `read_uncommitted` (default)
+| Processes all messages, including uncommitted transactional records.
+
+| `read_committed`
+| Processes only committed transactional records to ensure data consistency.
+
+|===
+
 
 === `consumer_group`
 

--- a/modules/components/pages/inputs/ockam_kafka.adoc
+++ b/modules/components/pages/inputs/ockam_kafka.adoc
@@ -30,6 +30,7 @@ input:
       seed_brokers: [] # No default (optional)
       topics: [] # No default (required)
       regexp_topics: false
+      transaction_isolation_level: read_uncommitted
       consumer_group: "" # No default (optional)
     disable_content_encryption: false
     enrollment_ticket: "" # No default (optional)
@@ -71,6 +72,7 @@ input:
       fetch_max_wait: 5s
       fetch_min_bytes: 1B
       fetch_max_partition_bytes: 1MiB
+      transaction_isolation_level: read_uncommitted
       consumer_group: "" # No default (optional)
       checkpoint_limit: 1024
       commit_period: 5s
@@ -397,6 +399,26 @@ If a single batch is larger than the `fetch_max_partition_bytes` value, the batc
 
 *Default*: `1MiB`
 
+=== `kafka.transaction_isolation_level`
+
+Defines how transactional messages are handled.
+
+*Type*: `string`
+
+*Default*: `read_uncommitted`
+
+Options:
+
+|===
+| Option | Description
+
+| `read_uncommitted` (default)
+| Processes all messages, including uncommitted transactional records.
+
+| `read_committed`
+| Processes only committed transactional records to ensure data consistency.
+
+|===
 
 === `kafka.consumer_group`
 

--- a/modules/components/pages/inputs/redpanda.adoc
+++ b/modules/components/pages/inputs/redpanda.adoc
@@ -29,6 +29,7 @@ input:
     seed_brokers: [] # No default (required)
     topics: [] # No default (required)
     regexp_topics: false
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     auto_replay_nacks: true
 ```
@@ -66,6 +67,7 @@ input:
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     commit_period: 5s
     partition_buffer_bytes: 1MB
@@ -641,6 +643,27 @@ If a single batch is larger than the `fetch_max_partition_bytes` value, the batc
 *Type*: `string`
 
 *Default*: `1MiB`
+
+=== `transaction_isolation_level`
+
+Defines how transactional messages are handled.
+
+*Type*: `string`
+
+*Default*: `read_uncommitted`
+
+Options:
+
+|===
+| Option | Description
+
+| `read_uncommitted` (default)
+| Processes all messages, including uncommitted transactional records.
+
+| `read_committed`
+| Processes only committed transactional records to ensure data consistency.
+
+|===
 
 === `consumer_group`
 

--- a/modules/components/pages/inputs/redpanda_common.adoc
+++ b/modules/components/pages/inputs/redpanda_common.adoc
@@ -29,6 +29,7 @@ input:
   redpanda_common:
     topics: [] # No default (required)
     regexp_topics: false
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     auto_replay_nacks: true
 ```
@@ -55,6 +56,7 @@ input:
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     commit_period: 5s
     partition_buffer_bytes: 1MB
@@ -307,6 +309,28 @@ If a single batch is larger than the `fetch_max_partition_bytes` value, the batc
 *Type*: `string`
 
 *Default*: `1MiB`
+
+=== `transaction_isolation_level`
+
+Defines how transactional messages are handled.
+
+*Type*: `string`
+
+*Default*: `read_uncommitted`
+
+Options:
+
+|===
+| Option | Description
+
+| `read_uncommitted` (default)
+| Processes all messages, including uncommitted transactional records.
+
+| `read_committed`
+| Processes only committed transactional records to ensure data consistency.
+
+|===
+
 
 === `consumer_group`
 

--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -31,6 +31,7 @@ input:
     seed_brokers: [] # No default (required)
     topics: [] # No default (required)
     regexp_topics: false
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     auto_replay_nacks: true
 ```
@@ -67,6 +68,7 @@ input:
     fetch_max_wait: 5s
     fetch_min_bytes: 1B
     fetch_max_partition_bytes: 1MiB
+    transaction_isolation_level: read_uncommitted
     consumer_group: "" # No default (optional)
     commit_period: 5s
     metadata_max_age: 5m
@@ -618,6 +620,28 @@ If a single batch is larger than the `fetch_max_partition_bytes` value, the batc
 *Type*: `string`
 
 *Default*: `1MiB`
+
+=== `transaction_isolation_level`
+
+Defines how transactional messages are handled.
+
+*Type*: `string`
+
+*Default*: `read_uncommitted`
+
+Options:
+
+|===
+| Option | Description
+
+| `read_uncommitted` (default)
+| Processes all messages, including uncommitted transactional records.
+
+| `read_committed`
+| Processes only committed transactional records to ensure data consistency.
+
+|===
+
 
 === `consumer_group`
 


### PR DESCRIPTION
## Description

Resolves: [DOC-1185](https://redpandadata.atlassian.net/browse/DOC-1185)
Review deadline: 17th April

This pull request introduces a new configuration parameter, `transaction_isolation_level`, to various Kafka-related input components. This parameter allows users to define how transactional messages are handled, with options for `read_uncommitted` and `read_committed`.

Key changes include:

### Addition of `transaction_isolation_level` parameter:

* Added `transaction_isolation_level` with default value `read_uncommitted` to the configuration sections of `kafka_franz.adoc`, `ockam_kafka.adoc`, `redpanda.adoc`, `redpanda_common.adoc`, and `redpanda_migrator.adoc`. [[1]](diffhunk://#diff-c55e6421afcaf7431ce2afeb374be459609e5fda08967092afe26b4007d41c18R33) [[2]](diffhunk://#diff-c55e6421afcaf7431ce2afeb374be459609e5fda08967092afe26b4007d41c18R71) [[3]](diffhunk://#diff-28bae536b9be2da81e36d6d6dcb0fff7e6f9dc4ac8ee74c0c4d8c221cba492beR33) [[4]](diffhunk://#diff-28bae536b9be2da81e36d6d6dcb0fff7e6f9dc4ac8ee74c0c4d8c221cba492beR75) [[5]](diffhunk://#diff-4ca4928f29b3b61ba8ca640fca70857d6490d70ea5f08052d891055752384a51R32) [[6]](diffhunk://#diff-4ca4928f29b3b61ba8ca640fca70857d6490d70ea5f08052d891055752384a51R70) [[7]](diffhunk://#diff-6de99cc42924c40d15f80ad8753d2b4c41503d2e9ec5156585fc7759b556c1caR32) [[8]](diffhunk://#diff-6de99cc42924c40d15f80ad8753d2b4c41503d2e9ec5156585fc7759b556c1caR59) [[9]](diffhunk://#diff-303929f5e3c124412009e62e373435c143b51794b49a8a46212797607df1565fR34) [[10]](diffhunk://#diff-303929f5e3c124412009e62e373435c143b51794b49a8a46212797607df1565fR71)

### Documentation updates:

* Added detailed descriptions for the `transaction_isolation_level` parameter, including its type, default value, and available options (`read_uncommitted` and `read_committed`), to the respective documentation files. [[1]](diffhunk://#diff-c55e6421afcaf7431ce2afeb374be459609e5fda08967092afe26b4007d41c18R626-R647) [[2]](diffhunk://#diff-28bae536b9be2da81e36d6d6dcb0fff7e6f9dc4ac8ee74c0c4d8c221cba492beR402-R421) [[3]](diffhunk://#diff-4ca4928f29b3b61ba8ca640fca70857d6490d70ea5f08052d891055752384a51R647-R667) [[4]](diffhunk://#diff-6de99cc42924c40d15f80ad8753d2b4c41503d2e9ec5156585fc7759b556c1caR313-R334) [[5]](diffhunk://#diff-303929f5e3c124412009e62e373435c143b51794b49a8a46212797607df1565fR624-R645)

## Page previews

Inputs:

[`kafka_franz`](https://deploy-preview-220--redpanda-connect.netlify.app/redpanda-connect/components/inputs/kafka_franz/)
[`ockam_kafka`](https://deploy-preview-220--redpanda-connect.netlify.app/redpanda-connect/components/inputs/ockam_kafka/)
[`redpanda`](https://deploy-preview-220--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda/)
[`redpanda_common`](https://deploy-preview-220--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_common/)
[`redpanda_migrator`](https://deploy-preview-220--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda_migrator/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1185]: https://redpandadata.atlassian.net/browse/DOC-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ