### PR TITLE
DOC-1322 Add uuid_v5 Bloblang method

### DIFF
--- a/modules/guides/pages/bloblang/methods.adoc
+++ b/modules/guides/pages/bloblang/methods.adoc
@@ -8,7 +8,7 @@
 Methods provide most of the power in Bloblang as they allow you to augment values and can be added to any expression (including other methods):
 
 ```coffeescript
-root.doc.id = this.thing.id.string().catch(uuid_v5())
+root.doc.id = this.thing.id.string().catch(uuid_v4())
 root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
   deleted()
 } else {
@@ -73,7 +73,7 @@ If the result of a target query fails (due to incorrect types, failed parsing, e
 
 
 ```coffeescript
-root.doc.id = this.thing.id.string().catch(uuid_v5())
+root.doc.id = this.thing.id.string().catch(uuid_v4())
 ```
 
 The fallback argument can be a mapping, allowing you to capture the error string and yield structured data back.
@@ -163,7 +163,7 @@ If the result of the target query fails or resolves to `null`, returns the argum
 
 
 ```coffeescript
-root.doc.id = this.thing.id.or(uuid_v5())
+root.doc.id = this.thing.id.or(uuid_v4())
 ```
 
 == String Manipulation

--- a/modules/guides/pages/bloblang/methods.adoc
+++ b/modules/guides/pages/bloblang/methods.adoc
@@ -8,7 +8,7 @@
 Methods provide most of the power in Bloblang as they allow you to augment values and can be added to any expression (including other methods):
 
 ```coffeescript
-root.doc.id = this.thing.id.string().catch(uuid_v4())
+root.doc.id = this.thing.id.string().catch(uuid_v5())
 root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
   deleted()
 } else {
@@ -73,7 +73,7 @@ If the result of a target query fails (due to incorrect types, failed parsing, e
 
 
 ```coffeescript
-root.doc.id = this.thing.id.string().catch(uuid_v4())
+root.doc.id = this.thing.id.string().catch(uuid_v5())
 ```
 
 The fallback argument can be a mapping, allowing you to capture the error string and yield structured data back.
@@ -163,7 +163,7 @@ If the result of the target query fails or resolves to `null`, returns the argum
 
 
 ```coffeescript
-root.doc.id = this.thing.id.or(uuid_v4())
+root.doc.id = this.thing.id.or(uuid_v5())
 ```
 
 == String Manipulation
@@ -3410,6 +3410,26 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 
 # In:  {"value":"hello world"}
 # Out: {"h1":"c99465aa","h2":"df373d3c"}
+```
+
+=== `uuid_v5`
+
+Generates a name-based UUID (version 5) for the given string.
+
+==== Parameters
+
+*`ns`* &lt;(optional) string&gt; An optional namespace name or UUID. Supported predefined namespaces include: `dns`, `url`, `oid`, and `x500`, but you can use any valid RFC-9562 UUID.
+
+If omitted, the nil UUID is used as the default namespace.
+
+==== Examples
+
+```coffeescript
+root.id = "example".uuid_v5()
+
+root.id = "example".uuid_v5("x500")
+
+root.id = "example".uuid_v5("77f836b7-9f61-46c0-851e-9b6ca3535e69")
 ```
 
 == SQL


### PR DESCRIPTION
## Description

Resolves [DOC-1322](https://redpandadata.atlassian.net/browse/DOC-1322)
Review deadline: 9th May

This pull request updates the Bloblang documentation to replace references to `uuid_v4` with `uuid_v5` and adds a new section documenting the `uuid_v5` method. These changes improve the clarity and functionality of the documentation for users working with name-based UUIDs.

### Updates to UUID Methods:

* Replaced all instances of `uuid_v4` with `uuid_v5` in code examples to reflect the usage of name-based UUIDs instead of randomly generated ones. (`modules/guides/pages/bloblang/methods.adoc`: [[1]](diffhunk://#diff-18236ccceeea3b158822ef572ddc0937734f985206891d27e31a4e9121e7933eL11-R11) [[2]](diffhunk://#diff-18236ccceeea3b158822ef572ddc0937734f985206891d27e31a4e9121e7933eL76-R76) [[3]](diffhunk://#diff-18236ccceeea3b158822ef572ddc0937734f985206891d27e31a4e9121e7933eL166-R166)

### New Documentation for `uuid_v5`:

* Added a new section explaining the `uuid_v5` method, including its purpose, parameters, and examples. This section clarifies how to generate name-based UUIDs using optional namespaces. (`modules/guides/pages/bloblang/methods.adoc`: [modules/guides/pages/bloblang/methods.adocR3415-R3434](diffhunk://#diff-18236ccceeea3b158822ef572ddc0937734f985206891d27e31a4e9121e7933eR3415-R3434))

## Page previews

[Bloblang Methods](https://deploy-preview-241--redpanda-connect.netlify.app/redpanda-connect/guides/bloblang/methods/#uuid_v5)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1322]: https://redpandadata.atlassian.net/browse/DOC-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ