### PR TITLE
Add an example of `fields` to redis_hash

### DIFF
--- a/modules/components/pages/outputs/redis_hash.adoc
+++ b/modules/components/pages/outputs/redis_hash.adoc
@@ -353,6 +353,14 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 *Default*: `{}`
 
+```yml
+# Examples
+
+fields:
+  foo: "${!this.foo}"
+  bar: "pew-${!this.bar.trim_prefix("sku-")}"
+```
+
 === `max_in_flight`
 
 The maximum number of messages to have in flight at a given time. Increase this to improve throughput.


### PR DESCRIPTION
Found this question in the kapa dashboard and it's clear an example is missing.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)