### PR TITLE
DOC-1246 Add aggregate option to mongodb output and processor

### DIFF
--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -255,7 +255,7 @@ hint_map: |-
 
 === `upsert`
 
-The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches the `upsert` value, the document is updated or replaced, otherwise it is created.
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise the document is created.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -255,7 +255,7 @@ hint_map: |-
 
 === `upsert`
 
-The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise the document is created.
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise a new document is created.
 
 *Type*: `bool`
 

--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -237,7 +237,7 @@ filter_map: |-
 
 === `hint_map`
 
-A bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
+A Bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
 
 Define a `hint_map` to improve performance when finding documents in the MongoDB database.
 

--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -21,30 +21,30 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 output:
   label: ""
   mongodb:
     url: mongodb://localhost:27017 # No default (required)
     database: "" # No default (required)
-    username: ""
-    password: ""
+    username: "" # No default (optional)
+    password: "" # No default (optional)
     collection: "" # No default (required)
     operation: update-one
     write_concern:
-      w: ""
+      w: "" # No default (optional)
       j: false
-      w_timeout: ""
-    document_map: ""
-    filter_map: ""
-    hint_map: ""
+      w_timeout: "" # No default (optional)
+    document_map: "" # No default (optional)
+    filter_map: "" # No default (optional)
+    hint_map: "" # No default (optional)
     upsert: false
     max_in_flight: 64
     batching:
       count: 0
       byte_size: 0
-      period: ""
-      check: ""
+      period: "" # No default (optional)
+      check: "" # No default (optional)
 ```
 
 --
@@ -53,31 +53,31 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 output:
   label: ""
   mongodb:
     url: mongodb://localhost:27017 # No default (required)
     database: "" # No default (required)
-    username: ""
-    password: ""
+    username: "" # No default (optional)
+    password: "" # No default (optional)
     app_name: benthos
     collection: "" # No default (required)
     operation: update-one
     write_concern:
-      w: ""
+      w: "" # No default (optional)
       j: false
-      w_timeout: ""
-    document_map: ""
-    filter_map: ""
-    hint_map: ""
+      w_timeout: "" # No default (optional)
+    document_map: "" # No default (optional)
+    filter_map: "" # No default (optional)
+    hint_map: "" # No default (optional)
     upsert: false
     max_in_flight: 64
     batching:
       count: 0
       byte_size: 0
-      period: ""
-      check: ""
+      period: "" # No default (optional)
+      check: "" # No default (optional)
       processors: [] # No default (optional)
 ```
 
@@ -87,9 +87,9 @@ output:
 
 == Performance
 
-This output benefits from sending multiple messages in flight in parallel for improved performance. You can tune the max number of in flight messages (or message batches) with the field `max_in_flight`.
+This output benefits from sending multiple messages in flight, in parallel, for improved performance. You can tune the maximum number of in flight messages (or message batches) using the `max_in_flight` field.
 
-This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. You can find out more xref:configuration:batching.adoc[in this doc].
+This output benefits from sending messages as a batch for improved performance. Batches can be formed at both the input and output level. For more information, see xref:configuration:batching.adoc[Message Batching].
 
 == Fields
 
@@ -117,7 +117,7 @@ The name of the target MongoDB database.
 
 === `username`
 
-The username to connect to the database.
+The username required to connect to the database.
 
 
 *Type*: `string`
@@ -126,10 +126,9 @@ The username to connect to the database.
 
 === `password`
 
-The password to connect to the database.
+The password required to connect to the database.
 
 include::components:partial$secret_warning.adoc[]
-
 
 
 *Type*: `string`
@@ -140,10 +139,10 @@ include::components:partial$secret_warning.adoc[]
 
 The client application name.
 
-
 *Type*: `string`
 
-*Default*: `"benthos"`
+*Default*: `benthos`
+
 
 === `collection`
 
@@ -155,12 +154,11 @@ The name of the target collection. This field supports xref:configuration:interp
 
 === `operation`
 
-The mongodb operation to perform.
-
+The MongoDB database operation to perform.
 
 *Type*: `string`
 
-*Default*: `"update-one"`
+*Default*: `update-one`
 
 Options:
 `insert-one`
@@ -168,19 +166,18 @@ Options:
 , `delete-many`
 , `replace-one`
 , `update-one`
-.
+, `aggregate`
 
 === `write_concern`
 
-The write concern settings for the mongo connection.
-
+The https://www.mongodb.com/docs/manual/reference/write-concern/[write concern settings^] for the MongoDB connection.
 
 *Type*: `object`
 
 
 === `write_concern.w`
 
-W requests acknowledgement that write operations propagate to the specified number of mongodb instances.
+The `w` requests acknowledgement, which write operations propagate to the specified number of MongoDB instances.
 
 
 *Type*: `string`
@@ -189,8 +186,7 @@ W requests acknowledgement that write operations propagate to the specified numb
 
 === `write_concern.j`
 
-J requests acknowledgement from MongoDB that write operations are written to the journal.
-
+The `j` requests acknowledgement from MongoDB, which is created when write operations are written to the journal.
 
 *Type*: `bool`
 
@@ -207,7 +203,7 @@ The write concern timeout.
 
 === `document_map`
 
-A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one and update-one.
+A Bloblang map that represents a document to store in MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `document_map` parameter is required for the following database operations: `insert-one`, `replace-one`, `update-one`, and `aggregate`.
 
 
 *Type*: `string`
@@ -224,8 +220,9 @@ document_map: |-
 
 === `filter_map`
 
-A bloblang map representing a filter for a MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The filter map is required for all operations except insert-one. It is used to find the document(s) for the operation. For example in a delete-one case, the filter map should have the fields required to locate the document to delete.
+A Bloblang map that represents a filter for a MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `filter_map` parameter is required for all database operations except `insert-one`. 
 
+This output uses `filter_map` to find documents for the specified operation. For example, for a `delete-one` operation, the filter map should include the fields required to locate the document for deletion.
 
 *Type*: `string`
 
@@ -241,8 +238,9 @@ filter_map: |-
 
 === `hint_map`
 
-A bloblang map representing the hint for the MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional and is used with all operations except insert-one. It is used to improve performance of finding the documents in the mongodb.
+A bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
 
+Define a `hint_map` to improve performance when finding documents in the MongoDB database.
 
 *Type*: `string`
 
@@ -258,17 +256,17 @@ hint_map: |-
 
 === `upsert`
 
-The upsert setting is optional and only applies for update-one and replace-one operations. If the filter specified in filter_map matches, the document is updated or replaced accordingly, otherwise it is created.
-
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches the `upsert` value, the document is updated or replaced, otherwise it is created.
 
 *Type*: `bool`
 
 *Default*: `false`
+
 Requires version 3.60.0 or newer
 
 === `max_in_flight`
 
-The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
+The maximum number of messages to have in flight at a given time. Increase this number to improve throughput.
 
 
 *Type*: `int`
@@ -303,8 +301,7 @@ batching:
 
 === `batching.count`
 
-A number of messages at which the batch should be flushed. If `0` disables count based batching.
-
+The number of messages after which the batch is flushed. Set to `0` to disable count-based batching.
 
 *Type*: `int`
 
@@ -312,8 +309,7 @@ A number of messages at which the batch should be flushed. If `0` disables count
 
 === `batching.byte_size`
 
-An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
-
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -321,7 +317,7 @@ An amount of bytes at which the batch should be flushed. If `0` disables size ba
 
 === `batching.period`
 
-A period in which an incomplete batch should be flushed regardless of its size.
+The period after which an incomplete batch is flushed regardless of its size.
 
 
 *Type*: `string`
@@ -355,7 +351,7 @@ check: this.type == "end_of_transaction"
 
 === `batching.processors`
 
-A list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
+For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches.
 
 
 *Type*: `array`

--- a/modules/components/pages/outputs/mongodb.adoc
+++ b/modules/components/pages/outputs/mongodb.adoc
@@ -166,7 +166,6 @@ Options:
 , `delete-many`
 , `replace-one`
 , `update-one`
-, `aggregate`
 
 === `write_concern`
 
@@ -203,7 +202,7 @@ The write concern timeout.
 
 === `document_map`
 
-A Bloblang map that represents a document to store in MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `document_map` parameter is required for the following database operations: `insert-one`, `replace-one`, `update-one`, and `aggregate`.
+A Bloblang map that represents a document to store in MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `document_map` parameter is required for the following database operations: `insert-one`, `replace-one`, and `update-one`.
 
 
 *Type*: `string`

--- a/modules/components/pages/processors/mongodb.adoc
+++ b/modules/components/pages/processors/mongodb.adoc
@@ -241,8 +241,7 @@ hint_map: |-
 
 === `upsert`
 
-The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches the `upsert` value, the document is updated or replaced, otherwise it is created.
-
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise the document is created.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/mongodb.adoc
+++ b/modules/components/pages/processors/mongodb.adoc
@@ -222,7 +222,7 @@ filter_map: |-
 
 === `hint_map`
 
-A bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
+A Bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
 
 Define a `hint_map` to improve performance when finding documents in the MongoDB database.
 

--- a/modules/components/pages/processors/mongodb.adoc
+++ b/modules/components/pages/processors/mongodb.adoc
@@ -21,22 +21,22 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 label: ""
 mongodb:
   url: mongodb://localhost:27017 # No default (required)
   database: "" # No default (required)
-  username: ""
-  password: ""
+  username: "" # No default (optional)
+  password: "" # No default (optional)
   collection: "" # No default (required)
   operation: insert-one
   write_concern:
-    w: ""
+    w: "" # No default (optional)
     j: false
-    w_timeout: ""
-  document_map: ""
-  filter_map: ""
-  hint_map: ""
+    w_timeout: "" # No default (optional)
+  document_map: "" # No default (optional)
+  filter_map: "" # No default (optional)
+  hint_map: "" # No default (optional)
   upsert: false
 ```
 
@@ -46,23 +46,23 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 label: ""
 mongodb:
   url: mongodb://localhost:27017 # No default (required)
   database: "" # No default (required)
-  username: ""
-  password: ""
+  username: "" # No default (optional)
+  password: "" # No default (optional)
   app_name: benthos
   collection: "" # No default (required)
   operation: insert-one
   write_concern:
-    w: ""
+    w: "" # No default (optional)
     j: false
-    w_timeout: ""
-  document_map: ""
-  filter_map: ""
-  hint_map: ""
+    w_timeout: "" # No default (optional)
+  document_map: "" # No default (optional)
+  filter_map: "" # No default (optional)
+  hint_map: "" # No default (optional)
   upsert: false
   json_marshal_mode: canonical
 ```
@@ -96,7 +96,7 @@ The name of the target MongoDB database.
 
 === `username`
 
-The username to connect to the database.
+The username required to connect to the database.
 
 
 *Type*: `string`
@@ -105,7 +105,7 @@ The username to connect to the database.
 
 === `password`
 
-The password to connect to the database.
+The password required to connect to the database.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -122,7 +122,7 @@ The client application name.
 
 *Type*: `string`
 
-*Default*: `"benthos"`
+*Default*: `benthos`
 
 === `collection`
 
@@ -134,12 +134,12 @@ The name of the target collection.
 
 === `operation`
 
-The mongodb operation to perform.
+The MongoDB database operation to perform.
 
 
 *Type*: `string`
 
-*Default*: `"insert-one"`
+*Default*: `insert-one`
 
 Options:
 `insert-one`
@@ -148,11 +148,11 @@ Options:
 , `replace-one`
 , `update-one`
 , `find-one`
-.
+, `aggregate`
 
 === `write_concern`
 
-The write concern settings for the mongo connection.
+The https://www.mongodb.com/docs/manual/reference/write-concern/[write concern settings^] for the MongoDB connection.
 
 
 *Type*: `object`
@@ -160,8 +160,7 @@ The write concern settings for the mongo connection.
 
 === `write_concern.w`
 
-W requests acknowledgement that write operations propagate to the specified number of mongodb instances.
-
+The `w` requests acknowledgement, which write operations propagate to the specified number of MongoDB instances.
 
 *Type*: `string`
 
@@ -169,7 +168,7 @@ W requests acknowledgement that write operations propagate to the specified numb
 
 === `write_concern.j`
 
-J requests acknowledgement from MongoDB that write operations are written to the journal.
+The `j` requests acknowledgement from MongoDB, which is created when write operations are written to the journal.
 
 
 *Type*: `bool`
@@ -187,7 +186,7 @@ The write concern timeout.
 
 === `document_map`
 
-A bloblang map representing a document to store within MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The document map is required for the operations insert-one, replace-one and update-one.
+A Bloblang map that represents a document to store in MongoDB, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `document_map` parameter is required for the following database operations: `insert-one`, `replace-one`, `update-one`, and `aggregate`.
 
 
 *Type*: `string`
@@ -204,7 +203,9 @@ document_map: |-
 
 === `filter_map`
 
-A bloblang map representing a filter for a MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The filter map is required for all operations except insert-one. It is used to find the document(s) for the operation. For example in a delete-one case, the filter map should have the fields required to locate the document to delete.
+A Bloblang map that represents a filter for a MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. The `filter_map` parameter is required for all database operations except `insert-one`. 
+
+This output uses `filter_map` to find documents for the specified operation. For example, for a `delete-one` operation, the filter map should include the fields required to locate the document for deletion.
 
 
 *Type*: `string`
@@ -221,7 +222,9 @@ filter_map: |-
 
 === `hint_map`
 
-A bloblang map representing the hint for the MongoDB command, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional and is used with all operations except insert-one. It is used to improve performance of finding the documents in the mongodb.
+A bloblang map that represents a hint or index for a MongoDB command to use, expressed as https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/[extended JSON in canonical form^]. This map is optional, and is used with all operations except `insert-one`. 
+
+Define a `hint_map` to improve performance when finding documents in the MongoDB database.
 
 
 *Type*: `string`
@@ -238,32 +241,31 @@ hint_map: |-
 
 === `upsert`
 
-The upsert setting is optional and only applies for update-one and replace-one operations. If the filter specified in filter_map matches, the document is updated or replaced accordingly, otherwise it is created.
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches the `upsert` value, the document is updated or replaced, otherwise it is created.
 
 
 *Type*: `bool`
 
 *Default*: `false`
+
 Requires version 3.60.0 or newer
 
 === `json_marshal_mode`
 
-The json_marshal_mode setting is optional and controls the format of the output message.
-
+Controls the format of the output message (optional).
 
 *Type*: `string`
 
-*Default*: `"canonical"`
+*Default*: `canonical`
+
 Requires version 3.60.0 or newer
 
 |===
-| Option | Summary
+| Option | Description
 
 | `canonical`
-| A string format that emphasizes type preservation at the expense of readability and interoperability. That is, conversion from canonical to BSON will generally preserve type information except in certain specific cases. 
+| A string format that preserves the exact data types of values stored in MongoDB at the expense of readability and interoperability. Conversion from `canonical` to JSON generally preserves type information.
 | `relaxed`
-| A string format that emphasizes readability and interoperability at the expense of type preservation. That is, conversion from relaxed format to BSON can lose type information.
+| A string format that is human-readable and compatible with most JSON parsers but may lose type fidelity. Conversion from `relaxed` format to JSON can lose type information.
 
 |===
-
-

--- a/modules/components/pages/processors/mongodb.adoc
+++ b/modules/components/pages/processors/mongodb.adoc
@@ -241,7 +241,7 @@ hint_map: |-
 
 === `upsert`
 
-The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise the document is created.
+The `upsert` parameter is optional, and only applies for `update-one` and `replace-one` operations. If the filter specified in `filter_map` matches an existing document, this operation updates or replaces the document, otherwise a new document is created.
 
 *Type*: `bool`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1246](https://redpandadata.atlassian.net/browse/DOC-1246)
Review deadline: 23rd April

This pull request updates the MongoDB configuration and documentation for both outputs and processors. The changes improve clarity, consistency, and accuracy in the descriptions of configuration fields and their usage. Additionally, optional fields are explicitly marked, and new options for certain parameters are introduced.

### MongoDB Configuration Updates

#### General Improvements:
* Updated descriptions for `username` and `password` fields to clarify that they are required for database connections. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L120-R120) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L129-L134) [[3]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L99-R99) [[4]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L108-R108)
* Added explicit "No default (optional)" comments to optional fields like `username`, `password`, `w`, `w_timeout`, `document_map`, `filter_map`, and `hint_map`. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L24-R47) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L56-R80) [[3]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L24-R39) [[4]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L49-R65)

#### Field-Specific Updates:
* Enhanced descriptions for `document_map`, `filter_map`, and `hint_map` to clarify their usage and requirements for specific database operations. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L210-R206) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L227-R225) [[3]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L244-R243) [[4]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L190-R189) [[5]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L207-R208) [[6]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L224-R227)
* Added the `aggregate` operation as a new option for `operation`. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L158-R180) [[2]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L151-R171)
* Improved descriptions for `upsert` and `write_concern` parameters for better readability and precision. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L261-R269) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L192-R189) [[3]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L241-L269) [[4]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L151-R171)

### Documentation Enhancements

#### Consistency and Readability:
* Replaced informal or ambiguous phrases with clearer alternatives, e.g., "mongodb operation to perform" changed to "MongoDB database operation to perform." [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L158-R180) [[2]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L137-R142)
* Updated default values for fields like `app_name` and `operation` to remove unnecessary quotation marks. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L143-R145) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L158-R180) [[3]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L125-R125) [[4]](diffhunk://#diff-1f5839b9eda516e93e851273a8b492235d271c16f81c8baaa50d88eaebea15f5L137-R142)

#### Performance and Batching:
* Refined descriptions of `max_in_flight` and batching parameters (`count`, `byte_size`, `period`, `processors`) to improve clarity on their functionality. [[1]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L90-R92) [[2]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L306-R320) [[3]](diffhunk://#diff-840e0b8a0c5c8fd8ca0fc5f8a26dcf79778cf62c30f89783a044ee88456a2748L358-R354)

#### Additional Notes:
* Enhanced `json_marshal_mode` documentation for processors, including detailed descriptions of the `canonical` and `relaxed` options.

These updates improve the usability and accuracy of the MongoDB configuration documentation, making it easier for developers to understand and configure their systems.

## Page previews

[`mongodb` output](https://deploy-preview-224--redpanda-connect.netlify.app/redpanda-connect/components/outputs/mongodb/)
[`mongodb` processor](https://deploy-preview-224--redpanda-connect.netlify.app/redpanda-connect/components/processors/mongodb/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1246]: https://redpandadata.atlassian.net/browse/DOC-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and consistency in MongoDB output and processor documentation.
  - Added explicit notes for optional fields without default values in configuration examples.
  - Refined field descriptions, default value formatting, and example configurations for better readability.
  - Enhanced explanations of field behaviors and database operations, including support for the aggregate operation.
  - Made minor wording, formatting, and punctuation corrections throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->