### PR TITLE
Open pull requests to update packages

### DIFF
--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -4,40 +4,48 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [trigger-npm-update]
+
 jobs:
   update-dependency:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
-    strategy:
-      matrix:
-        branch: [main]
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
+
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          ref: main
           token: ${{ env.ACTIONS_BOT_TOKEN }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
+
       - run: npm install
+
       - run: npm update @redpanda-data/docs-extensions-and-macros
-      - name: Commit changes
-        run: |
-          git config --global user.name "vbotbuildovich"
-          git config --global user.email "vbotbuildovich@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "Update @redpanda-data/docs-extensions-and-macros"
-          git push origin ${{ matrix.branch }}
-        env:
-          ACCESS_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          commit-message: Update @redpanda-data/docs-extensions-and-macros
+          title: Update @redpanda-data/docs-extensions-and-macros
+          labels: auto-docs
+          body: |
+            This PR updates `@redpanda-data/docs-extensions-and-macros`.
+          branch: update/docs-extensions-and-macros-main
+          base: main


### PR DESCRIPTION
## Description

Review deadline: May 2

This pull request updates the `.github/workflows/update-extensions.yml` workflow to improve the process for updating the `@redpanda-data/docs-extensions-and-macros` package. Key changes include modifying permissions, simplifying branch handling, and replacing manual commits with an automated pull request creation step.

### Workflow improvements:

* Updated permissions for the `update-dependency` job to include `pull-requests: write` and changed `contents` permission from `read` to `write` to enable pull request creation.
* Replaced the matrix strategy for branches with a fixed reference to the `main` branch, simplifying the workflow.

### Automation enhancements:

* Added a step to use the `peter-evans/create-pull-request@v6` action to automate the creation of pull requests for dependency updates, replacing the previous manual commit and push steps.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)