### PR TITLE
DOC-1317 Adds topic_prefix field to redpanda_migrator output

### DIFF
--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -70,7 +70,7 @@ output:
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
-    topic prefix: "" # No default (optional) 
+    topic_prefix: source # No default (optional)
     max_in_flight: 256
     input_resource: redpanda_migrator_input
     replication_factor_override: true
@@ -584,6 +584,12 @@ Adds the specified prefix to the name of each migrated topic. This field support
 *Type*: `string`
 
 *Default*: `""`
+
+```yml
+# Examples
+
+topic_prefix: source
+```
 
 
 === `timestamp_ms`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -70,6 +70,7 @@ output:
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
+    topic prefix: "" # No default (optional) 
     max_in_flight: 256
     input_resource: redpanda_migrator_input
     replication_factor_override: true
@@ -575,6 +576,14 @@ Define how long connections can remain idle before they are closed.
 *Type*: `string`
 
 *Default*: `20s`
+
+=== `topic_prefix`
+
+Adds the specified prefix to the name of each migrated topic. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
 
 
 === `timestamp_ms`

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -70,7 +70,7 @@ output:
     request_timeout_overhead: 10s
     conn_idle_timeout: 20s
     timestamp_ms: ${! timestamp_unix_milli() } # No default (optional)
-    topic_prefix: source # No default (optional)
+    topic_prefix: source. # No default (optional)
     max_in_flight: 256
     input_resource: redpanda_migrator_input
     replication_factor_override: true
@@ -588,7 +588,7 @@ Adds the specified prefix to the name of each migrated topic. This field support
 ```yml
 # Examples
 
-topic_prefix: source
+topic_prefix: source.
 ```
 
 


### PR DESCRIPTION
## Description

Resolves [DOC-1317](https://redpandadata.atlassian.net/browse/DOC-1317)
Review deadline: 15 May

This pull request introduces a new configuration option, `topic_prefix`, to the Redpanda Migrator documentation. The change allows users to specify a prefix for migrated topic names, enhancing flexibility in topic naming.

### Documentation Updates:
* [`modules/components/pages/outputs/redpanda_migrator.adoc`](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4R73): Added a new configuration field, `topic_prefix`, which allows users to prepend a specified string to the names of migrated topics. This field supports interpolation functions and has a default value of an empty string. [[1]](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4R73) [[2]](diffhunk://#diff-8ac53c4414b1931639c3db5e6efce57d9a764192bd996f242084a3d4a30aebc4R580-R587)

## Page previews

[`redpanda_migrator` output](https://deploy-preview-242--redpanda-connect.netlify.app/redpanda-connect/components/outputs/redpanda_migrator/#topic_prefix)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1317]: https://redpandadata.atlassian.net/browse/DOC-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ