### PR TITLE
Add permissions for GitHub Action

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,8 +6,12 @@ on:
     types: [generate-rpcn-docs]
 
 jobs:
-  generate-and-pr:
+  generate-docs-and-submit-pull-request:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     concurrency:
       group: update-rpcn-connector-docs


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow in `.github/workflows/update-docs.yml` to improve job naming and permissions configuration.

### Workflow improvements:

* Renamed the job from `generate-and-pr` to `generate-docs-and-submit-pull-request` for better clarity.
* Added `permissions` configuration with `id-token: write` and `contents: read` to enhance security and control over access.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)