### PR TITLE
DOC-1311 Add google_drive_list_labels processor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -146,6 +146,7 @@
 *** xref:components:processors/gcp_bigquery_select.adoc[]
 *** xref:components:processors/gcp_vertex_ai_chat.adoc[]
 *** xref:components:processors/gcp_vertex_ai_embeddings.adoc[]
+*** xref:components:processors/google_drive_list_labels.adoc[]
 *** xref:components:processors/grok.adoc[]
 *** xref:components:processors/group_by.adoc[]
 *** xref:components:processors/group_by_value.adoc[]

--- a/modules/components/pages/processors/google_drive_list_labels.adoc
+++ b/modules/components/pages/processors/google_drive_list_labels.adoc
@@ -1,0 +1,57 @@
+= google_drive_list_labels
+// tag::single-source[]
+:type: processor
+:categories: ["AI"]
+
+component_type_dropdown::[]
+
+Lists https://developers.google.com/workspace/drive/api/guides/about-labels[labels] for files on a Google Drive.
+
+ifndef::env-cloud[]
+Introduced in version 4.53.0.
+endif::[]
+
+```yml
+# Configuration fields, showing default values
+label: ""
+google_drive_list_labels:
+  credentials_json: "" # No default (optional)
+```
+
+== Authentication
+
+By default, this processor uses https://cloud.google.com/docs/authentication/application-default-credentials[Google Application Default Credentials (ADC)^] to authenticate with Google APIs.
+
+To set up local ADC authentication, use the following `gcloud` commands:
+
+- Authenticate using Application Default Credentials and grant read-only access to your Google Drive.
++
+```bash
+gcloud auth application-default login --scopes='openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive.readonly'
+```
+- Assign a quota project to the Application Default Credentials when using a user account.
++
+```bash
+gcloud auth application-default set-quota-project <project-id>
+```
++
+Replace the `<project-id>` placeholder with your Google Cloud project ID
+
+To use a service account instead, create a JSON key for the account and add it to the <<credentials_json,`credentials_json`>> field. To access Google Drive files using a service account, either:
+
+- Explicitly share files with the service account's email account
+- Use https://support.google.com/a/answer/162106[domain-wide delegation^] to share all files within a Google Workspace
+
+== Fields
+
+=== `credentials_json`
+
+The JSON key for your service account (optional). If left empty, Application Default Credentials are used. For more details, see <<authentication, Authentication>>.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves [DOC-1311](https://redpandadata.atlassian.net/browse/DOC-1311)
Review deadline: 14 May

Related Cloud PR: [https://github.com/redpanda-data/cloud-docs/pull/292](https://github.com/redpanda-data/cloud-docs/pull/292)

This pull request introduces a new processor for Google Drive, `google_drive_list_labels`, and updates the documentation to include it. The most important changes are the addition of the processor's documentation and its inclusion in the navigation structure.

### New Processor Documentation:
* [`modules/components/pages/processors/google_drive_list_labels.adoc`](diffhunk://#diff-d8d11be79bc3157c2dcb191c34a2cd5ead0376fdbbd3951ab1db1be2d3f486e8R1-R57): Added a new documentation page for the `google_drive_list_labels` processor, detailing its purpose, configuration, authentication methods, and fields. This processor lists labels for files on Google Drive and supports both Application Default Credentials and service account authentication.

### Navigation Update:
* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R149): Updated the navigation to include a link to the newly added `google_drive_list_labels` processor documentation.

## Page previews

[`google_drive_list_labels` processor](https://deploy-preview-249--redpanda-connect.netlify.app/redpanda-connect/components/processors/google_drive_list_labels/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1311]: https://redpandadata.atlassian.net/browse/DOC-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ