### PR TITLE
DOC-1241 Add history fields to chat completion processors

### DIFF
--- a/modules/components/pages/processors/ollama_chat.adoc
+++ b/modules/components/pages/processors/ollama_chat.adoc
@@ -35,6 +35,7 @@ ollama_chat:
   max_tokens: 0 # No default (optional)
   temperature: 0 # No default (optional)
   save_prompt_metadata: false
+  history: "" # No default (optional)
   tools: [] # No default (required)
   runner:
     context_size: 0 # No default (optional)
@@ -67,6 +68,7 @@ ollama_chat:
   frequency_penalty: 0 # No default (optional)
   stop: [] # No default (optional)
   save_prompt_metadata: false
+  history: "" # No default (optional)
   max_tool_calls: 3
   tools: [] # No default (required)
   runner:
@@ -245,6 +247,18 @@ Set to `true` to save the prompt value to a metadata field (`@prompt`) on the co
 *Type*: `bool`
 
 *Default*: `false`
+
+
+=== `history`
+
+Include historical messages in a chat request. You must use a Bloblang query to create an array of objects in the form of `[{"role": "", "content":""}]` where:
+
+- `role` is the sender of the original messages, either `system`, `user`, `assistant`, or `tool`.
+- `content` is the text of the original messages.
+
+*Type*: `string`
+
+*Default*: `""`
 
 
 === `max_tool_calls`
@@ -448,6 +462,7 @@ output:
     codec: lines
 ```
 --
+
 
 Use a series of processors to make calls to external tools::
 +

--- a/modules/components/pages/processors/ollama_chat.adoc
+++ b/modules/components/pages/processors/ollama_chat.adoc
@@ -260,6 +260,14 @@ Include historical messages in a chat request. You must use a Bloblang query to 
 
 *Default*: `""`
 
+```yml
+# Examples
+
+history: [{"role": "user", "content": "My favorite color is blue"}, {"role":"assistant", "content":"Nice"}]
+
+```
+If the `prompt` is set to `"What is my favorite color?"`, the specified `model` responds with `blue`.
+
 
 === `max_tool_calls`
 

--- a/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/modules/components/pages/processors/openai_chat_completion.adoc
@@ -171,6 +171,15 @@ For more information, see <<Examples, Examples>>.
 
 *Default*: `""`
 
+```yml
+# Examples
+
+history: [{"role": "user", "content": "My favorite color is blue"}, {"role":"assistant", "content":"Nice"}]
+
+```
+If the `prompt` is set to `"What is my favorite color?"`, the specified `model` responds with `blue`.
+
+
 === `image`
 
 An optional image to submit along with the prompt. The result of the Bloblang mapping must be a byte array.

--- a/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/modules/components/pages/processors/openai_chat_completion.adoc
@@ -31,6 +31,7 @@ openai_chat_completion:
   model: gpt-4o # No default (required)
   prompt: "" # No default (optional)
   system_prompt: "" # No default (optional)
+  history: "" # No default (optional)
   image: 'root = this.image.decode("base64") # decode base64 encoded image' # No default (optional)
   max_tokens: 0 # No default (optional)
   temperature: 0 # No default (optional)
@@ -56,6 +57,7 @@ openai_chat_completion:
   model: gpt-4o # No default (required)
   prompt: "" # No default (optional)
   system_prompt: "" # No default (optional)
+  history: "" # No default (optional)
   image: 'root = this.image.decode("base64") # decode base64 encoded image' # No default (optional)
   max_tokens: 0 # No default (optional)
   temperature: 0 # No default (optional)
@@ -155,6 +157,19 @@ The user prompt for which a response is generated. By default, the processor sen
 The system prompt to submit along with the user prompt. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
+
+=== `history`
+
+Include messages from a prior conversation. You must use a Bloblang query to create an array of objects in the form of `[{"role": "user", "content": "<text>"}, {"role":"assistant", "content":"<text>"}]` where:
+
+- `role` is the sender of the original messages, either `system`, `user`, or `assistant`.
+- `content` is the text of the original messages.
+
+For more information, see <<Examples, Examples>>.
+
+*Type*: `string`
+
+*Default*: `""`
 
 === `image`
 
@@ -660,6 +675,58 @@ output:
     codec: lines: lines
 ```
 
+--
+Generate chat history::
++
+--
+In this configuration, a pipeline executes a number of processors, including a cache, to generate and send chat history to a GPT-4o model.
+
+```yaml
+input: 
+  stdin:
+    scanner:
+      lines: {}
+pipeline:
+  processors:
+    - mapping: |
+        root.prompt = content().string()
+    - branch:
+        processors: 
+          - cache:
+              resource: mem
+              operator: get
+              key: history
+          - catch: 
+            - mapping: 'root = []'
+        result_map: 'root.history = this'
+    - branch:
+        processors:
+        - openai_chat_completion:
+            model: gpt-4o
+            api_key: TODO
+            prompt: "${!this.prompt}"
+            history: 'root = this.history'
+        result_map: 'root.response = content().string()'
+    - mutation: |
+        root.history = this.history.concat([
+          {"role": "user", "content": this.prompt},
+          {"role": "assistant", "content": this.response},
+         ])
+    - cache:
+        resource: mem
+        operator: set
+        key: history
+        value: '${!this.history}'
+    - mapping: |
+        root = this.response
+output:
+  stdout:
+    codec: lines
+ 
+cache_resources:
+  - label: mem 
+    memory: {}
+```
 --
 
 Make calls to external tools::

--- a/modules/components/pages/processors/openai_chat_completion.adoc
+++ b/modules/components/pages/processors/openai_chat_completion.adoc
@@ -712,7 +712,7 @@ pipeline:
         processors:
         - openai_chat_completion:
             model: gpt-4o
-            api_key: TODO
+            api_key: "${OPENAI_API_KEY}"
             prompt: "${!this.prompt}"
             history: 'root = this.history'
         result_map: 'root.response = content().string()'


### PR DESCRIPTION
## Description

Resolves [DOC-1241](https://redpandadata.atlassian.net/browse/DOC-1241)
Review deadline: 24th April

This pull request introduces a new `history` field to both the `ollama_chat` and `openai_chat_completion` processors, enabling the inclusion of historical messages in chat requests. It also provides detailed documentation and examples for using this feature.

### Addition of `history` field:

* **`ollama_chat` processor**:
  - Added a `history` field to include historical messages in chat requests. Users must format the messages as an array of objects with `role` and `content` fields. [[1]](diffhunk://#diff-85239c85c003eb2e0b21ba906ed7431886575987628182740a1e180ea911a383R38) [[2]](diffhunk://#diff-85239c85c003eb2e0b21ba906ed7431886575987628182740a1e180ea911a383R71) [[3]](diffhunk://#diff-85239c85c003eb2e0b21ba906ed7431886575987628182740a1e180ea911a383R252-R263)

* **`openai_chat_completion` processor**:
  - Introduced a `history` field to include prior conversation messages. Messages should be formatted as an array of objects with `role` and `content` fields. Documentation includes a reference to examples for implementation. [[1]](diffhunk://#diff-1580ac1b6255128fb800dd626db7e51cf0ee7bbc171df5e31714664ee9cedd13R34) [[2]](diffhunk://#diff-1580ac1b6255128fb800dd626db7e51cf0ee7bbc171df5e31714664ee9cedd13R60) [[3]](diffhunk://#diff-1580ac1b6255128fb800dd626db7e51cf0ee7bbc171df5e31714664ee9cedd13R161-R173)

### Documentation and examples:

* **Examples for `openai_chat_completion`**:
  - Added a YAML configuration example demonstrating how to generate and send chat history to a GPT-4o model using a pipeline of processors. This includes caching and updating the `history` field dynamically.

* **Formatting improvements**:
  - Minor formatting changes to improve readability in the documentation.

## Page previews

[`ollama_chat` processor](https://deploy-preview-225--redpanda-connect.netlify.app/redpanda-connect/components/processors/ollama_chat/)
[`openai_chat_completion` processor](https://deploy-preview-225--redpanda-connect.netlify.app/redpanda-connect/components/processors/openai_chat_completion/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1241]: https://redpandadata.atlassian.net/browse/DOC-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for both the Ollama and OpenAI chat processors to describe a new optional configuration field, `history`, enabling inclusion of prior conversation messages as context.
	- Added detailed usage instructions, formatting guidelines, and examples for the `history` field, including an advanced example demonstrating chat history management with caching in a pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->