### PR TITLE
DOC-1238 Add slack_post output

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -269,6 +269,7 @@
 *** xref:components:outputs/retry.adoc[]
 *** xref:components:outputs/schema_registry.adoc[]
 *** xref:components:outputs/sftp.adoc[]
+*** xref:components:outputs/slack_post.adoc[]
 *** xref:components:outputs/snowflake_put.adoc[]
 *** xref:components:outputs/snowflake_streaming.adoc[]
 *** xref:components:outputs/socket.adoc[]

--- a/modules/components/pages/outputs/ockam_kafka.adoc
+++ b/modules/components/pages/outputs/ockam_kafka.adoc
@@ -23,7 +23,7 @@ Common::
 --
 ```yml
 # Common configuration fields, showing default values
-input:
+output:
   label: ""
   ockam_kafka:
     kafka:
@@ -55,7 +55,7 @@ Advanced::
 --
 ```yml
 # All configuration fields, showing default values
-input:
+output:
   label: ""
   ockam_kafka:
     kafka:

--- a/modules/components/pages/outputs/slack_post.adoc
+++ b/modules/components/pages/outputs/slack_post.adoc
@@ -1,7 +1,6 @@
 = slack_post
 // tag::single-source[]
 :type: output
-:page-beta: true
 
 component_type_dropdown::[]
 
@@ -103,7 +102,7 @@ When set to `1`, this output finds and links to https://api.slack.com/reference/
 
 == Examples
 
-The following pipeline reposts messages created by a Slack app to a new channel, excluding hidden or non-message events, and any activity originating from the Slack bot.
+The following pipeline reposts messages created by a Slack app to the same thread in the same channel, adding `ECHO:` to the original message text. All hidden or non-message events, and any activity originating from the Slack bot, are excluded.
 
 ```yml
 input:

--- a/modules/components/pages/outputs/slack_post.adoc
+++ b/modules/components/pages/outputs/slack_post.adoc
@@ -27,6 +27,8 @@ output:
     link_names: 0
 ```
 
+See also: <<Examples, Examples>>
+
 == Fields
 
 === `bot_token`
@@ -99,5 +101,32 @@ When set to `1`, this output finds and links to https://api.slack.com/reference/
 
 *Default*: `0`
 
+== Examples
+
+The following pipeline reposts messages created by a Slack app to a new channel, excluding hidden or non-message events, and any activity originating from the Slack bot.
+
+```yml
+input:
+  slack:
+    app_token: "${APP_TOKEN:xapp-demo}"
+    bot_token: "${BOT_TOKEN:xoxb-demo}"
+pipeline:
+  processors:
+    - mutation: |
+        # Ignore hidden or non-message events.
+        if this.event.type != "message" || (this.event.hidden | false) {
+          root = deleted()
+        }
+        # Ignore messages sent by the bot.
+        if this.authorizations.any(auth -> auth.user_id == this.event.user) {
+          root = deleted()
+        }
+output:
+  slack_post:
+    bot_token: "${BOT_TOKEN:xoxb-demo}"
+    channel_id: "${!this.event.channel}"
+    thread_ts: "${!this.event.ts}"
+    text: "ECHO: ${!this.event.text}"
+```
 
 // end::single-source[]

--- a/modules/components/pages/outputs/slack_post.adoc
+++ b/modules/components/pages/outputs/slack_post.adoc
@@ -1,0 +1,103 @@
+= slack_post
+// tag::single-source[]
+:type: output
+:page-beta: true
+
+component_type_dropdown::[]
+
+Posts a new message to a Slack channel using the Slack API method https://api.slack.com/methods/chat.postMessage[chat.postMessage^].
+
+ifndef::env-cloud[]
+Introduced in version 4.52.0.
+endif::[]
+
+```yml
+# Common configuration fields, showing default values
+output:
+  label: ""
+  slack_post:
+    bot_token: "" # No default (required)
+    channel_id: "" # No default (required)
+    thread_ts: "" # No default (optional)
+    text: "" # No default (optional)
+    blocks: "" # No default (optional)
+    markdown: true
+    unfurl_links: false
+    unfurl_media: true
+    link_names: 0
+```
+
+== Fields
+
+=== `bot_token`
+
+Your Slack bot user's OAuth token, which must have the correct permissions to post messages to the target Slack channel.
+
+*Type*: `string`
+
+=== `channel_id`
+
+The encoded ID of the target Slack channel. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+=== `thread_ts`
+
+Specify the thread timestamp (`ts` value) of another message to post a reply within the same thread. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `text`
+
+The text content of the message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+You can either specify message content in the `text` or `blocks` fields, but not both.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `blocks`
+
+A Bloblang query that should return a JSON array of https://api.slack.com/reference/block-kit/blocks[Slack blocks^].
+
+You can either specify message content in the `text` or `blocks` fields, but not both.
+
+*Type*: `string`
+
+=== `markdown`
+
+When set to `true`, this output accepts message content in Markdown format.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `unfurl_links`
+
+When set to `true`, this output provides previews of linked content in Slack messages. For more information about unfurling links, see the https://api.slack.com/reference/messaging/link-unfurling[Slack documentation^].
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `unfurl_media`
+
+When set to `true`, this output provides previews of rich content in Slack messages, such as videos or embedded tweets.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+=== `link_names`
+
+When set to `1`, this output finds and links to https://api.slack.com/reference/surfaces/formatting#mentioning-groups[user groups^] mentioned in Slack messages. 
+
+*Type*: `bool`
+
+*Default*: `0`
+
+
+// end::single-source[]

--- a/modules/components/pages/outputs/slack_post.adoc
+++ b/modules/components/pages/outputs/slack_post.adoc
@@ -112,12 +112,11 @@ input:
     bot_token: "${BOT_TOKEN:xoxb-demo}"
 pipeline:
   processors:
+    # Ignore hidden or non-message events, and messages sent by the bot.
     - mutation: |
-        # Ignore hidden or non-message events.
         if this.event.type != "message" || (this.event.hidden | false) {
           root = deleted()
         }
-        # Ignore messages sent by the bot.
         if this.authorizations.any(auth -> auth.user_id == this.event.user) {
           root = deleted()
         }


### PR DESCRIPTION
## Description

Resolves [DOC-1238](https://redpandadata.atlassian.net/browse/DOC-1238)
Review deadline: 24th April

Related PR: [https://github.com/redpanda-data/cloud-docs/pull/265](https://github.com/redpanda-data/cloud-docs/pull/265)

This pull request introduces a new Slack output component, updates the navigation to include it, and corrects a configuration field label in the Kafka output component documentation. Below is a summary of the most important changes grouped by theme:

### New Slack Output Component
* Added a new Slack output component in `modules/components/pages/outputs/slack_post.adoc`, which allows posting messages to Slack channels using the Slack API. The configuration includes fields like `bot_token`, `channel_id`, `text`, `blocks`, and others, with detailed descriptions and default values.
* Updated the navigation file `modules/ROOT/nav.adoc` to include a link to the newly added Slack output documentation.

### Kafka Output Component Documentation Fixes
* Corrected the configuration field label from `input` to `output` in the "Common configuration fields" section of `modules/components/pages/outputs/ockam_kafka.adoc`.
* Corrected the configuration field label from `input` to `output` in the "All configuration fields" section of `modules/components/pages/outputs/ockam_kafka.adoc`.

## Page previews

[`slack_post` output](https://deploy-preview-226--redpanda-connect.netlify.app/redpanda-connect/components/outputs/slack_post/)
[`ockam_kafka` output](https://deploy-preview-226--redpanda-connect.netlify.app/redpanda-connect/components/outputs/ockam_kafka/) (bug fix)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1238]: https://redpandadata.atlassian.net/browse/DOC-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added documentation for the new Slack output component, enabling users to post messages to Slack channels with various configuration options. Includes example usage and field descriptions.

- **Documentation**
  - Updated navigation to include the new Slack output component documentation.
  - Corrected configuration examples in the Ockam Kafka output documentation to use the appropriate field names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->