### PR TITLE
DOC-1312 Add use_enum_numbers and general editing

### DIFF
--- a/modules/components/pages/processors/protobuf.adoc
+++ b/modules/components/pages/processors/protobuf.adoc
@@ -21,6 +21,7 @@ protobuf:
   discard_unknown: false
   use_proto_names: false
   import_paths: []
+  use_enum_numbers: false
 ```
 
 == Performance considerations

--- a/modules/components/pages/processors/protobuf.adoc
+++ b/modules/components/pages/processors/protobuf.adoc
@@ -4,18 +4,16 @@
 :status: stable
 :categories: ["Parsing"]
 
-// © 2024 Redpanda Data Inc.
-
 
 component_type_dropdown::[]
 
+Handles conversions between JSON documents and protobuf messages using reflection, which allows you to make conversions from or to the target `.proto` files.
 
-
-Performs conversions to or from a protobuf message. This processor uses reflection, meaning conversions can be made directly from the target .proto files.
+For more information about JSON mapping of protobuf messages, see https://protobuf.dev/programming-guides/json/[ProtoJSON Format^] and <<Examples, Examples>>.
 
 
 ```yml
-# Config fields, showing default values
+# Configuration fields, showing default values
 label: ""
 protobuf:
   operator: "" # No default (required)
@@ -25,31 +23,85 @@ protobuf:
   import_paths: []
 ```
 
-The main functionality of this processor is to map to and from JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json[https://developers.google.com/protocol-buffers/docs/proto3#json^]
+== Performance considerations
 
-Using reflection for processing protobuf messages in this way is less performant than generating and using native code. Therefore when performance is critical it is recommended that you use Redpanda Connect plugins instead for processing protobuf messages natively, you can find an example of Redpanda Connect plugins at https://github.com/benthosdev/benthos-plugin-example[https://github.com/benthosdev/benthos-plugin-example^]
+Processing protobuf messages using reflection is less performant than using generated native code. For scenarios where performance is critical, consider using https://github.com/benthosdev/benthos-plugin-example[Redpanda Connect plugins^].
 
 == Operators
 
 === `to_json`
 
-Converts protobuf messages into a generic JSON structure. This makes it easier to manipulate the contents of the document within Benthos.
+Converts protobuf messages into a generic JSON structure, which makes it easier to manipulate the contents of the JSON document within Redpanda Connect.
 
 === `from_json`
 
 Attempts to create a target protobuf message from a generic JSON structure.
+
+== Fields
+
+=== `operator`
+
+The <<operators, operator>> to execute.
+
+*Type*: `string`
+
+
+Options:
+`to_json`
+, `from_json`
+
+
+=== `message`
+
+The fully-qualified name of the protobuf message to convert from or to JSON.
+
+
+*Type*: `string`
+
+
+=== `discard_unknown`
+
+When set to `true`, the `from_json` operator discards fields that are unknown to the schema.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `use_proto_names`
+
+When set to `true`, the `to_json` operator deserializes fields exactly as named in schema file.
+
+*Type*: `bool`
+
+*Default*: `false`
+
+=== `import_paths`
+
+A list of directories containing `.proto` files, including all definitions required for parsing the target message. If left empty, the current directory is used. This processor imports all `.proto` files listed within specified or default directories.
+
+*Type*: `array`
+
+*Default*: `[]`
+
+=== `use_enum_numbers`
+
+When set to `true`, the `to_json` operator deserializes enumeration fields as their numerical values instead of their string names. For example, an enum field with a value of `ENUM_VALUE_ONE` is represented as `1` in the JSON output.
+
+*Type*: `bool`
+
+*Default*: `false`
 
 
 == Examples
 
 [tabs]
 ======
-JSON to Protobuf::
+JSON to Protobuf conversion::
 +
 --
 
 
-If we have the following protobuf definition within a directory called `testing/schema`:
+A protobuf definition is stored in the `testing/schema` directory:
 
 ```protobuf
 syntax = "proto3";
@@ -69,7 +121,7 @@ message Person {
 }
 ```
 
-And a stream of JSON documents of the form:
+And you have a stream of JSON documents with the format:
 
 ```json
 {
@@ -79,7 +131,7 @@ And a stream of JSON documents of the form:
 }
 ```
 
-We can convert the documents into protobuf messages with the following config:
+The following configuration converts the JSON documents into protobuf messages:
 
 ```yaml
 pipeline:
@@ -91,12 +143,12 @@ pipeline:
 ```
 
 --
-Protobuf to JSON::
+Protobuf to JSON conversion::
 +
 --
 
 
-If we have the following protobuf definition within a directory called `testing/schema`:
+A protobuf definition is stored in the `testing/schema` directory:
 
 ```protobuf
 syntax = "proto3";
@@ -116,7 +168,7 @@ message Person {
 }
 ```
 
-And a stream of protobuf messages of the type `Person`, we could convert them into JSON documents of the format:
+And you have a stream of protobuf messages of the type `Person`:
 
 ```json
 {
@@ -126,7 +178,7 @@ And a stream of protobuf messages of the type `Person`, we could convert them in
 }
 ```
 
-With the following config:
+The following configuration converts the messages into JSON documents:
 
 ```yaml
 pipeline:
@@ -139,55 +191,5 @@ pipeline:
 
 --
 ======
-
-== Fields
-
-=== `operator`
-
-The <<operators, operator>> to execute
-
-
-*Type*: `string`
-
-
-Options:
-`to_json`
-, `from_json`
-.
-
-=== `message`
-
-The fully qualified name of the protobuf message to convert to/from.
-
-
-*Type*: `string`
-
-
-=== `discard_unknown`
-
-If `true`, the `from_json` operator discards fields that are unknown to the schema.
-
-
-*Type*: `bool`
-
-*Default*: `false`
-
-=== `use_proto_names`
-
-If `true`, the `to_json` operator deserializes fields exactly as named in schema file.
-
-
-*Type*: `bool`
-
-*Default*: `false`
-
-=== `import_paths`
-
-A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported.
-
-
-*Type*: `array`
-
-*Default*: `[]`
 
 // end::single-source[]

--- a/modules/components/pages/processors/protobuf.adoc
+++ b/modules/components/pages/processors/protobuf.adoc
@@ -77,7 +77,7 @@ When set to `true`, the `to_json` operator deserializes fields exactly as named 
 
 === `import_paths`
 
-A list of directories containing `.proto` files, including all definitions required for parsing the target message. If left empty, the current directory is used. This processor imports all `.proto` files listed within specified or default directories.
+A list of directories that contain `.proto` files, including all definitions required for parsing the target message. If left empty, the current directory is used. This processor imports all `.proto` files listed within specified or default directories.
 
 *Type*: `array`
 


### PR DESCRIPTION
## Description

Resolves [DOC-1312](https://redpandadata.atlassian.net/browse/DOC-1312)
Review deadline: 15 May

This pull request updates the documentation for the Protobuf processor to improve clarity, provide additional details, and structure the content more effectively. The primary changes include rewording for better readability, adding a new section on performance considerations, and expanding the descriptions of configuration fields.

### Documentation Enhancements:

* **Improved clarity and readability**:
  - Rephrased explanations for JSON-to-Protobuf and Protobuf-to-JSON conversions to make them more concise and user-friendly. [[1]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L72-R124) [[2]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L82-R134) [[3]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L94-R151) [[4]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L119-R171) [[5]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L129-R181)
  - Updated section headings to be more descriptive, such as renaming "Fields" to "Configuration fields" and updating example titles. [[1]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L7-R16) [[2]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L28-R104)

* **Added performance considerations**:
  - Introduced a new section highlighting the trade-offs of using reflection for Protobuf processing and recommending Redpanda Connect plugins for performance-critical scenarios.

* **Expanded configuration field descriptions**:
  - Added detailed explanations for fields such as `operator`, `message`, `discard_unknown`, `use_proto_names`, `import_paths`, and `use_enum_numbers`, including their types, default values, and usage. [[1]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L7-R16) [[2]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L28-R104)

* **Updated references and links**:
  - Replaced outdated links with updated references to official documentation and examples, ensuring accuracy and relevance. [[1]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L7-R16) [[2]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L28-R104)

* **Reorganized content**:
  - Rearranged sections for better logical flow, moving performance considerations closer to the beginning and grouping related configuration fields together. [[1]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L28-R104) [[2]](diffhunk://#diff-a4d6ada951ca591a8ffb01021b367de90a22d6b9df7bb76b736f6afa235748d1L143-L192)

## Page previews

[`protobuf` processor](https://deploy-preview-252--redpanda-connect.netlify.app/redpanda-connect/components/processors/protobuf/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1312]: https://redpandadata.atlassian.net/browse/DOC-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ