### PR TITLE
DOC-1239 Add slack_users input

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -91,6 +91,7 @@
 *** xref:components:inputs/schema_registry.adoc[]
 *** xref:components:inputs/sequence.adoc[]
 *** xref:components:inputs/sftp.adoc[]
+*** xref:components:inputs/slack_users.adoc[]
 *** xref:components:inputs/socket.adoc[]
 *** xref:components:inputs/socket_server.adoc[]
 *** xref:components:inputs/spicedb_watch.adoc[]

--- a/modules/components/pages/inputs/slack_users.adoc
+++ b/modules/components/pages/inputs/slack_users.adoc
@@ -4,7 +4,7 @@
 
 component_type_dropdown::[]
 
-Returns https://api.slack.com/methods/users.list#examples[the full profile^] of all users in a Slack organization using the Slack API method https://api.slack.com/methods/users.list[users.list^]. Optionally, you can filter the list of returned users by team ID.
+Returns https://api.slack.com/methods/users.list#examples[the full profile^] of all users your Slack organization using the API method https://api.slack.com/methods/users.list[users.list^]. Optionally, you can filter the list of returned users by team ID.
 
 This input is useful when you need to:
 
@@ -22,7 +22,7 @@ input:
   label: ""
   slack_users:
     bot_token: "" # No default (required)
-    team_id: "" No default (optional)
+    team_id: "" # No default (optional)
     auto_replay_nacks: true
 ```
 

--- a/modules/components/pages/inputs/slack_users.adoc
+++ b/modules/components/pages/inputs/slack_users.adoc
@@ -1,11 +1,16 @@
 = slack_users
 // tag::single-source[]
 :type: input
-:page-beta: true
 
 component_type_dropdown::[]
 
-Reads all users in a Slack organization, and optionally filters the list of returned users by team ID.
+Returns https://api.slack.com/methods/users.list#examples[the full profile^] of all users in a Slack organization using the Slack API method https://api.slack.com/methods/users.list[users.list^]. Optionally, you can filter the list of returned users by team ID.
+
+This input is useful when you need to:
+
+- Join user information to Slack posts.
+- Ingest user information into a data lakehouse to create joins with other fields. 
+
 
 ifndef::env-cloud[]
 Introduced in version 4.52.0.
@@ -25,13 +30,13 @@ input:
 
 === `bot_token`
 
-Your https://api.slack.com/concepts/token-types[Slack bot user's OAuth token^], which must have the correct permissions to access your Slack organization.
+Your https://api.slack.com/concepts/token-types[Slack bot user's OAuth token^], which must have the https://api.slack.com/scopes/users:read[`users.read` scope^] to access your Slack organization.
 
 *Type*: `string`
 
 === `team_id`
 
-The encoded ID of a Slack team by which to filter the list of returned users. If left empty, users from all teams within the organization are returned.
+The encoded ID of a Slack team by which to filter the list of returned users, which you can get from the https://api.slack.com/methods/team.info[`team.info` Slack API method^]. If `team_id` is left empty, users from all teams within the organization are returned.
 
 *Type*: `string`
 

--- a/modules/components/pages/inputs/slack_users.adoc
+++ b/modules/components/pages/inputs/slack_users.adoc
@@ -4,7 +4,7 @@
 
 component_type_dropdown::[]
 
-Returns https://api.slack.com/methods/users.list#examples[the full profile^] of all users your Slack organization using the API method https://api.slack.com/methods/users.list[users.list^]. Optionally, you can filter the list of returned users by team ID.
+Returns https://api.slack.com/methods/users.list#examples[the full profile^] of all users in your Slack organization using the API method https://api.slack.com/methods/users.list[users.list^]. Optionally, you can filter the list of returned users by team ID.
 
 This input is useful when you need to:
 

--- a/modules/components/pages/inputs/slack_users.adoc
+++ b/modules/components/pages/inputs/slack_users.adoc
@@ -1,0 +1,50 @@
+= slack_users
+// tag::single-source[]
+:type: input
+:page-beta: true
+
+component_type_dropdown::[]
+
+Reads all users in a Slack organization, and optionally filters the list of returned users by team ID.
+
+ifndef::env-cloud[]
+Introduced in version 4.52.0.
+endif::[]
+
+```yml
+# Common configuration fields, showing default values
+input:
+  label: ""
+  slack_users:
+    bot_token: "" # No default (required)
+    team_id: "" No default (optional)
+    auto_replay_nacks: true
+```
+
+== Fields
+
+=== `bot_token`
+
+Your https://api.slack.com/concepts/token-types[Slack bot user's OAuth token^], which must have the correct permissions to access your Slack organization.
+
+*Type*: `string`
+
+=== `team_id`
+
+The encoded ID of a Slack team by which to filter the list of returned users. If left empty, users from all teams within the organization are returned.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `auto_replay_nacks`
+
+Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.
+
+Set `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation.
+
+*Type*: `bool`
+
+*Default*: `true`
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves [DOC-1239](https://redpandadata.atlassian.net/browse/DOC-1239)
Review deadline: 1st May

Also see related cloud PR: https://github.com/redpanda-data/cloud-docs/pull/266

This pull request introduces a new input component for Slack user data and updates the documentation to include it. The changes primarily focus on adding the new `slack_users` input and its configuration details.

### Documentation Updates:

* **Navigation Update**: Added a reference to the new `slack_users` input component in the navigation file `modules/ROOT/nav.adoc`.
* **New Component Documentation**: Created a new documentation page `modules/components/pages/inputs/slack_users.adoc` for the `slack_users` input. This page includes:
  - A description of the component's functionality, which reads all users in a Slack organization and optionally filters by team ID.
  - Configuration fields such as `bot_token`, `team_id`, and `auto_replay_nacks`, with detailed explanations of their types, defaults, and usage.

## Page previews

[`slack_users` input](https://deploy-preview-227--redpanda-connect.netlify.app/redpanda-connect/components/inputs/slack_users/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1239]: https://redpandadata.atlassian.net/browse/DOC-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added documentation for a new input component that retrieves full Slack user profiles, with options for team filtering and message replay settings.

- **Documentation**
  - Updated navigation to include the new Slack users input component documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->