### PR TITLE
DOC-1249 Update type field in amqp_0_9 output

### DIFF
--- a/modules/components/pages/outputs/amqp_0_9.adoc
+++ b/modules/components/pages/outputs/amqp_0_9.adoc
@@ -142,6 +142,8 @@ Whether to enable exchange declaration.
 
 The type of the exchange, which determines how messages are routed to queues.
 
+NOTE: Dots (`.`) in message keys are only enforced in routing keys and message types for `topic` exchanges.
+
 *Type*: `string`
 
 *Default*: `direct`
@@ -150,6 +152,7 @@ Options:
 `direct`
 , `fanout`
 , `topic`
+, `headers`
 , `x-custom`
 
 === `exchange_declare.durable`


### PR DESCRIPTION
## Description

Resolves [DOC-1249](https://redpandadata.atlassian.net/browse/DOC-1249)
Review deadline: 28th April

This pull request updates the documentation for AMQP 0.9 outputs to clarify exchange behavior and expand the list of supported exchange types. The changes improve the accuracy and completeness of the documentation.

### Documentation updates:

* [`modules/components/pages/outputs/amqp_0_9.adoc`](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91R145-R146): Added a note clarifying that dots (`.`) in message keys are enforced only in routing keys and message types for `topic` exchanges.
* [`modules/components/pages/outputs/amqp_0_9.adoc`](diffhunk://#diff-0fa2b78527cdf56e74956fe9fb81d314a5256ae115d048fb53d5282d2df0db91R155): Expanded the list of supported exchange types by adding `headers` to the `Options:` section.

## Page previews

[`amqp_09` output](https://deploy-preview-232--redpanda-connect.netlify.app/redpanda-connect/components/outputs/amqp_0_9/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1249]: https://redpandadata.atlassian.net/browse/DOC-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that dots in message keys are only enforced for routing keys and message types in `topic` exchanges.
  - Updated the list of valid exchange types to include the `headers` exchange type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->