### PR TITLE
DOC-1240 Add slack_thread processor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -187,6 +187,7 @@
 *** xref:components:processors/schema_registry_encode.adoc[]
 *** xref:components:processors/select_parts.adoc[]
 *** xref:components:processors/sentry_capture.adoc[]
+*** xref:components:processors/slack_thread.adoc[]
 *** xref:components:processors/sleep.adoc[]
 *** xref:components:processors/split.adoc[]
 *** xref:components:processors/sql.adoc[]

--- a/modules/components/pages/processors/slack_thread.adoc
+++ b/modules/components/pages/processors/slack_thread.adoc
@@ -1,0 +1,43 @@
+= slack_thread
+// tag::single-source[]
+:type: processor
+:page-beta: true
+
+component_type_dropdown::[]
+
+Reads a Slack thread using the Slack API method https://api.slack.com/methods/conversations.replies[conversations.replies^].
+
+ifndef::env-cloud[]
+Introduced in version 4.52.0.
+endif::[]
+
+```yml
+# Common configuration fields, showing default values
+label: ""
+slack_thread:
+  bot_token: "" # No default (required)
+  channel_id: "" # No default (required)
+  thread_ts: "" # No default (required)
+```
+
+== Fields
+
+=== `bot_token`
+
+Your Slack bot user's OAuth token, which must have the correct permissions to read messages from the Slack channel specified in `channel_id`.
+
+*Type*: `string`
+
+=== `channel_id`
+
+The encoded ID of the Slack channel from which to read threads. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+=== `thread_ts`
+
+The timestamp of the parent message of the thread you want to read. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves [DOC-1240](https://redpandadata.atlassian.net/browse/DOC-1240)
Review deadline: 25th April

This pull request adds documentation for a new `slack_thread` processor, which integrates with the Slack API to read threads. The changes include adding the processor to the navigation menu and creating a detailed documentation page for its configuration and usage.

### Documentation Updates:

* **Navigation Menu Update**:
  - Added a link to the new `slack_thread` processor documentation in the navigation file `modules/ROOT/nav.adoc`.

* **New Processor Documentation**:
  - Created a new page `modules/components/pages/processors/slack_thread.adoc` to document the `slack_thread` processor. This includes an overview, configuration fields (`bot_token`, `channel_id`, and `thread_ts`), and usage examples. The processor uses the Slack API's `conversations.replies` method and supports interpolation functions for its fields.

## Page previews

[`slack_thread` processor](url)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)