### PR TITLE
DOC-1321 Add `client_auth` field to socket_server input

### DIFF
--- a/modules/components/pages/inputs/socket_server.adoc
+++ b/modules/components/pages/inputs/socket_server.adoc
@@ -24,6 +24,7 @@ input:
       cert_file: "" # No default (optional)
       key_file: "" # No default (optional)
       self_signed: false
+      client_auth: no
     auto_replay_nacks: true
     scanner:
       lines: {}
@@ -103,6 +104,38 @@ Whether to generate self signed certificates.
 *Type*: `bool`
 
 *Default*: `false`
+
+=== `tls.client_auth`
+
+Specifies how client authentication is handled when using TLS.
+
+*Type*: `string`
+
+*Default*: `no`
+
+Requires version 4.45.0 or newer.
+
+Options:
+
+|===
+| Option | Description
+
+| `no`
+| Client certificate is neither requested nor required.
+
+| `request`
+| Client certificate is requested but not required.
+
+| `require_valid` 
+| Requires a valid client certificate.
+
+| `require_any`
+| Accepts any client certificate, even if invalid.
+
+| `verify_if_given` 
+| Verifies the client certificate if one is provided.
+
+|===
 
 === `auto_replay_nacks`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1321](https://redpandadata.atlassian.net/browse/DOC-1321)
Review deadline: 8 May

This pull request adds a new configuration option, `tls.client_auth`, to the `socket_server` input module documentation. This option allows users to specify how client authentication is handled when using TLS, enhancing flexibility and security.

### New configuration option for TLS:

* [`modules/components/pages/inputs/socket_server.adoc`](diffhunk://#diff-8b8f4e52f2a4df9e6fbf1d34e10857dd4f388f7be35d8f663d8c916f02bafe3aR108-R139): Added the `tls.client_auth` option with detailed descriptions of its purpose, type, default value, and available options. This option specifies how client certificates are handled during TLS connections, with choices like `no`, `request`, `require_valid`, `require_any`, and `verify_if_given`. It requires version 4.45.0 or newer.

* [`modules/components/pages/inputs/socket_server.adoc`](diffhunk://#diff-8b8f4e52f2a4df9e6fbf1d34e10857dd4f388f7be35d8f663d8c916f02bafe3aR27): Updated the configuration example to include the new `client_auth` field with a default value of `no`.

## Page previews

[`socket_server` input](https://deploy-preview-240--redpanda-connect.netlify.app/redpanda-connect/components/inputs/socket_server/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1321]: https://redpandadata.atlassian.net/browse/DOC-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ