### PR TITLE
DOC-1315 Add credentials fields to aws_kinesis input

### DIFF
--- a/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/modules/components/pages/inputs/aws_kinesis.adoc
@@ -23,7 +23,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   aws_kinesis:
@@ -48,7 +48,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   aws_kinesis:

--- a/modules/components/pages/inputs/aws_kinesis.adoc
+++ b/modules/components/pages/inputs/aws_kinesis.adoc
@@ -54,32 +54,40 @@ input:
   aws_kinesis:
     streams: [] # No default (required)
     dynamodb:
-      table: ""
+      table: "" # No default (required)
       create: false
       billing_mode: PAY_PER_REQUEST
       read_capacity_units: 0
       write_capacity_units: 0
+      credentials:
+        profile: "" # No default (optional)
+        id: "" # No default (optional)
+        secret: "" # No default (optional)
+        token: "" # No default (optional)
+        from_ec2_role: false # No default (optional)
+        role: "" # No default (optional)
+        role_external_id: "" # No default (optional)
     checkpoint_limit: 1024
     auto_replay_nacks: true
     commit_period: 5s
     rebalance_period: 30s
     lease_period: 30s
     start_from_oldest: true
-    region: ""
-    endpoint: ""
+    region: "" # No default (optional)
+    endpoint: "" # No default (optional)
     credentials:
-      profile: ""
-      id: ""
-      secret: ""
-      token: ""
+      profile: "" # No default (optional)
+      id: "" # No default (optional)
+      secret: "" # No default (optional)
+      token: "" # No default (optional)
       from_ec2_role: false
-      role: ""
-      role_external_id: ""
+      role: "" # No default (optional)
+      role_external_id: "" # No default (optional)
     batching:
       count: 0
       byte_size: 0
-      period: ""
-      check: ""
+      period: "" # No default (optional)
+      check: "" # No default (optional)
       processors: [] # No default (optional)
 ```
 
@@ -179,6 +187,97 @@ Set the provisioned write capacity when creating the table with a `billing_mode`
 
 *Default*: `0`
 
+
+=== `dynamodb.region`
+
+The AWS region to target.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.endpoint`
+
+Specify a custom endpoint for the AWS API.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials`
+
+Manually configure the AWS credentials to use (optional). For more information, see the xref:guides:cloud/aws.adoc[].
+
+*Type*: `object`
+
+=== `dynamodb.credentials.profile`
+
+The profile from `~/.aws/credentials` to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials.id`
+
+The ID of the AWS credentials to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials.secret`
+
+The secret for the AWS credentials in use.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials.token`
+
+The token for the AWS credentials in use. This is a required value for short-term credentials.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials.from_ec2_role`
+
+Use the credentials of a host EC2 machine configured to assume https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[an IAM role associated with the instance^].
+
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 4.2.0 or newer
+endif::[]
+
+=== `dynamodb.credentials.role`
+
+The role ARN to assume.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `dynamodb.credentials.role_external_id`
+
+An external ID to use when assuming a role.
+
+
+*Type*: `string`
+
+*Default*: `""`
+
 === `checkpoint_limit`
 
 The maximum gap between the in flight sequence versus the latest acknowledged sequence at a given time. Increasing this limit enables parallel processing and batching at the output level to work on individual shards. Any given sequence will not be committed unless all messages under that offset are delivered in order to preserve at least once delivery guarantees.
@@ -244,7 +343,7 @@ The AWS region to target.
 
 === `endpoint`
 
-Allows you to specify a custom endpoint for the AWS API.
+Specify a custom endpoint for the AWS API.
 
 
 *Type*: `string`
@@ -253,16 +352,13 @@ Allows you to specify a custom endpoint for the AWS API.
 
 === `credentials`
 
-Optional manual configuration of AWS credentials to use. More information can be found in xref:guides:cloud/aws.adoc[].
-
+Manually configure the AWS credentials to use (optional). For more information, see the xref:guides:cloud/aws.adoc[].
 
 *Type*: `object`
 
-
 === `credentials.profile`
 
-A profile from `~/.aws/credentials` to use.
-
+The profile from `~/.aws/credentials` to use.
 
 *Type*: `string`
 
@@ -270,8 +366,7 @@ A profile from `~/.aws/credentials` to use.
 
 === `credentials.id`
 
-The ID of credentials to use.
-
+The ID of the AWS credentials to use.
 
 *Type*: `string`
 
@@ -279,7 +374,7 @@ The ID of credentials to use.
 
 === `credentials.secret`
 
-The secret for the credentials being used.
+The secret for the AWS credentials in use.
 
 include::components:partial$secret_warning.adoc[]
 
@@ -289,7 +384,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `credentials.token`
 
-The token for the credentials being used, required when using short term credentials.
+The token for the AWS credentials in use. This is a required value for short-term credentials.
 
 
 *Type*: `string`
@@ -311,7 +406,7 @@ endif::[]
 
 === `credentials.role`
 
-A role ARN to assume.
+The role ARN to assume.
 
 
 *Type*: `string`
@@ -320,7 +415,7 @@ A role ARN to assume.
 
 === `credentials.role_external_id`
 
-An external ID to provide when assuming a role.
+An external ID to use when assuming a role.
 
 
 *Type*: `string`

--- a/modules/components/pages/inputs/aws_s3.adoc
+++ b/modules/components/pages/inputs/aws_s3.adoc
@@ -20,7 +20,7 @@ Common::
 --
 
 ```yml
-# Common config fields, showing default values
+# Common configuration fields, showing default values
 input:
   label: ""
   aws_s3:
@@ -41,7 +41,7 @@ Advanced::
 --
 
 ```yml
-# All config fields, showing default values
+# All configuration fields, showing default values
 input:
   label: ""
   aws_s3:


### PR DESCRIPTION
## Description

Resolves [DOC-1315](https://redpandadata.atlassian.net/browse/DOC-1315)
Review deadline: 13 May

This pull request updates the AWS Kinesis and AWS S3 input documentation to improve clarity, add missing details, and introduce new configuration options for AWS credentials. The most significant changes include the addition of detailed descriptions for DynamoDB and Kinesis credential fields, updates to existing descriptions for consistency, and minor corrections in the AWS S3 documentation.

### AWS Kinesis Documentation Updates:

#### New Configuration Options:
* Added detailed descriptions for `dynamodb.credentials`, including fields like `profile`, `id`, `secret`, `token`, `from_ec2_role`, `role`, and `role_external_id`. These fields allow for more granular control over AWS credentials. [[1]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L57-R90) [[2]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218R190-R280)

#### Improved Descriptions:
* Updated descriptions for `endpoint`, `credentials`, and their subfields (e.g., `credentials.token`, `credentials.role`, `credentials.role_external_id`) to enhance clarity and consistency. [[1]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L247-R346) [[2]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L256-R377) [[3]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L292-R387) [[4]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L314-R409) [[5]](diffhunk://#diff-4351cceebb80c15c78a27a23373ab5b1946dd6368a2bba8c907b2f01b6a10218L323-R418)

### AWS S3 Documentation Updates:

#### Minor Corrections:
* Corrected wording in comments for configuration examples, changing "config fields" to "configuration fields" for improved readability. [[1]](diffhunk://#diff-016c80d8952b6ffb4277901d19e1f061159f5e722b4f3fc7d05445b6b07f6d97L23-R23) [[2]](diffhunk://#diff-016c80d8952b6ffb4277901d19e1f061159f5e722b4f3fc7d05445b6b07f6d97L44-R44)

## Page previews

[`aws_kinesis` input](https://deploy-preview-246--redpanda-connect.netlify.app/redpanda-connect/components/inputs/aws_kinesis/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1315]: https://redpandadata.atlassian.net/browse/DOC-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ