### PR TITLE
DOC-1316 Add cohere_rerank processor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -135,6 +135,7 @@
 *** xref:components:processors/cached.adoc[]
 *** xref:components:processors/cohere_chat.adoc[]
 *** xref:components:processors/cohere_embeddings.adoc[]
+*** xref:components:processors/cohere_rerank.adoc[]
 *** xref:components:processors/catch.adoc[]
 *** xref:components:processors/command.adoc[]
 *** xref:components:processors/compress.adoc[]

--- a/modules/components/pages/processors/cohere_rerank.adoc
+++ b/modules/components/pages/processors/cohere_rerank.adoc
@@ -5,7 +5,7 @@
 
 component_type_dropdown::[]
 
-Sends document strings to the https://docs.cohere.com/docs/rerank-2[Cohere API^], which returns them https://docs.cohere.com/reference/rerank[ranked by their relevance to a specified query^].
+Sends document strings to the https://docs.cohere.com/reference/rerank[Cohere API^], which returns them https://docs.cohere.com/docs/rerank-2[ranked by their relevance to a specified query^].
 
 The output of this processor is an array of strings, ordered by their relevance to the query.
 

--- a/modules/components/pages/processors/cohere_rerank.adoc
+++ b/modules/components/pages/processors/cohere_rerank.adoc
@@ -1,0 +1,125 @@
+= cohere_rerank
+// tag::single-source[]
+:type: processor
+:categories: ["AI"]
+
+component_type_dropdown::[]
+
+Sends document strings to the https://docs.cohere.com/docs/rerank-2[Cohere API^], which returns them https://docs.cohere.com/reference/rerank[ranked by their relevance to a specified query^].
+
+The output of this processor is an array of strings, ordered by their relevance to the query.
+
+ifndef::env-cloud[]
+Introduced in version 4.53.0.
+endif::[]
+
+```yml
+# Configuration fields, showing default values
+label: ""
+cohere_rerank:
+  base_url: https://api.cohere.com
+  api_key: "" # No default (required)
+  model: rerank-v3.5 # No default (required)
+  query: "" # No default (required)
+  documents: "" # No default (required)
+  top_n: 0
+  max_tokens_per_doc: 4096
+```
+
+== Metadata
+
+- `relevance_scores`: An array of scores for each input document that indicates how relevant it is to the query. The scores are in the same order as the documents in the input. The higher the score, the more relevant the document.
+
+== Examples
+
+This pipeline reranks the input documents based on how closely they match the query specified in the `cohere_rerank` processor.
+
+```yaml
+input:
+  generate:
+    interval: 1s
+    mapping: |
+      root = {
+        "query": fake("sentence"),
+        "docs": [fake("paragraph"), fake("paragraph"), fake("paragraph")],
+      }
+pipeline:
+  processors:
+  - cohere_rerank:
+      model: rerank-v3.5
+      api_key: "${COHERE_API_KEY}"
+      query: "${!this.query}"
+      documents: "root = this.docs"
+output:
+  stdout: {}```
+```
+
+== Fields
+
+=== `base_url`
+
+The base URL to use for API requests.
+
+*Type*: `string`
+
+*Default*: `https://api.cohere.com`
+
+=== `api_key`
+
+Your API key for the Cohere API.
+
+include::components:partial$secret_warning.adoc[]
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `model`
+
+The name of the Cohere LLM you want to use.
+
+*Type*: `string`
+
+*Default*: `""`
+
+```yml
+# Examples
+
+model: rerank-v3.5
+```
+=== `query`
+
+The search query you want to execute. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `documents`
+
+A list of text strings that are compared to the specified query. For optimal performance:
+
+- Send fewer than 1000 documents in a single request
+- Send structured data in YAML format
+
+*Type*: `string`
+
+*Default*: `""`
+
+=== `top_n`
+
+The number of documents to return when the query is executed. If set to `0`, all documents are returned.
+
+*Type*: `int`
+
+*Default*: `0`
+
+=== `max_tokens_per_doc`
+
+This processor automatically truncates long documents to the specified number of tokens.
+
+*Type*: `int`
+
+*Default*: `4096`
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Resolves [DOC-1316](https://redpandadata.atlassian.net/browse/DOC-1316)
Review deadline: 16 May

Related Cloud PR: [https://github.com/redpanda-data/cloud-docs/pull/296](https://github.com/redpanda-data/cloud-docs/pull/296)

This pull request introduces a new processor, `cohere_rerank`, to the documentation. The processor integrates with the Cohere API to rank documents based on their relevance to a specified query. The changes include adding the processor to the navigation and providing detailed documentation about its configuration, metadata, and usage.

### Additions to Documentation:

* **Navigation Update**:
  - Added a reference to the new `cohere_rerank` processor in the navigation file `modules/ROOT/nav.adoc` to make it accessible in the documentation structure.

* **New Processor Documentation**:
  - Created a new file `modules/components/pages/processors/cohere_rerank.adoc` that documents the `cohere_rerank` processor. This includes:
    - Description of its functionality: Sends document strings to the Cohere API for ranking based on relevance to a query.
    - Configuration fields with examples, such as `api_key`, `model`, `query`, `documents`, `top_n`, and `max_tokens_per_doc`.
    - Metadata output, including `relevance_scores`.
    - Example pipeline usage to demonstrate how the processor can be integrated into workflows.

## Page previews

[`cohere_rerank` processor](https://deploy-preview-254--redpanda-connect.netlify.app/redpanda-connect/components/processors/cohere_rerank/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1316]: https://redpandadata.atlassian.net/browse/DOC-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ