### PR TITLE
DOC-1270 Remove beta flag from redpanda input

### DIFF
--- a/modules/components/pages/inputs/redpanda.adoc
+++ b/modules/components/pages/inputs/redpanda.adoc
@@ -1,7 +1,6 @@
 = redpanda
 // tag::single-source[]
 :type: input
-:page-beta: true
 :categories: ["Services"]
 
 component_type_dropdown::[]


### PR DESCRIPTION
## Description

Resolves [DOC-1270](https://redpandadata.atlassian.net/browse/DOC-1270)
Review deadline: 25th April

The change removes the beta status from the redpanda connector.

Related cloud PR: [https://github.com/redpanda-data/cloud-docs/pull/272](https://github.com/redpanda-data/cloud-docs/pull/272)

## Page previews

[`redpanda` input](https://deploy-preview-231--redpanda-connect.netlify.app/redpanda-connect/components/inputs/redpanda/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1270]: https://redpandadata.atlassian.net/browse/DOC-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove the beta label from the Redpanda page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->