### PR TITLE
DOC-1320 Add cache_duration_field to schema_registry_decode processor

### DIFF
--- a/modules/components/pages/processors/schema_registry_decode.adoc
+++ b/modules/components/pages/processors/schema_registry_decode.adoc
@@ -28,6 +28,7 @@ schema_registry_decode:
   avro:
     raw_unions: false # No default (optional)
     preserve_logical_types: false
+  cache_duration: 10m
   url: "" # No default (required)
 ```
 
@@ -44,6 +45,7 @@ schema_registry_decode:
     raw_unions: false
     preserve_logical_types: false
     mapping: "" # No default (optional)
+  cache_duration: 10m
   url: "" # No default (required)
   oauth:
     enabled: false
@@ -179,6 +181,22 @@ mapping: |2
   # Apply the Debezium to Avro timestamp mapping to the root
   root = this.apply("debeziumTimestampToAvroTimestamp")
 
+```
+
+=== `cache_duration`
+
+The duration after which a cached schema is considered stale and is removed from the cache.
+
+*Type*: `string`
+
+*Default*: `10m`
+
+```yml
+# Examples
+
+cache_duration: 1h
+
+cache_duration: 5m
 ```
 
 === `url`


### PR DESCRIPTION
## Description

Resolves [DOC-1320](https://redpandadata.atlassian.net/browse/DOC-1320)
Review deadline: 8 May

This pull request introduces a new configuration option, `cache_duration`, to the `schema_registry_decode` processor documentation. The change enhances the ability to manage schema caching by specifying how long a cached schema remains valid before being considered stale.

### Enhancements to `schema_registry_decode` documentation:

* **Added `cache_duration` configuration option**: 
  - Included `cache_duration` in the example configuration blocks to demonstrate its usage. [[1]](diffhunk://#diff-fc62b03da657b2dfa3924d3a7d1f7cf3df3e46e4dbd38b4b5fa0ebc463c31d37R31) [[2]](diffhunk://#diff-fc62b03da657b2dfa3924d3a7d1f7cf3df3e46e4dbd38b4b5fa0ebc463c31d37R48)
  - Documented `cache_duration` with details about its purpose, type, default value (`10m`), and example usage. This option determines the duration after which a cached schema is removed from the cache.

## Page previews

[`schema_registry_decode` processor](url)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)