### PR TITLE
DOC-1328 Add qdrant processor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -180,6 +180,7 @@
 *** xref:components:processors/parse_log.adoc[]
 *** xref:components:processors/processors.adoc[]
 *** xref:components:processors/protobuf.adoc[]
+*** xref:components:processors/qdrant.adoc[]
 *** xref:components:processors/rate_limit.adoc[]
 *** xref:components:processors/redpanda_data_transform.adoc[]
 *** xref:components:processors/redis.adoc[]

--- a/modules/components/pages/outputs/qdrant.adoc
+++ b/modules/components/pages/outputs/qdrant.adoc
@@ -226,7 +226,7 @@ include::components:partial$secret_warning.adoc[]
 
 === `tls`
 
-TLS(HTTPS) config to use when connecting
+Specify a secure TLS (HTTPS) connection to the Qdrant server.
 
 
 *Type*: `object`

--- a/modules/components/pages/outputs/redpanda.adoc
+++ b/modules/components/pages/outputs/redpanda.adoc
@@ -136,7 +136,7 @@ Whether to skip server-side certificate verification.
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you’re seeing the error message Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
 
 *Type*: `bool`
 

--- a/modules/components/pages/processors/qdrant.adoc
+++ b/modules/components/pages/processors/qdrant.adoc
@@ -1,0 +1,325 @@
+= qdrant
+// tag::single-source[]
+:type: processor
+:categories: ["AI"]
+
+component_type_dropdown::[]
+Query items within a https://qdrant.tech/documentation/concepts/collections/[Qdrant collection^] and filter the returned results.
+
+ifndef::env-cloud[]
+Introduced in version 4.54.0.
+endif::[]
+
+[tabs]
+======
+Common::
++
+--
+```yml
+# Common configuration fields, showing default values
+label: ""
+qdrant:
+  grpc_host: localhost:6334 # No default (required)
+  api_token: ""
+  collection_name: "" # No default (required)
+  vector_mapping: root = [1.2, 0.5, 0.76] # No default (required)
+  filter: | # No default (optional)
+    root.must = [
+    	{"has_id":{"has_id":[{"num": 8}, { "uuid":"1234-5678-90ab-cdef" }]}},
+    	{"field":{"key": "city", "match": {"text": "London"}}},
+    ]
+  payload_fields: []  
+  payload_filter: include
+  limit: 10
+```
+--
+Advanced::
++
+--
+```yml
+# All configuration fields, showing default values
+label: ""
+qdrant:
+  grpc_host: localhost:6334 # No default (required)
+  api_token: ""
+  tls:
+    enabled: false
+    skip_cert_verify: false
+    enable_renegotiation: false
+    root_cas: ""
+    root_cas_file: ""
+    client_certs: []
+  collection_name: "" # No default (required)
+  vector_mapping: root = [1.2, 0.5, 0.76] # No default (required)
+  filter: | # No default (optional)
+    root.must = [
+    	{"has_id":{"has_id":[{"num": 8}, { "uuid":"1234-5678-90ab-cdef" }]}},
+    	{"field":{"key": "city", "match": {"text": "London"}}},
+    ]
+  payload_fields: []
+  payload_filter: include
+  limit: 10
+```
+--
+======
+
+== Fields
+
+=== `grpc_host`
+
+The gRPC host of the Qdrant server.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+grpc_host: localhost:6334
+
+grpc_host: xyz-example.eu-central.aws.cloud.qdrant.io:6334
+```
+
+=== `api_token`
+
+The Qdrant API token to use for authentication, which defaults to an empty string.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls`
+
+Specify a secure TLS (HTTPS) connection to the Qdrant server.
+
+*Type*: `object`
+
+=== `tls.enabled`
+
+Whether custom TLS settings are enabled.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.skip_cert_verify`
+
+Whether to skip server-side certificate verification.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `tls.enable_renegotiation`
+
+Whether to allow the remote server to request renegotiation. Enable this option if you’re seeing the error message Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+ifndef::env-cloud[]
+Requires version 3.45.0 or newer
+endif::[]
+
+=== `tls.root_cas`
+
+Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas: |-
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+```
+
+=== `tls.root_cas_file`
+
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+root_cas_file: ./root_cas.pem
+```
+
+=== `tls.client_certs`
+
+A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+
+*Type*: `array`
+
+*Default*: `[]`
+
+```yml
+# Examples
+
+client_certs:
+  - cert: foo
+    key: bar
+
+client_certs:
+  - cert_file: ./example.pem
+    key_file: ./example.key
+```
+
+=== `tls.client_certs[].cert`
+
+The plain text certificate to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key`
+
+The plain text certificate key to use.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].cert_file`
+
+The path to the certificate to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].key_file`
+
+The path of a certificate key to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `tls.client_certs[].password`
+
+The plain text password for when the private key is password encrypted in PKCS#1 or PKCS#8 format. The obsolete `pbeWithMD5AndDES-CBC` algorithm is not supported for the PKCS#8 format. 
+
+WARNING: The `pbeWithMD5AndDES-CBC` algorithm does not authenticate ciphertext, and is vulnerable to padding oracle attacks that may allow an attacker to recover the plain text password.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+password: foo
+
+password: ${KEY_PASSWORD}
+```
+
+=== `collection_name`
+
+The name of the Qdrant collection you want to query. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+=== `vector_mapping`
+
+A mapping to extract search vectors from the returned document.
+
+*Type*: `string`
+
+
+```yml
+# Examples
+
+vector_mapping: root = [1.2, 0.5, 0.76]
+
+vector_mapping: root = this.vector
+
+vector_mapping: root = [[0.352,0.532,0.532,0.234],[0.352,0.532,0.532,0.234]]
+
+vector_mapping: 'root = {"some_sparse": {"indices":[23,325,532],"values":[0.352,0.532,0.532]}}'
+
+vector_mapping: 'root = {"some_multi": [[0.352,0.532,0.532,0.234],[0.352,0.532,0.532,0.234]]}'
+
+vector_mapping: 'root = {"some_dense": [0.352,0.532,0.532,0.234]}'
+```
+
+=== `filter`
+
+Specify additional filtering to perform on returned results. Mappings must return https://qdrant.tech/documentation/concepts/filtering/[a valid filter^] using the proto3-encoded form.
+
+*Type*: `string`
+
+```yml
+# Examples
+
+filter: |2
+  root.must = [
+  	{"has_id":{"has_id":[{"num": 8}, { "uuid":"1234-5678-90ab-cdef" }]}},
+  	{"field":{"key": "city", "match": {"text": "London"}}},
+  ]
+
+filter: |2
+  root.must = [
+  	{"field":{"key": "city", "match": {"text": "London"}}},
+  ]
+  root.must_not = [
+  	{"field":{"color": "city", "match": {"text": "red"}}},
+  ]
+```
+
+=== `payload_fields`
+
+The fields to include or exclude in returned results. Use this field in combination with `payload_filter`.
+
+*Type*: `array`
+
+*Default*: `[]`
+
+=== `payload_filter`
+
+Whether to include or exclude the fields specified in `payload_fields` from the returned results.
+
+*Type*: `string`
+
+*Default*: `include`
+
+|===
+| Option | Description
+
+| `exclude`
+| Exclude `payload_fields` from the returned results.
+
+| `include`
+| Include `payload_fields` from the returned results.
+
+|===
+
+=== `limit`
+
+The maximum number of points to return from the collection.
+
+*Type*: `int`
+
+*Default*: `10`
+
+
+
+// end::single-source[]

--- a/modules/components/pages/processors/qdrant.adoc
+++ b/modules/components/pages/processors/qdrant.adoc
@@ -115,7 +115,7 @@ Whether to skip server-side certificate verification.
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you’re seeing the error message Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
 
 *Type*: `bool`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1328](https://redpandadata.atlassian.net/browse/DOC-1328)
Review deadline: 15 May

Related cloud PR: [https://github.com/redpanda-data/cloud-docs/pull/294](https://github.com/redpanda-data/cloud-docs/pull/294)

This pull request introduces a new Qdrant processor to the documentation, along with updates to related files to support its inclusion. The Qdrant processor integrates with the Qdrant vector database, providing configuration options for secure connections, querying, and filtering. Below are the key changes grouped by theme:

### New Qdrant Processor Documentation

* Added a new file `modules/components/pages/processors/qdrant.adoc` to document the Qdrant processor, including its configuration fields (e.g., `grpc_host`, `api_token`, `tls`) and usage examples. This includes support for TLS settings, vector mapping, filtering, and payload field management.

### Navigation Updates

* Updated `modules/ROOT/nav.adoc` to include a link to the new Qdrant processor documentation.

### TLS Configuration Clarification

* Improved the description of the `tls` field in `modules/components/pages/outputs/qdrant.adoc` to clarify its purpose as specifying a secure TLS connection to the Qdrant server.

## Page previews

[`qdrant` processor](https://deploy-preview-251--redpanda-connect.netlify.app/redpanda-connect/components/processors/qdrant/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1328]: https://redpandadata.atlassian.net/browse/DOC-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ