### PR TITLE
DOC-1557 Update fields to explicitly call out their use for mTLS

### DIFF
--- a/docs-data/overrides.json
+++ b/docs-data/overrides.json
@@ -1,4 +1,174 @@
 {
+  "definitions": {
+    "client_certs_description": {
+      "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk."
+    },
+    "skip_cert_verify_description": {
+      "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production."
+    },
+    "tls_description": {
+      "description": "Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates."
+    },
+    "count_description": {
+      "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+    },
+    "root_cas_file_description": {
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+    },
+    "processors_description": {
+      "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+    },
+    "tls_handshake_first_description": {
+      "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation."
+    },
+    "initial_interval_description": {
+      "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+    },
+    "check_description": {
+      "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+    },
+    "urls_description": {
+      "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+    },
+    "nkey_description": {
+      "description": "Your NKey seed or private key."
+    },
+    "user_credentials_file_description": {
+      "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+    },
+    "user_jwt_description": {
+      "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+    },
+    "byte_size_description": {
+      "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+    },
+    "period_description": {
+      "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+    },
+    "user_nkey_seed_description": {
+      "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+    },
+    "auto_replay_nacks_description": {
+      "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+    },
+    "oauth_description": {
+      "description": "Allows you to specify open authentication using OAuth version 1."
+    },
+    "access_token_secret_description": {
+      "description": "The secret that establishes ownership of the `oauth.access_token`."
+    },
+    "jwt_description": {
+      "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication."
+    },
+    "private_key_file_description": {
+      "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+    },
+    "signing_method_description": {
+      "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+    },
+    "headers_description": {
+      "description": "Add key/value headers to the JWT (optional)."
+    },
+    "conn_idle_timeout_description": {
+      "description": "Define how long connections can remain idle before they are closed."
+    },
+    "dsn_description": {
+      "description": "A Data Source Name to identify the target database."
+    },
+    "credentials_json_description": {
+      "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+    },
+    "consumer_secret_description": {
+      "description": "The secret used to establish ownership of the consumer key."
+    },
+    "topic_lag_refresh_period_description": {
+      "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+    },
+    "endpoint_description": {
+      "description": "Specify a custom endpoint for the AWS API."
+    },
+    "seed_brokers_description": {
+      "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+    },
+    "metadata_max_age_description": {
+      "description": "The maximum period of time after which metadata is refreshed."
+    },
+    "instance_id_description": {
+      "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+    },
+    "rebalance_timeout_description": {
+      "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+    },
+    "session_timeout_description": {
+      "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+    },
+    "heartbeat_interval_description": {
+      "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+    },
+    "start_offset_description": {
+      "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+    },
+    "fetch_max_wait_description": {
+      "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+    },
+    "fetch_min_bytes_description": {
+      "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+    },
+    "fetch_max_partition_bytes_description": {
+      "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+    },
+    "transaction_isolation_level_description": {
+      "description": "Defines how transactional messages are handled."
+    },
+    "enable_renegotiation_description": {
+      "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+    },
+    "username_description": {
+      "description": "The username of the account credentials to authenticate as."
+    },
+    "password_description": {
+      "description": "The password of the account credentials to authenticate with."
+    },
+    "metadata_description": {
+      "description": "Specify which (if any) metadata values are added to messages as headers."
+    },
+    "batching_description": {
+      "description": "Configure a xref:configuration:batching.adoc[batching policy]."
+    },
+    "broker_write_max_bytes_description": {
+      "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+    },
+    "root_cas_file_description_1": {
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+    },
+    "enable_renegotiation_description_1": {
+      "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
+    },
+    "root_cas_description_3": {
+      "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+    },
+    "root_cas_file_description_2": {
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+    },
+    "password_description_1": {
+      "description": "The password for the username used to authenticate with the SFTP server."
+    },
+    "key_description": {
+      "description": "The key to publish messages with.\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+    },
+    "key_description_1": {
+      "description": "An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+    },
+    "password_description_2": {
+      "description": "The password required to connect to the database."
+    },
+    "tls_description_1": {
+      "description": "Specify a secure TLS (HTTPS) connection to the Qdrant server."
+    },
+    "enabled_description": {
+      "description": "Whether to use OAuth version 1 in requests to the schema registry."
+    }
+  },
   "inputs": [
     {
       "name": "amqp_0_9",
@@ -55,7 +225,7 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as it reduces security."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
@@ -67,7 +237,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
             ]
           }
@@ -83,7 +253,7 @@
             "children": [
               {
                 "name": "endpoint",
-                "description": "Specify a custom endpoint for the AWS API."
+                "$ref": "#/definitions/endpoint_description"
               },
               {
                 "name": "credentials",
@@ -119,7 +289,7 @@
           },
           {
             "name": "endpoint",
-            "description": "Specify a custom endpoint for the AWS API."
+            "$ref": "#/definitions/endpoint_description"
           },
           {
             "name": "credentials",
@@ -216,7 +386,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           },
@@ -273,7 +443,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           }
         ]
       }
@@ -288,7 +458,7 @@
           },
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           }
         ]
       }
@@ -299,7 +469,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           }
         ]
       }
@@ -315,7 +485,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           },
           {
             "name": "credentials_json",
@@ -366,7 +536,7 @@
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "count",
@@ -465,7 +635,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -496,11 +666,10 @@
           },
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1.",
             "children": [
               {
                 "name": "consumer_secret",
-                "description": "The secret used to establish ownership of the consumer key."
+                "$ref": "#/definitions/consumer_secret_description"
               },
               {
                 "name": "access_token",
@@ -508,9 +677,10 @@
               },
               {
                 "name": "access_token_secret",
-                "description": "The secret that establishes ownership of the `oauth.access_token`."
+                "$ref": "#/definitions/access_token_secret_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "oauth2",
@@ -532,43 +702,43 @@
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "extract_headers",
@@ -668,29 +838,29 @@
         "children": [
           {
             "name": "seed_brokers",
-            "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+            "$ref": "#/definitions/seed_brokers_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -698,7 +868,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -706,7 +876,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "topics",
@@ -718,23 +888,23 @@
           },
           {
             "name": "instance_id",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+            "$ref": "#/definitions/instance_id_description"
           },
           {
             "name": "rebalance_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+            "$ref": "#/definitions/rebalance_timeout_description"
           },
           {
             "name": "session_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+            "$ref": "#/definitions/session_timeout_description"
           },
           {
             "name": "heartbeat_interval",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+            "$ref": "#/definitions/heartbeat_interval_description"
           },
           {
             "name": "start_offset",
-            "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+            "$ref": "#/definitions/start_offset_description"
           },
           {
             "name": "fetch_max_bytes",
@@ -742,19 +912,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+            "$ref": "#/definitions/fetch_max_wait_description"
           },
           {
             "name": "fetch_min_bytes",
-            "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+            "$ref": "#/definitions/fetch_min_bytes_description"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+            "$ref": "#/definitions/fetch_max_partition_bytes_description"
           },
           {
             "name": "transaction_isolation_level",
-            "description": "Defines how transactional messages are handled."
+            "$ref": "#/definitions/transaction_isolation_level_description"
           },
           {
             "name": "consumer_group",
@@ -774,25 +944,25 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           },
           {
             "name": "topic_lag_refresh_period",
-            "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+            "$ref": "#/definitions/topic_lag_refresh_period_description"
           },
           {
             "name": "auto_replay_nacks",
@@ -913,23 +1083,23 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           }
@@ -943,7 +1113,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "send_ack",
@@ -954,26 +1124,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -985,7 +1155,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "queue",
@@ -1000,15 +1170,15 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
@@ -1018,8 +1188,8 @@
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -1031,33 +1201,33 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -1069,26 +1239,26 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
@@ -1098,8 +1268,8 @@
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -1117,29 +1287,29 @@
               },
               {
                 "name": "tls",
-                "description": "Override system defaults with custom TLS settings.",
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "description": "Whether to skip server-side certificate verification."
+                    "$ref": "#/definitions/skip_cert_verify_description"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+                    "$ref": "#/definitions/enable_renegotiation_description"
                   },
                   {
                     "name": "root_cas",
-                    "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_description_3"
                   },
                   {
                     "name": "root_cas_file",
-                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_file_description"
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                    "$ref": "#/definitions/client_certs_description"
                   }
-                ]
+                ],
+                "$ref": "#/definitions/tls_description"
               },
               {
                 "name": "topics",
@@ -1155,23 +1325,23 @@
               },
               {
                 "name": "instance_id",
-                "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+                "$ref": "#/definitions/instance_id_description"
               },
               {
                 "name": "rebalance_timeout",
-                "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+                "$ref": "#/definitions/rebalance_timeout_description"
               },
               {
                 "name": "session_timeout",
-                "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+                "$ref": "#/definitions/session_timeout_description"
               },
               {
                 "name": "heartbeat_interval",
-                "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+                "$ref": "#/definitions/heartbeat_interval_description"
               },
               {
                 "name": "start_offset",
-                "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+                "$ref": "#/definitions/start_offset_description"
               },
               {
                 "name": "fetch_max_bytes",
@@ -1179,19 +1349,19 @@
               },
               {
                 "name": "fetch_max_wait",
-                "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+                "$ref": "#/definitions/fetch_max_wait_description"
               },
               {
                 "name": "fetch_min_bytes",
-                "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+                "$ref": "#/definitions/fetch_min_bytes_description"
               },
               {
                 "name": "fetch_max_partition_bytes",
-                "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+                "$ref": "#/definitions/fetch_max_partition_bytes_description"
               },
               {
                 "name": "transaction_isolation_level",
-                "description": "Defines how transactional messages are handled."
+                "$ref": "#/definitions/transaction_isolation_level_description"
               },
               {
                 "name": "consumer_group",
@@ -1211,19 +1381,19 @@
                 "children": [
                   {
                     "name": "count",
-                    "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                    "$ref": "#/definitions/count_description"
                   },
                   {
                     "name": "byte_size",
-                    "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                    "$ref": "#/definitions/byte_size_description"
                   },
                   {
                     "name": "period",
-                    "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                    "$ref": "#/definitions/period_description"
                   },
                   {
                     "name": "check",
-                    "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                    "$ref": "#/definitions/check_description"
                   },
                   {
                     "name": "processors",
@@ -1233,7 +1403,7 @@
               },
               {
                 "name": "topic_lag_refresh_period",
-                "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+                "$ref": "#/definitions/topic_lag_refresh_period_description"
               }
             ]
           },
@@ -1341,23 +1511,23 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           }
@@ -1370,15 +1540,14 @@
         "children": [
           {
             "name": "seed_brokers",
-            "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+            "$ref": "#/definitions/seed_brokers_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
@@ -1386,17 +1555,18 @@
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description_1"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -1404,7 +1574,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -1412,7 +1582,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "topics",
@@ -1428,23 +1598,23 @@
           },
           {
             "name": "instance_id",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+            "$ref": "#/definitions/instance_id_description"
           },
           {
             "name": "rebalance_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+            "$ref": "#/definitions/rebalance_timeout_description"
           },
           {
             "name": "session_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+            "$ref": "#/definitions/session_timeout_description"
           },
           {
             "name": "heartbeat_interval",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+            "$ref": "#/definitions/heartbeat_interval_description"
           },
           {
             "name": "start_offset",
-            "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+            "$ref": "#/definitions/start_offset_description"
           },
           {
             "name": "fetch_max_bytes",
@@ -1452,19 +1622,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+            "$ref": "#/definitions/fetch_max_wait_description"
           },
           {
             "name": "fetch_min_bytes",
-            "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+            "$ref": "#/definitions/fetch_min_bytes_description"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+            "$ref": "#/definitions/fetch_max_partition_bytes_description"
           },
           {
             "name": "transaction_isolation_level",
-            "description": "Defines how transactional messages are handled."
+            "$ref": "#/definitions/transaction_isolation_level_description"
           },
           {
             "name": "consumer_group",
@@ -1476,11 +1646,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+            "$ref": "#/definitions/topic_lag_refresh_period_description"
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -1503,23 +1673,23 @@
           },
           {
             "name": "instance_id",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+            "$ref": "#/definitions/instance_id_description"
           },
           {
             "name": "rebalance_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+            "$ref": "#/definitions/rebalance_timeout_description"
           },
           {
             "name": "session_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+            "$ref": "#/definitions/session_timeout_description"
           },
           {
             "name": "heartbeat_interval",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+            "$ref": "#/definitions/heartbeat_interval_description"
           },
           {
             "name": "start_offset",
-            "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+            "$ref": "#/definitions/start_offset_description"
           },
           {
             "name": "fetch_max_bytes",
@@ -1527,19 +1697,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+            "$ref": "#/definitions/fetch_max_wait_description"
           },
           {
             "name": "fetch_min_bytes",
-            "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+            "$ref": "#/definitions/fetch_min_bytes_description"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+            "$ref": "#/definitions/fetch_max_partition_bytes_description"
           },
           {
             "name": "transaction_isolation_level",
-            "description": "Defines how transactional messages are handled."
+            "$ref": "#/definitions/transaction_isolation_level_description"
           },
           {
             "name": "consumer_group",
@@ -1551,11 +1721,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+            "$ref": "#/definitions/topic_lag_refresh_period_description"
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -1566,29 +1736,29 @@
         "children": [
           {
             "name": "seed_brokers",
-            "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+            "$ref": "#/definitions/seed_brokers_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -1608,23 +1778,23 @@
           },
           {
             "name": "instance_id",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
+            "$ref": "#/definitions/instance_id_description"
           },
           {
             "name": "rebalance_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+            "$ref": "#/definitions/rebalance_timeout_description"
           },
           {
             "name": "session_timeout",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+            "$ref": "#/definitions/session_timeout_description"
           },
           {
             "name": "heartbeat_interval",
-            "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+            "$ref": "#/definitions/heartbeat_interval_description"
           },
           {
             "name": "start_offset",
-            "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
+            "$ref": "#/definitions/start_offset_description"
           },
           {
             "name": "fetch_max_bytes",
@@ -1632,19 +1802,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
+            "$ref": "#/definitions/fetch_max_wait_description"
           },
           {
             "name": "fetch_min_bytes",
-            "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
+            "$ref": "#/definitions/fetch_min_bytes_description"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
+            "$ref": "#/definitions/fetch_max_partition_bytes_description"
           },
           {
             "name": "transaction_isolation_level",
-            "description": "Defines how transactional messages are handled."
+            "$ref": "#/definitions/transaction_isolation_level_description"
           },
           {
             "name": "consumer_group",
@@ -1652,7 +1822,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed. Reducing this value increases the frequency with which newly-created topics are identified."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -1660,7 +1830,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "partition_buffer_bytes",
@@ -1672,7 +1842,7 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+            "$ref": "#/definitions/topic_lag_refresh_period_description"
           }
         ]
       }
@@ -1702,25 +1872,25 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -1752,11 +1922,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+            "$ref": "#/definitions/topic_lag_refresh_period_description"
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -1775,25 +1945,25 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description_1"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "auto_replay_nacks",
@@ -1809,7 +1979,7 @@
               },
               {
                 "name": "consumer_secret",
-                "description": "The secret used to establish ownership of the consumer key."
+                "$ref": "#/definitions/consumer_secret_description"
               },
               {
                 "name": "access_token",
@@ -1817,7 +1987,7 @@
               },
               {
                 "name": "access_token_secret",
-                "description": "The secret that establishes ownership of the `oauth.access_token`."
+                "$ref": "#/definitions/access_token_secret_description"
               }
             ]
           },
@@ -1827,11 +1997,11 @@
             "children": [
               {
                 "name": "username",
-                "description": "The username of the account credentials to authenticate as."
+                "$ref": "#/definitions/username_description"
               },
               {
                 "name": "password",
-                "description": "The password of the account credentials to authenticate with."
+                "$ref": "#/definitions/password_description"
               }
             ]
           },
@@ -1878,7 +2048,7 @@
               },
               {
                 "name": "password",
-                "description": "The password for the username used to authenticate with the SFTP server."
+                "$ref": "#/definitions/password_description_1"
               },
               {
                 "name": "private_key_file",
@@ -1911,7 +2081,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -1930,7 +2100,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
+            "$ref": "#/definitions/auto_replay_nacks_description"
           }
         ]
       }
@@ -1977,29 +2147,29 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                "$ref": "#/definitions/root_cas_file_description_1"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           }
         ]
       }
@@ -2010,7 +2180,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           },
           {
             "name": "query",
@@ -2029,7 +2199,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           }
         ]
       }
@@ -2071,25 +2241,25 @@
         "children": [
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1."
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           }
         ]
       }
@@ -2173,14 +2343,14 @@
           },
           {
             "name": "metadata",
-            "description": "Specify which (if any) metadata values are added to messages as headers.",
             "children": [
               {
                 "name": "exclude_prefixes",
                 "type": "array",
                 "description": "Provide a list of explicit metadata key prefixes to exclude when adding metadata to sent messages."
               }
-            ]
+            ],
+            "$ref": "#/definitions/metadata_description"
           },
           {
             "name": "priority",
@@ -2208,15 +2378,14 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
@@ -2224,9 +2393,10 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           }
         ]
       }
@@ -2255,7 +2425,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -2279,7 +2449,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -2295,7 +2465,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -2405,7 +2575,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -2551,7 +2721,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           },
@@ -2629,29 +2799,29 @@
           },
           {
             "name": "batching",
-            "description": "Configure a xref:configuration:batching.adoc[batching policy].",
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/batching_description"
           }
         ]
       }
@@ -2678,11 +2848,11 @@
             "children": [
               {
                 "name": "username",
-                "description": "The username of the account credentials to authenticate as."
+                "$ref": "#/definitions/username_description"
               },
               {
                 "name": "password",
-                "description": "The password of the account credentials to authenticate with."
+                "$ref": "#/definitions/password_description"
               },
               {
                 "name": "realm",
@@ -2692,55 +2862,55 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message \n`local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                "$ref": "#/definitions/root_cas_file_description_1"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "batching",
-            "description": "Configure a xref:configuration:batching.adoc[batching policy].",
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/batching_description"
           },
           {
             "name": "max_in_flight",
@@ -2786,7 +2956,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -2828,7 +2998,6 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "enabled",
@@ -2836,21 +3005,22 @@
               },
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "basic_auth",
@@ -2866,19 +3036,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           }
@@ -2968,29 +3138,29 @@
           },
           {
             "name": "batching",
-            "description": "Configure a xref:configuration:batching.adoc[batching policy].",
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/batching_description"
           }
         ]
       }
@@ -3013,7 +3183,7 @@
           },
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           }
         ]
       }
@@ -3024,7 +3194,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           },
           {
             "name": "topic",
@@ -3078,11 +3248,10 @@
           },
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1.",
             "children": [
               {
                 "name": "consumer_secret",
-                "description": "The secret used to establish ownership of the consumer key."
+                "$ref": "#/definitions/consumer_secret_description"
               },
               {
                 "name": "access_token",
@@ -3090,9 +3259,10 @@
               },
               {
                 "name": "access_token_secret",
-                "description": "The secret that establishes ownership of the `oauth.access_token`."
+                "$ref": "#/definitions/access_token_secret_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "oauth2",
@@ -3114,43 +3284,43 @@
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "extract_headers",
@@ -3203,19 +3373,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           },
@@ -3236,7 +3406,7 @@
           },
           {
             "name": "key",
-            "description": "The key to publish messages with.\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description"
           },
           {
             "name": "partition",
@@ -3247,7 +3417,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           },
@@ -3264,7 +3434,7 @@
         "children": [
           {
             "name": "seed_brokers",
-            "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+            "$ref": "#/definitions/seed_brokers_description"
           },
           {
             "name": "topic",
@@ -3272,7 +3442,7 @@
           },
           {
             "name": "key",
-            "description": "An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description_1"
           },
           {
             "name": "partition",
@@ -3284,7 +3454,7 @@
           },
           {
             "name": "metadata",
-            "description": "Specify which (if any) metadata values are added to messages as headers."
+            "$ref": "#/definitions/metadata_description"
           },
           {
             "name": "max_in_flight",
@@ -3299,19 +3469,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           },
@@ -3321,7 +3491,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+            "$ref": "#/definitions/broker_write_max_bytes_description"
           },
           {
             "name": "compression",
@@ -3329,25 +3499,25 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -3355,7 +3525,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -3363,7 +3533,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "timestamp_ms",
@@ -3382,7 +3552,7 @@
           },
           {
             "name": "password",
-            "description": "The password required to connect to the database."
+            "$ref": "#/definitions/password_description_2"
           },
           {
             "name": "collection",
@@ -3431,19 +3601,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           }
@@ -3477,7 +3647,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "subject",
@@ -3492,26 +3662,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -3523,7 +3693,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "subject",
@@ -3538,26 +3708,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -3569,7 +3739,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "key",
@@ -3580,26 +3750,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -3611,33 +3781,33 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -3709,29 +3879,29 @@
               },
               {
                 "name": "batching",
-                "description": "Configure a xref:configuration:batching.adoc[batching policy].",
                 "children": [
                   {
                     "name": "count",
-                    "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                    "$ref": "#/definitions/count_description"
                   },
                   {
                     "name": "byte_size",
-                    "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                    "$ref": "#/definitions/byte_size_description"
                   },
                   {
                     "name": "period",
-                    "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                    "$ref": "#/definitions/period_description"
                   },
                   {
                     "name": "check",
-                    "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                    "$ref": "#/definitions/check_description"
                   },
                   {
                     "name": "processors",
                     "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed (optional). All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
                   }
-                ]
+                ],
+                "$ref": "#/definitions/batching_description"
               },
               {
                 "name": "max_message_bytes",
@@ -3739,7 +3909,7 @@
               },
               {
                 "name": "broker_write_max_bytes",
-                "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+                "$ref": "#/definitions/broker_write_max_bytes_description"
               },
               {
                 "name": "compression",
@@ -3747,29 +3917,29 @@
               },
               {
                 "name": "tls",
-                "description": "Override system defaults with custom TLS settings.",
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "description": "Whether to skip server-side certificate verification."
+                    "$ref": "#/definitions/skip_cert_verify_description"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+                    "$ref": "#/definitions/enable_renegotiation_description"
                   },
                   {
                     "name": "root_cas",
-                    "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_description_3"
                   },
                   {
                     "name": "root_cas_file",
-                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_file_description"
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                    "$ref": "#/definitions/client_certs_description"
                   }
-                ]
+                ],
+                "$ref": "#/definitions/tls_description"
               },
               {
                 "name": "timestamp_ms",
@@ -3860,7 +4030,7 @@
         "children": [
           {
             "name": "key",
-            "description": "The key to publish messages with.\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description"
           },
           {
             "name": "ordering_key",
@@ -3886,7 +4056,7 @@
         "children": [
           {
             "name": "tls",
-            "description": "Specify a secure TLS (HTTPS) connection to the Qdrant server."
+            "$ref": "#/definitions/tls_description_1"
           },
           {
             "name": "collection_name",
@@ -3908,51 +4078,51 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                "$ref": "#/definitions/root_cas_file_description_1"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "address",
@@ -4071,33 +4241,33 @@
         "children": [
           {
             "name": "seed_brokers",
-            "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
+            "$ref": "#/definitions/seed_brokers_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -4105,7 +4275,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -4113,7 +4283,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "topic",
@@ -4121,7 +4291,7 @@
           },
           {
             "name": "key",
-            "description": "An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description_1"
           },
           {
             "name": "partition",
@@ -4129,7 +4299,7 @@
           },
           {
             "name": "metadata",
-            "description": "Specify which (if any) metadata values are added to messages as headers."
+            "$ref": "#/definitions/metadata_description"
           },
           {
             "name": "timestamp_ms",
@@ -4157,7 +4327,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+            "$ref": "#/definitions/broker_write_max_bytes_description"
           }
         ]
       }
@@ -4180,7 +4350,7 @@
           },
           {
             "name": "metadata",
-            "description": "Specify which (if any) metadata values are added to messages as headers."
+            "$ref": "#/definitions/metadata_description"
           },
           {
             "name": "timestamp_ms",
@@ -4195,19 +4365,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           }
@@ -4224,25 +4394,25 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -4254,7 +4424,7 @@
           },
           {
             "name": "key",
-            "description": "An optional key to populate for each message.\n\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description_1"
           },
           {
             "name": "partition",
@@ -4262,11 +4432,11 @@
           },
           {
             "name": "metadata",
-            "description": "Specify which (if any) metadata values are added to messages as headers."
+            "$ref": "#/definitions/metadata_description"
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed. Reducing this value increases the frequency with which newly-created topics are identified."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -4274,7 +4444,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "topic_prefix",
@@ -4330,7 +4500,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+            "$ref": "#/definitions/broker_write_max_bytes_description"
           }
         ]
       }
@@ -4364,25 +4534,25 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "sasl",
@@ -4390,7 +4560,7 @@
           },
           {
             "name": "metadata_max_age",
-            "description": "The maximum period of time after which metadata is refreshed."
+            "$ref": "#/definitions/metadata_max_age_description"
           },
           {
             "name": "request_timeout_overhead",
@@ -4398,7 +4568,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "description": "Define how long connections can remain idle before they are closed."
+            "$ref": "#/definitions/conn_idle_timeout_description"
           },
           {
             "name": "offset_topic",
@@ -4438,7 +4608,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
+            "$ref": "#/definitions/broker_write_max_bytes_description"
           },
           {
             "name": "max_retries",
@@ -4474,7 +4644,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -4539,21 +4709,21 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "max_in_flight",
@@ -4569,7 +4739,7 @@
               },
               {
                 "name": "consumer_secret",
-                "description": "The secret used to establish ownership of the consumer key."
+                "$ref": "#/definitions/consumer_secret_description"
               },
               {
                 "name": "access_token",
@@ -4577,7 +4747,7 @@
               },
               {
                 "name": "access_token_secret",
-                "description": "The secret that establishes ownership of the `oauth.access_token`."
+                "$ref": "#/definitions/access_token_secret_description"
               }
             ]
           },
@@ -4587,11 +4757,11 @@
             "children": [
               {
                 "name": "username",
-                "description": "The username of the account credentials to authenticate as."
+                "$ref": "#/definitions/username_description"
               },
               {
                 "name": "password",
-                "description": "The password of the account credentials to authenticate with."
+                "$ref": "#/definitions/password_description"
               }
             ]
           },
@@ -4657,7 +4827,7 @@
               },
               {
                 "name": "password",
-                "description": "The password for the username used to authenticate with the SFTP server."
+                "$ref": "#/definitions/password_description_1"
               },
               {
                 "name": "private_key_file",
@@ -4852,19 +5022,19 @@
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
             ]
           },
@@ -4908,7 +5078,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           }
         ]
       }
@@ -4919,7 +5089,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           },
           {
             "name": "query",
@@ -4978,29 +5148,29 @@
           },
           {
             "name": "batching",
-            "description": "Configure a xref:configuration:batching.adoc[batching policy].",
             "children": [
               {
                 "name": "count",
-                "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
+                "$ref": "#/definitions/count_description"
               },
               {
                 "name": "byte_size",
-                "description": "The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
+                "$ref": "#/definitions/byte_size_description"
               },
               {
                 "name": "period",
-                "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+                "$ref": "#/definitions/period_description"
               },
               {
                 "name": "check",
-                "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
+                "$ref": "#/definitions/check_description"
               },
               {
                 "name": "processors",
-                "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
+                "$ref": "#/definitions/processors_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/batching_description"
           }
         ]
       }
@@ -5011,25 +5181,25 @@
         "children": [
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1."
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           }
         ]
       }
@@ -5087,7 +5257,7 @@
           },
           {
             "name": "endpoint",
-            "description": "Specify a custom endpoint for the AWS API."
+            "$ref": "#/definitions/endpoint_description"
           },
           {
             "name": "temperature",
@@ -5118,7 +5288,7 @@
           },
           {
             "name": "endpoint",
-            "description": "Specify a custom endpoint for the AWS API."
+            "$ref": "#/definitions/endpoint_description"
           },
           {
             "name": "credentials",
@@ -5259,29 +5429,29 @@
               },
               {
                 "name": "tls",
-                "description": "Override system defaults with custom TLS settings.",
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "description": "Whether to skip server-side certificate verification."
+                    "$ref": "#/definitions/skip_cert_verify_description"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
+                    "$ref": "#/definitions/enable_renegotiation_description"
                   },
                   {
                     "name": "root_cas",
-                    "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_description_3"
                   },
                   {
                     "name": "root_cas_file",
-                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                    "$ref": "#/definitions/root_cas_file_description_1"
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                    "$ref": "#/definitions/client_certs_description"
                   }
-                ]
+                ],
+                "$ref": "#/definitions/tls_description"
               },
               {
                 "name": "oauth",
@@ -5289,7 +5459,7 @@
                 "children": [
                   {
                     "name": "enabled",
-                    "description": "Whether to use OAuth version 1 in requests to the schema registry."
+                    "$ref": "#/definitions/enabled_description"
                   },
                   {
                     "name": "consumer_key",
@@ -5297,7 +5467,7 @@
                   },
                   {
                     "name": "consumer_secret",
-                    "description": "The secret used to establish ownership of the consumer key."
+                    "$ref": "#/definitions/consumer_secret_description"
                   },
                   {
                     "name": "access_token",
@@ -5305,7 +5475,7 @@
                   },
                   {
                     "name": "access_token_secret",
-                    "description": "The secret that establishes ownership of the `oauth.access_token`."
+                    "$ref": "#/definitions/access_token_secret_description"
                   }
                 ]
               },
@@ -5315,11 +5485,11 @@
                 "children": [
                   {
                     "name": "username",
-                    "description": "The username of the account credentials to authenticate as."
+                    "$ref": "#/definitions/username_description"
                   },
                   {
                     "name": "password",
-                    "description": "The password of the account credentials to authenticate with."
+                    "$ref": "#/definitions/password_description"
                   }
                 ]
               },
@@ -5467,7 +5637,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+            "$ref": "#/definitions/credentials_json_description"
           }
         ]
       }
@@ -5652,7 +5822,6 @@
           },
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1.",
             "children": [
               {
                 "name": "access_token",
@@ -5660,9 +5829,10 @@
               },
               {
                 "name": "access_token_secret",
-                "description": "The secret that establishes ownership of the `oauth.access_token`."
+                "$ref": "#/definitions/access_token_secret_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "oauth2",
@@ -5684,43 +5854,43 @@
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description"
           },
           {
             "name": "extract_headers",
@@ -5835,7 +6005,7 @@
           },
           {
             "name": "password",
-            "description": "The password required to connect to the database."
+            "$ref": "#/definitions/password_description_2"
           },
           {
             "name": "operation",
@@ -5885,7 +6055,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "key",
@@ -5900,26 +6070,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -5931,7 +6101,7 @@
           {
             "name": "urls",
             "type": "array",
-            "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
+            "$ref": "#/definitions/urls_description"
           },
           {
             "name": "subject",
@@ -5946,26 +6116,26 @@
             "children": [
               {
                 "name": "nkey",
-                "description": "Your NKey seed or private key."
+                "$ref": "#/definitions/nkey_description"
               },
               {
                 "name": "user_credentials_file",
-                "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
+                "$ref": "#/definitions/user_credentials_file_description"
               },
               {
                 "name": "user_jwt",
-                "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+                "$ref": "#/definitions/user_jwt_description"
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+                "$ref": "#/definitions/user_nkey_seed_description"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }
@@ -6177,15 +6347,15 @@
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "description": "Whether to skip server-side certificate verification."
+                    "$ref": "#/definitions/skip_cert_verify_description"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
+                    "$ref": "#/definitions/enable_renegotiation_description_1"
                   },
                   {
                     "name": "root_cas",
-                    "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                    "$ref": "#/definitions/root_cas_description_3"
                   },
                   {
                     "name": "root_cas_file",
@@ -6193,7 +6363,7 @@
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                    "$ref": "#/definitions/client_certs_description"
                   }
                 ]
               },
@@ -6203,7 +6373,7 @@
                 "children": [
                   {
                     "name": "enabled",
-                    "description": "Whether to use OAuth version 1 in requests to the schema registry."
+                    "$ref": "#/definitions/enabled_description"
                   },
                   {
                     "name": "consumer_key",
@@ -6211,7 +6381,7 @@
                   },
                   {
                     "name": "consumer_secret",
-                    "description": "The secret used to establish ownership of the consumer key."
+                    "$ref": "#/definitions/consumer_secret_description"
                   },
                   {
                     "name": "access_token",
@@ -6219,7 +6389,7 @@
                   },
                   {
                     "name": "access_token_secret",
-                    "description": "The secret that establishes ownership of the `oauth.access_token`."
+                    "$ref": "#/definitions/access_token_secret_description"
                   }
                 ]
               },
@@ -6229,11 +6399,11 @@
                 "children": [
                   {
                     "name": "username",
-                    "description": "The username of the account credentials to authenticate as."
+                    "$ref": "#/definitions/username_description"
                   },
                   {
                     "name": "password",
-                    "description": "The password of the account credentials to authenticate with."
+                    "$ref": "#/definitions/password_description"
                   }
                 ]
               },
@@ -6410,29 +6580,29 @@
           },
           {
             "name": "tls",
-            "description": "Specify a secure TLS (HTTPS) connection to the Qdrant server.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation_description"
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_description_3"
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "$ref": "#/definitions/client_certs_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/tls_description_1"
           },
           {
             "name": "collection_name",
@@ -6478,7 +6648,7 @@
         "children": [
           {
             "name": "input_key",
-            "description": "An optional key to populate for each message.\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+            "$ref": "#/definitions/key_description_1"
           }
         ]
       }
@@ -6492,7 +6662,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+                "$ref": "#/definitions/initial_interval_description"
               }
             ]
           }
@@ -6526,25 +6696,25 @@
           },
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1."
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           }
         ]
       }
@@ -6563,25 +6733,25 @@
           },
           {
             "name": "oauth",
-            "description": "Allows you to specify open authentication using OAuth version 1."
+            "$ref": "#/definitions/oauth_description"
           },
           {
             "name": "jwt",
-            "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication.",
             "children": [
               {
                 "name": "private_key_file",
-                "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+                "$ref": "#/definitions/private_key_file_description"
               },
               {
                 "name": "signing_method",
-                "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                "$ref": "#/definitions/signing_method_description"
               },
               {
                 "name": "headers",
-                "description": "Add key/value headers to the JWT (optional)."
+                "$ref": "#/definitions/headers_description"
               }
-            ]
+            ],
+            "$ref": "#/definitions/jwt_description"
           }
         ]
       }
@@ -6648,7 +6818,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           }
         ]
       }
@@ -6659,7 +6829,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           },
           {
             "name": "query",
@@ -6686,7 +6856,7 @@
         "children": [
           {
             "name": "dsn",
-            "description": "A Data Source Name to identify the target database."
+            "$ref": "#/definitions/dsn_description"
           }
         ]
       }
@@ -6772,11 +6942,10 @@
               },
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "$ref": "#/definitions/skip_cert_verify_description"
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.",
                 "children": [
                   {
                     "name": "cert",
@@ -6798,7 +6967,8 @@
                     "name": "password",
                     "description": "Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management."
                   }
-                ]
+                ],
+                "$ref": "#/definitions/client_certs_description"
               }
             ]
           },
@@ -6834,7 +7004,7 @@
                   },
                   {
                     "name": "endpoint",
-                    "description": "Specify a custom endpoint for the AWS API."
+                    "$ref": "#/definitions/endpoint_description"
                   }
                 ]
               },
@@ -6887,8 +7057,8 @@
         "children": [
           {
             "name": "tls_handshake_first",
-            "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation.",
-            "version": "4.60.0"
+            "version": "4.60.0",
+            "$ref": "#/definitions/tls_handshake_first_description"
           }
         ]
       }

--- a/docs-data/overrides.json
+++ b/docs-data/overrides.json
@@ -51,23 +51,23 @@
           },
           {
             "name": "tls",
-            "description": "Override system defaults with custom TLS settings.",
+            "description": "Configure Transport Layer Security (TLS) encryption and mutual TLS (mTLS) authentication for secure connections. Supports both basic TLS encryption and mTLS with client certificate authentication.",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "description": "Whether to skip server-side certificate verification."
+                "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as it reduces security."
               },
               {
                 "name": "root_cas",
-                "description": "Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "description": "Root certificate authorities as inline PEM data. Used to verify the server certificate in both TLS and mTLS configurations."
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "description": "Path to a root certificate authority file in PEM format. Used to verify the server certificate in both TLS and mTLS configurations."
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           }
@@ -566,7 +566,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -688,7 +688,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -1137,7 +1137,7 @@
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates to use. For each certificate, specify either the fields `cert` and `key` or `cert_file` and `key_file`."
+                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
                   }
                 ]
               },
@@ -1394,7 +1394,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -1586,7 +1586,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -1718,7 +1718,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key`, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -1791,7 +1791,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -1997,7 +1997,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           }
@@ -2224,7 +2224,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           }
@@ -2712,7 +2712,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -2848,7 +2848,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -3148,7 +3148,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -3345,7 +3345,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -3767,7 +3767,7 @@
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates to use. For each certificate, specify either the fields `cert` and `key` or `cert_file` and `key_file`."
+                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
                   }
                 ]
               },
@@ -3950,7 +3950,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -4095,7 +4095,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -4240,7 +4240,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -4380,7 +4380,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key`, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -4551,7 +4551,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -4617,7 +4617,7 @@
               }
             ]
           },
-                    {
+          {
             "name": "normalize",
             "description": "Normalize schemas.",
             "version": "4.61.0"
@@ -5279,7 +5279,7 @@
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
                   }
                 ]
               },
@@ -5718,7 +5718,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -6193,7 +6193,7 @@
                   },
                   {
                     "name": "client_certs",
-                    "description": "A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                    "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
                   }
                 ]
               },
@@ -6430,7 +6430,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields."
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields."
               }
             ]
           },
@@ -6776,7 +6776,7 @@
               },
               {
                 "name": "client_certs",
-                "description": "A list of client certificates to use. For each certificate, specify only one of the field pairs `cert` and `key`, or `cert_file` and `key_file`. Do not include both pairs.",
+                "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.",
                 "children": [
                   {
                     "name": "cert",
@@ -6788,15 +6788,15 @@
                   },
                   {
                     "name": "key",
-                    "description": "The plaintext private key to use for TLS authentication."
+                    "description": "Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field."
                   },
                   {
                     "name": "key_file",
-                    "description": "The path to a file containing the private key to use for TLS authentication."
+                    "description": "Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field."
                   },
                   {
                     "name": "password",
-                    "description": "The password to use for the private key, if it is encrypted. This field is optional and only required if the private key is encrypted. The PKCS#1 and PKCS#8 formats are supported.\n\nThe `pbeWithMD5AndDES-CBC` algorithm is obsolete and not supported for the PKCS#8 format. This algorithm does not authenticate the ciphertext, making it vulnerable to padding oracle attacks that can let an attacker recover the plaintext."
+                    "description": "Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management."
                   }
                 ]
               }

--- a/docs-data/overrides.json
+++ b/docs-data/overrides.json
@@ -136,7 +136,7 @@
       "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
     },
     "root_cas_file": {
-      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
     },
     "enable_renegotiation": {
       "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
@@ -200,7 +200,7 @@
           },
           {
             "name": "tls",
-            "description": "Configure Transport Layer Security (TLS) encryption and mutual TLS (mTLS) authentication for secure connections. Supports both basic TLS encryption and mTLS with client certificate authentication.",
+            "$ref": "#/definitions/tls",
             "children": [
               {
                 "name": "skip_cert_verify",
@@ -208,11 +208,11 @@
               },
               {
                 "name": "root_cas",
-                "description": "Root certificate authorities as inline PEM data. Used to verify the server certificate in both TLS and mTLS configurations."
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "description": "Path to a root certificate authority file in PEM format. Used to verify the server certificate in both TLS and mTLS configurations."
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
@@ -1530,7 +1530,7 @@
               },
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to request renegotiation. Enable this option if you\u2019re seeing the error message `local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
@@ -2368,7 +2368,7 @@
               },
               {
                 "name": "root_cas_file",
-                "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
@@ -6322,7 +6322,7 @@
               },
               {
                 "name": "tls",
-                "description": "Specify custom TLS settings to override system defaults.",
+                "$ref": "#/definitions/tls",
                 "children": [
                   {
                     "name": "skip_cert_verify",
@@ -6338,7 +6338,7 @@
                   },
                   {
                     "name": "root_cas_file",
-                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                    "$ref": "#/definitions/root_cas_file"
                   },
                   {
                     "name": "client_certs",
@@ -6909,15 +6909,15 @@
           },
           {
             "name": "tls",
-            "description": "Use this field for custom TLS settings that override system defaults.",
+            "$ref": "#/definitions/tls",
             "children": [
               {
                 "name": "enable_renegotiation",
-                "description": "Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you see the error message `local error: tls: no renegotiation`."
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas_file",
-                "description": "An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent-trusted root certificate, to possible intermediate signing certificates, to the host certificate."
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "skip_cert_verify",

--- a/docs-data/overrides.json
+++ b/docs-data/overrides.json
@@ -1,172 +1,151 @@
 {
   "definitions": {
-    "client_certs_description": {
+    "client_certs": {
       "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk."
     },
-    "skip_cert_verify_description": {
+    "skip_cert_verify": {
       "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production."
     },
-    "tls_description": {
+    "tls": {
       "description": "Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates."
     },
-    "count_description": {
+    "count": {
       "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
     },
-    "root_cas_file_description": {
-      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
-    },
-    "processors_description": {
+    "processors": {
       "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed. All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
     },
-    "tls_handshake_first_description": {
+    "tls_handshake_first": {
       "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation."
     },
-    "initial_interval_description": {
+    "initial_interval": {
       "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
     },
-    "check_description": {
+    "check": {
       "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
     },
-    "urls_description": {
+    "urls": {
       "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
     },
-    "nkey_description": {
+    "nkey": {
       "description": "Your NKey seed or private key."
     },
-    "user_credentials_file_description": {
+    "user_credentials_file": {
       "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
     },
-    "user_jwt_description": {
+    "user_jwt": {
       "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
     },
-    "byte_size_description": {
+    "byte_size": {
       "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
     },
-    "period_description": {
+    "period": {
       "description": "The period of time after which an incomplete batch is flushed regardless of its size."
     },
-    "user_nkey_seed_description": {
+    "user_nkey_seed": {
       "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
     },
-    "auto_replay_nacks_description": {
+    "auto_replay_nacks": {
       "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
     },
-    "oauth_description": {
+    "oauth": {
       "description": "Allows you to specify open authentication using OAuth version 1."
     },
-    "access_token_secret_description": {
+    "access_token_secret": {
       "description": "The secret that establishes ownership of the `oauth.access_token`."
     },
-    "jwt_description": {
+    "jwt": {
       "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication."
     },
-    "private_key_file_description": {
+    "private_key_file": {
       "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
     },
-    "signing_method_description": {
+    "signing_method": {
       "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
     },
-    "headers_description": {
+    "headers": {
       "description": "Add key/value headers to the JWT (optional)."
     },
-    "conn_idle_timeout_description": {
+    "conn_idle_timeout": {
       "description": "Define how long connections can remain idle before they are closed."
     },
-    "dsn_description": {
+    "dsn": {
       "description": "A Data Source Name to identify the target database."
     },
-    "credentials_json_description": {
+    "credentials_json": {
       "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
     },
-    "consumer_secret_description": {
+    "consumer_secret": {
       "description": "The secret used to establish ownership of the consumer key."
     },
-    "topic_lag_refresh_period_description": {
+    "topic_lag_refresh_period": {
       "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
     },
-    "endpoint_description": {
+    "endpoint": {
       "description": "Specify a custom endpoint for the AWS API."
     },
-    "seed_brokers_description": {
+    "seed_brokers": {
       "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
     },
-    "metadata_max_age_description": {
+    "metadata_max_age": {
       "description": "The maximum period of time after which metadata is refreshed."
     },
-    "instance_id_description": {
+    "instance_id": {
       "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
     },
-    "rebalance_timeout_description": {
+    "rebalance_timeout": {
       "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
     },
-    "session_timeout_description": {
+    "session_timeout": {
       "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
     },
-    "heartbeat_interval_description": {
+    "heartbeat_interval": {
       "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
     },
-    "start_offset_description": {
+    "start_offset": {
       "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
     },
-    "fetch_max_wait_description": {
+    "fetch_max_wait": {
       "description": "The maximum period of time a broker can wait for a fetch response to reach the required minimum number of bytes (`fetch_min_bytes`)."
     },
-    "fetch_min_bytes_description": {
+    "fetch_min_bytes": {
       "description": "The minimum number of bytes that a broker tries to send during a fetch. This field is equivalent to the Java setting `fetch.min.bytes`."
     },
-    "fetch_max_partition_bytes_description": {
+    "fetch_max_partition_bytes": {
       "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
     },
-    "transaction_isolation_level_description": {
+    "transaction_isolation_level": {
       "description": "Defines how transactional messages are handled."
     },
-    "enable_renegotiation_description": {
-      "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`."
-    },
-    "username_description": {
+    "username": {
       "description": "The username of the account credentials to authenticate as."
     },
-    "password_description": {
-      "description": "The password of the account credentials to authenticate with."
-    },
-    "metadata_description": {
+    "metadata": {
       "description": "Specify which (if any) metadata values are added to messages as headers."
     },
-    "batching_description": {
+    "batching": {
       "description": "Configure a xref:configuration:batching.adoc[batching policy]."
     },
-    "broker_write_max_bytes_description": {
+    "broker_write_max_bytes": {
       "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
     },
-    "root_cas_file_description_1": {
-      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+    "enabled": {
+      "description": "Whether to use OAuth version 1 in requests to the schema registry."
     },
-    "enable_renegotiation_description_1": {
-      "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
-    },
-    "root_cas_description_3": {
+    "root_cas": {
       "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
     },
-    "root_cas_file_description_2": {
-      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+    "root_cas_file": {
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
     },
-    "password_description_1": {
+    "enable_renegotiation": {
+      "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
+    },
+    "password": {
       "description": "The password for the username used to authenticate with the SFTP server."
     },
-    "key_description": {
-      "description": "The key to publish messages with.\nThis field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
-    },
-    "key_description_1": {
+    "key": {
       "description": "An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
-    },
-    "password_description_2": {
-      "description": "The password required to connect to the database."
-    },
-    "tls_description_1": {
-      "description": "Specify a secure TLS (HTTPS) connection to the Qdrant server."
-    },
-    "enabled_description": {
-      "description": "Whether to use OAuth version 1 in requests to the schema registry."
     }
   },
   "inputs": [
@@ -225,7 +204,7 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
@@ -237,7 +216,7 @@
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ]
           }
@@ -253,7 +232,7 @@
             "children": [
               {
                 "name": "endpoint",
-                "$ref": "#/definitions/endpoint_description"
+                "$ref": "#/definitions/endpoint"
               },
               {
                 "name": "credentials",
@@ -289,7 +268,7 @@
           },
           {
             "name": "endpoint",
-            "$ref": "#/definitions/endpoint_description"
+            "$ref": "#/definitions/endpoint"
           },
           {
             "name": "credentials",
@@ -386,7 +365,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           },
@@ -443,7 +422,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           }
         ]
       }
@@ -458,7 +437,7 @@
           },
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           }
         ]
       }
@@ -469,7 +448,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           }
         ]
       }
@@ -485,7 +464,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           },
           {
             "name": "credentials_json",
@@ -536,7 +515,7 @@
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "count",
@@ -635,7 +614,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -669,7 +648,7 @@
             "children": [
               {
                 "name": "consumer_secret",
-                "$ref": "#/definitions/consumer_secret_description"
+                "$ref": "#/definitions/consumer_secret"
               },
               {
                 "name": "access_token",
@@ -677,10 +656,10 @@
               },
               {
                 "name": "access_token_secret",
-                "$ref": "#/definitions/access_token_secret_description"
+                "$ref": "#/definitions/access_token_secret"
               }
             ],
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "oauth2",
@@ -705,40 +684,40 @@
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "extract_headers",
@@ -838,29 +817,29 @@
         "children": [
           {
             "name": "seed_brokers",
-            "$ref": "#/definitions/seed_brokers_description"
+            "$ref": "#/definitions/seed_brokers"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -868,7 +847,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -876,7 +855,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "topics",
@@ -888,23 +867,23 @@
           },
           {
             "name": "instance_id",
-            "$ref": "#/definitions/instance_id_description"
+            "$ref": "#/definitions/instance_id"
           },
           {
             "name": "rebalance_timeout",
-            "$ref": "#/definitions/rebalance_timeout_description"
+            "$ref": "#/definitions/rebalance_timeout"
           },
           {
             "name": "session_timeout",
-            "$ref": "#/definitions/session_timeout_description"
+            "$ref": "#/definitions/session_timeout"
           },
           {
             "name": "heartbeat_interval",
-            "$ref": "#/definitions/heartbeat_interval_description"
+            "$ref": "#/definitions/heartbeat_interval"
           },
           {
             "name": "start_offset",
-            "$ref": "#/definitions/start_offset_description"
+            "$ref": "#/definitions/start_offset"
           },
           {
             "name": "fetch_max_bytes",
@@ -912,19 +891,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "$ref": "#/definitions/fetch_max_wait_description"
+            "$ref": "#/definitions/fetch_max_wait"
           },
           {
             "name": "fetch_min_bytes",
-            "$ref": "#/definitions/fetch_min_bytes_description"
+            "$ref": "#/definitions/fetch_min_bytes"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "$ref": "#/definitions/fetch_max_partition_bytes_description"
+            "$ref": "#/definitions/fetch_max_partition_bytes"
           },
           {
             "name": "transaction_isolation_level",
-            "$ref": "#/definitions/transaction_isolation_level_description"
+            "$ref": "#/definitions/transaction_isolation_level"
           },
           {
             "name": "consumer_group",
@@ -944,25 +923,25 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           },
           {
             "name": "topic_lag_refresh_period",
-            "$ref": "#/definitions/topic_lag_refresh_period_description"
+            "$ref": "#/definitions/topic_lag_refresh_period"
           },
           {
             "name": "auto_replay_nacks",
@@ -1083,23 +1062,23 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           }
@@ -1113,7 +1092,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "send_ack",
@@ -1124,26 +1103,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -1155,7 +1134,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "queue",
@@ -1170,15 +1149,15 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
@@ -1189,7 +1168,7 @@
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -1201,33 +1180,33 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -1239,26 +1218,26 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
@@ -1269,7 +1248,7 @@
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -1290,26 +1269,26 @@
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "$ref": "#/definitions/skip_cert_verify_description"
+                    "$ref": "#/definitions/skip_cert_verify"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "$ref": "#/definitions/enable_renegotiation_description"
+                    "$ref": "#/definitions/enable_renegotiation"
                   },
                   {
                     "name": "root_cas",
-                    "$ref": "#/definitions/root_cas_description_3"
+                    "$ref": "#/definitions/root_cas"
                   },
                   {
                     "name": "root_cas_file",
-                    "$ref": "#/definitions/root_cas_file_description"
+                    "$ref": "#/definitions/root_cas_file"
                   },
                   {
                     "name": "client_certs",
-                    "$ref": "#/definitions/client_certs_description"
+                    "$ref": "#/definitions/client_certs"
                   }
                 ],
-                "$ref": "#/definitions/tls_description"
+                "$ref": "#/definitions/tls"
               },
               {
                 "name": "topics",
@@ -1325,23 +1304,23 @@
               },
               {
                 "name": "instance_id",
-                "$ref": "#/definitions/instance_id_description"
+                "$ref": "#/definitions/instance_id"
               },
               {
                 "name": "rebalance_timeout",
-                "$ref": "#/definitions/rebalance_timeout_description"
+                "$ref": "#/definitions/rebalance_timeout"
               },
               {
                 "name": "session_timeout",
-                "$ref": "#/definitions/session_timeout_description"
+                "$ref": "#/definitions/session_timeout"
               },
               {
                 "name": "heartbeat_interval",
-                "$ref": "#/definitions/heartbeat_interval_description"
+                "$ref": "#/definitions/heartbeat_interval"
               },
               {
                 "name": "start_offset",
-                "$ref": "#/definitions/start_offset_description"
+                "$ref": "#/definitions/start_offset"
               },
               {
                 "name": "fetch_max_bytes",
@@ -1349,19 +1328,19 @@
               },
               {
                 "name": "fetch_max_wait",
-                "$ref": "#/definitions/fetch_max_wait_description"
+                "$ref": "#/definitions/fetch_max_wait"
               },
               {
                 "name": "fetch_min_bytes",
-                "$ref": "#/definitions/fetch_min_bytes_description"
+                "$ref": "#/definitions/fetch_min_bytes"
               },
               {
                 "name": "fetch_max_partition_bytes",
-                "$ref": "#/definitions/fetch_max_partition_bytes_description"
+                "$ref": "#/definitions/fetch_max_partition_bytes"
               },
               {
                 "name": "transaction_isolation_level",
-                "$ref": "#/definitions/transaction_isolation_level_description"
+                "$ref": "#/definitions/transaction_isolation_level"
               },
               {
                 "name": "consumer_group",
@@ -1381,19 +1360,19 @@
                 "children": [
                   {
                     "name": "count",
-                    "$ref": "#/definitions/count_description"
+                    "$ref": "#/definitions/count"
                   },
                   {
                     "name": "byte_size",
-                    "$ref": "#/definitions/byte_size_description"
+                    "$ref": "#/definitions/byte_size"
                   },
                   {
                     "name": "period",
-                    "$ref": "#/definitions/period_description"
+                    "$ref": "#/definitions/period"
                   },
                   {
                     "name": "check",
-                    "$ref": "#/definitions/check_description"
+                    "$ref": "#/definitions/check"
                   },
                   {
                     "name": "processors",
@@ -1403,7 +1382,7 @@
               },
               {
                 "name": "topic_lag_refresh_period",
-                "$ref": "#/definitions/topic_lag_refresh_period_description"
+                "$ref": "#/definitions/topic_lag_refresh_period"
               }
             ]
           },
@@ -1511,23 +1490,23 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           }
@@ -1540,14 +1519,14 @@
         "children": [
           {
             "name": "seed_brokers",
-            "$ref": "#/definitions/seed_brokers_description"
+            "$ref": "#/definitions/seed_brokers"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
@@ -1555,18 +1534,18 @@
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description_1"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -1574,7 +1553,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -1582,7 +1561,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "topics",
@@ -1598,23 +1577,23 @@
           },
           {
             "name": "instance_id",
-            "$ref": "#/definitions/instance_id_description"
+            "$ref": "#/definitions/instance_id"
           },
           {
             "name": "rebalance_timeout",
-            "$ref": "#/definitions/rebalance_timeout_description"
+            "$ref": "#/definitions/rebalance_timeout"
           },
           {
             "name": "session_timeout",
-            "$ref": "#/definitions/session_timeout_description"
+            "$ref": "#/definitions/session_timeout"
           },
           {
             "name": "heartbeat_interval",
-            "$ref": "#/definitions/heartbeat_interval_description"
+            "$ref": "#/definitions/heartbeat_interval"
           },
           {
             "name": "start_offset",
-            "$ref": "#/definitions/start_offset_description"
+            "$ref": "#/definitions/start_offset"
           },
           {
             "name": "fetch_max_bytes",
@@ -1622,19 +1601,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "$ref": "#/definitions/fetch_max_wait_description"
+            "$ref": "#/definitions/fetch_max_wait"
           },
           {
             "name": "fetch_min_bytes",
-            "$ref": "#/definitions/fetch_min_bytes_description"
+            "$ref": "#/definitions/fetch_min_bytes"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "$ref": "#/definitions/fetch_max_partition_bytes_description"
+            "$ref": "#/definitions/fetch_max_partition_bytes"
           },
           {
             "name": "transaction_isolation_level",
-            "$ref": "#/definitions/transaction_isolation_level_description"
+            "$ref": "#/definitions/transaction_isolation_level"
           },
           {
             "name": "consumer_group",
@@ -1646,11 +1625,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "$ref": "#/definitions/topic_lag_refresh_period_description"
+            "$ref": "#/definitions/topic_lag_refresh_period"
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -1673,23 +1652,23 @@
           },
           {
             "name": "instance_id",
-            "$ref": "#/definitions/instance_id_description"
+            "$ref": "#/definitions/instance_id"
           },
           {
             "name": "rebalance_timeout",
-            "$ref": "#/definitions/rebalance_timeout_description"
+            "$ref": "#/definitions/rebalance_timeout"
           },
           {
             "name": "session_timeout",
-            "$ref": "#/definitions/session_timeout_description"
+            "$ref": "#/definitions/session_timeout"
           },
           {
             "name": "heartbeat_interval",
-            "$ref": "#/definitions/heartbeat_interval_description"
+            "$ref": "#/definitions/heartbeat_interval"
           },
           {
             "name": "start_offset",
-            "$ref": "#/definitions/start_offset_description"
+            "$ref": "#/definitions/start_offset"
           },
           {
             "name": "fetch_max_bytes",
@@ -1697,19 +1676,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "$ref": "#/definitions/fetch_max_wait_description"
+            "$ref": "#/definitions/fetch_max_wait"
           },
           {
             "name": "fetch_min_bytes",
-            "$ref": "#/definitions/fetch_min_bytes_description"
+            "$ref": "#/definitions/fetch_min_bytes"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "$ref": "#/definitions/fetch_max_partition_bytes_description"
+            "$ref": "#/definitions/fetch_max_partition_bytes"
           },
           {
             "name": "transaction_isolation_level",
-            "$ref": "#/definitions/transaction_isolation_level_description"
+            "$ref": "#/definitions/transaction_isolation_level"
           },
           {
             "name": "consumer_group",
@@ -1721,11 +1700,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "$ref": "#/definitions/topic_lag_refresh_period_description"
+            "$ref": "#/definitions/topic_lag_refresh_period"
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -1736,29 +1715,29 @@
         "children": [
           {
             "name": "seed_brokers",
-            "$ref": "#/definitions/seed_brokers_description"
+            "$ref": "#/definitions/seed_brokers"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -1778,23 +1757,23 @@
           },
           {
             "name": "instance_id",
-            "$ref": "#/definitions/instance_id_description"
+            "$ref": "#/definitions/instance_id"
           },
           {
             "name": "rebalance_timeout",
-            "$ref": "#/definitions/rebalance_timeout_description"
+            "$ref": "#/definitions/rebalance_timeout"
           },
           {
             "name": "session_timeout",
-            "$ref": "#/definitions/session_timeout_description"
+            "$ref": "#/definitions/session_timeout"
           },
           {
             "name": "heartbeat_interval",
-            "$ref": "#/definitions/heartbeat_interval_description"
+            "$ref": "#/definitions/heartbeat_interval"
           },
           {
             "name": "start_offset",
-            "$ref": "#/definitions/start_offset_description"
+            "$ref": "#/definitions/start_offset"
           },
           {
             "name": "fetch_max_bytes",
@@ -1802,19 +1781,19 @@
           },
           {
             "name": "fetch_max_wait",
-            "$ref": "#/definitions/fetch_max_wait_description"
+            "$ref": "#/definitions/fetch_max_wait"
           },
           {
             "name": "fetch_min_bytes",
-            "$ref": "#/definitions/fetch_min_bytes_description"
+            "$ref": "#/definitions/fetch_min_bytes"
           },
           {
             "name": "fetch_max_partition_bytes",
-            "$ref": "#/definitions/fetch_max_partition_bytes_description"
+            "$ref": "#/definitions/fetch_max_partition_bytes"
           },
           {
             "name": "transaction_isolation_level",
-            "$ref": "#/definitions/transaction_isolation_level_description"
+            "$ref": "#/definitions/transaction_isolation_level"
           },
           {
             "name": "consumer_group",
@@ -1822,7 +1801,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -1830,7 +1809,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "partition_buffer_bytes",
@@ -1842,7 +1821,7 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "$ref": "#/definitions/topic_lag_refresh_period_description"
+            "$ref": "#/definitions/topic_lag_refresh_period"
           }
         ]
       }
@@ -1875,22 +1854,22 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -1922,11 +1901,11 @@
           },
           {
             "name": "topic_lag_refresh_period",
-            "$ref": "#/definitions/topic_lag_refresh_period_description"
+            "$ref": "#/definitions/topic_lag_refresh_period"
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -1948,22 +1927,22 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description_1"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "auto_replay_nacks",
@@ -1979,7 +1958,7 @@
               },
               {
                 "name": "consumer_secret",
-                "$ref": "#/definitions/consumer_secret_description"
+                "$ref": "#/definitions/consumer_secret"
               },
               {
                 "name": "access_token",
@@ -1987,7 +1966,7 @@
               },
               {
                 "name": "access_token_secret",
-                "$ref": "#/definitions/access_token_secret_description"
+                "$ref": "#/definitions/access_token_secret"
               }
             ]
           },
@@ -1997,11 +1976,11 @@
             "children": [
               {
                 "name": "username",
-                "$ref": "#/definitions/username_description"
+                "$ref": "#/definitions/username"
               },
               {
                 "name": "password",
-                "$ref": "#/definitions/password_description"
+                "$ref": "#/definitions/password"
               }
             ]
           },
@@ -2048,7 +2027,7 @@
               },
               {
                 "name": "password",
-                "$ref": "#/definitions/password_description_1"
+                "$ref": "#/definitions/password"
               },
               {
                 "name": "private_key_file",
@@ -2081,7 +2060,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -2100,7 +2079,7 @@
           },
           {
             "name": "auto_replay_nacks",
-            "$ref": "#/definitions/auto_replay_nacks_description"
+            "$ref": "#/definitions/auto_replay_nacks"
           }
         ]
       }
@@ -2150,26 +2129,26 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
-                "$ref": "#/definitions/enable_renegotiation_description"
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description_1"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           }
         ]
       }
@@ -2180,7 +2159,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           },
           {
             "name": "query",
@@ -2199,7 +2178,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           }
         ]
       }
@@ -2241,25 +2220,25 @@
         "children": [
           {
             "name": "oauth",
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "jwt",
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           }
         ]
       }
@@ -2350,7 +2329,7 @@
                 "description": "Provide a list of explicit metadata key prefixes to exclude when adding metadata to sent messages."
               }
             ],
-            "$ref": "#/definitions/metadata_description"
+            "$ref": "#/definitions/metadata"
           },
           {
             "name": "priority",
@@ -2381,11 +2360,11 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
@@ -2393,10 +2372,10 @@
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           }
         ]
       }
@@ -2425,7 +2404,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -2449,7 +2428,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -2465,7 +2444,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -2575,7 +2554,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -2721,7 +2700,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           },
@@ -2802,26 +2781,26 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ],
-            "$ref": "#/definitions/batching_description"
+            "$ref": "#/definitions/batching"
           }
         ]
       }
@@ -2848,11 +2827,11 @@
             "children": [
               {
                 "name": "username",
-                "$ref": "#/definitions/username_description"
+                "$ref": "#/definitions/username"
               },
               {
                 "name": "password",
-                "$ref": "#/definitions/password_description"
+                "$ref": "#/definitions/password"
               },
               {
                 "name": "realm",
@@ -2865,52 +2844,52 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
-                "$ref": "#/definitions/enable_renegotiation_description"
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description_1"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "batching",
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ],
-            "$ref": "#/definitions/batching_description"
+            "$ref": "#/definitions/batching"
           },
           {
             "name": "max_in_flight",
@@ -2956,7 +2935,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -3005,22 +2984,22 @@
               },
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "basic_auth",
@@ -3036,19 +3015,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           }
@@ -3141,26 +3120,26 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ],
-            "$ref": "#/definitions/batching_description"
+            "$ref": "#/definitions/batching"
           }
         ]
       }
@@ -3183,7 +3162,7 @@
           },
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           }
         ]
       }
@@ -3194,7 +3173,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           },
           {
             "name": "topic",
@@ -3251,7 +3230,7 @@
             "children": [
               {
                 "name": "consumer_secret",
-                "$ref": "#/definitions/consumer_secret_description"
+                "$ref": "#/definitions/consumer_secret"
               },
               {
                 "name": "access_token",
@@ -3259,10 +3238,10 @@
               },
               {
                 "name": "access_token_secret",
-                "$ref": "#/definitions/access_token_secret_description"
+                "$ref": "#/definitions/access_token_secret"
               }
             ],
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "oauth2",
@@ -3287,40 +3266,40 @@
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "extract_headers",
@@ -3373,19 +3352,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           },
@@ -3406,7 +3385,7 @@
           },
           {
             "name": "key",
-            "$ref": "#/definitions/key_description"
+            "$ref": "#/definitions/key"
           },
           {
             "name": "partition",
@@ -3417,7 +3396,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           },
@@ -3434,7 +3413,7 @@
         "children": [
           {
             "name": "seed_brokers",
-            "$ref": "#/definitions/seed_brokers_description"
+            "$ref": "#/definitions/seed_brokers"
           },
           {
             "name": "topic",
@@ -3442,7 +3421,7 @@
           },
           {
             "name": "key",
-            "$ref": "#/definitions/key_description_1"
+            "$ref": "#/definitions/key"
           },
           {
             "name": "partition",
@@ -3454,7 +3433,7 @@
           },
           {
             "name": "metadata",
-            "$ref": "#/definitions/metadata_description"
+            "$ref": "#/definitions/metadata"
           },
           {
             "name": "max_in_flight",
@@ -3469,19 +3448,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           },
@@ -3491,7 +3470,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "$ref": "#/definitions/broker_write_max_bytes_description"
+            "$ref": "#/definitions/broker_write_max_bytes"
           },
           {
             "name": "compression",
@@ -3502,22 +3481,22 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -3525,7 +3504,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -3533,7 +3512,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "timestamp_ms",
@@ -3552,7 +3531,7 @@
           },
           {
             "name": "password",
-            "$ref": "#/definitions/password_description_2"
+            "$ref": "#/definitions/password"
           },
           {
             "name": "collection",
@@ -3601,19 +3580,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           }
@@ -3647,7 +3626,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "subject",
@@ -3662,26 +3641,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -3693,7 +3672,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "subject",
@@ -3708,26 +3687,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -3739,7 +3718,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "key",
@@ -3750,26 +3729,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -3781,33 +3760,33 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "auth",
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -3882,26 +3861,26 @@
                 "children": [
                   {
                     "name": "count",
-                    "$ref": "#/definitions/count_description"
+                    "$ref": "#/definitions/count"
                   },
                   {
                     "name": "byte_size",
-                    "$ref": "#/definitions/byte_size_description"
+                    "$ref": "#/definitions/byte_size"
                   },
                   {
                     "name": "period",
-                    "$ref": "#/definitions/period_description"
+                    "$ref": "#/definitions/period"
                   },
                   {
                     "name": "check",
-                    "$ref": "#/definitions/check_description"
+                    "$ref": "#/definitions/check"
                   },
                   {
                     "name": "processors",
                     "description": "For aggregating and archiving message batches, you can add a list of xref:components:processors/about.adoc[processors] to apply to a batch as it is flushed (optional). All resulting messages are flushed as a single batch even when you configure processors to split the batch into smaller batches."
                   }
                 ],
-                "$ref": "#/definitions/batching_description"
+                "$ref": "#/definitions/batching"
               },
               {
                 "name": "max_message_bytes",
@@ -3909,7 +3888,7 @@
               },
               {
                 "name": "broker_write_max_bytes",
-                "$ref": "#/definitions/broker_write_max_bytes_description"
+                "$ref": "#/definitions/broker_write_max_bytes"
               },
               {
                 "name": "compression",
@@ -3920,26 +3899,26 @@
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "$ref": "#/definitions/skip_cert_verify_description"
+                    "$ref": "#/definitions/skip_cert_verify"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "$ref": "#/definitions/enable_renegotiation_description"
+                    "$ref": "#/definitions/enable_renegotiation"
                   },
                   {
                     "name": "root_cas",
-                    "$ref": "#/definitions/root_cas_description_3"
+                    "$ref": "#/definitions/root_cas"
                   },
                   {
                     "name": "root_cas_file",
-                    "$ref": "#/definitions/root_cas_file_description"
+                    "$ref": "#/definitions/root_cas_file"
                   },
                   {
                     "name": "client_certs",
-                    "$ref": "#/definitions/client_certs_description"
+                    "$ref": "#/definitions/client_certs"
                   }
                 ],
-                "$ref": "#/definitions/tls_description"
+                "$ref": "#/definitions/tls"
               },
               {
                 "name": "timestamp_ms",
@@ -4030,7 +4009,7 @@
         "children": [
           {
             "name": "key",
-            "$ref": "#/definitions/key_description"
+            "$ref": "#/definitions/key"
           },
           {
             "name": "ordering_key",
@@ -4056,7 +4035,7 @@
         "children": [
           {
             "name": "tls",
-            "$ref": "#/definitions/tls_description_1"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "collection_name",
@@ -4078,23 +4057,23 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           },
@@ -4103,26 +4082,26 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
-                "$ref": "#/definitions/enable_renegotiation_description"
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description_1"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "address",
@@ -4241,33 +4220,33 @@
         "children": [
           {
             "name": "seed_brokers",
-            "$ref": "#/definitions/seed_brokers_description"
+            "$ref": "#/definitions/seed_brokers"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
-                "$ref": "#/definitions/enable_renegotiation_description"
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -4275,7 +4254,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -4283,7 +4262,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "topic",
@@ -4291,7 +4270,7 @@
           },
           {
             "name": "key",
-            "$ref": "#/definitions/key_description_1"
+            "$ref": "#/definitions/key"
           },
           {
             "name": "partition",
@@ -4299,7 +4278,7 @@
           },
           {
             "name": "metadata",
-            "$ref": "#/definitions/metadata_description"
+            "$ref": "#/definitions/metadata"
           },
           {
             "name": "timestamp_ms",
@@ -4327,7 +4306,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "$ref": "#/definitions/broker_write_max_bytes_description"
+            "$ref": "#/definitions/broker_write_max_bytes"
           }
         ]
       }
@@ -4350,7 +4329,7 @@
           },
           {
             "name": "metadata",
-            "$ref": "#/definitions/metadata_description"
+            "$ref": "#/definitions/metadata"
           },
           {
             "name": "timestamp_ms",
@@ -4365,19 +4344,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           }
@@ -4397,22 +4376,22 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -4424,7 +4403,7 @@
           },
           {
             "name": "key",
-            "$ref": "#/definitions/key_description_1"
+            "$ref": "#/definitions/key"
           },
           {
             "name": "partition",
@@ -4432,11 +4411,11 @@
           },
           {
             "name": "metadata",
-            "$ref": "#/definitions/metadata_description"
+            "$ref": "#/definitions/metadata"
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -4444,7 +4423,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "topic_prefix",
@@ -4500,7 +4479,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "$ref": "#/definitions/broker_write_max_bytes_description"
+            "$ref": "#/definitions/broker_write_max_bytes"
           }
         ]
       }
@@ -4537,22 +4516,22 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "sasl",
@@ -4560,7 +4539,7 @@
           },
           {
             "name": "metadata_max_age",
-            "$ref": "#/definitions/metadata_max_age_description"
+            "$ref": "#/definitions/metadata_max_age"
           },
           {
             "name": "request_timeout_overhead",
@@ -4568,7 +4547,7 @@
           },
           {
             "name": "conn_idle_timeout",
-            "$ref": "#/definitions/conn_idle_timeout_description"
+            "$ref": "#/definitions/conn_idle_timeout"
           },
           {
             "name": "offset_topic",
@@ -4608,7 +4587,7 @@
           },
           {
             "name": "broker_write_max_bytes",
-            "$ref": "#/definitions/broker_write_max_bytes_description"
+            "$ref": "#/definitions/broker_write_max_bytes"
           },
           {
             "name": "max_retries",
@@ -4644,7 +4623,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -4712,18 +4691,18 @@
             "children": [
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "max_in_flight",
@@ -4739,7 +4718,7 @@
               },
               {
                 "name": "consumer_secret",
-                "$ref": "#/definitions/consumer_secret_description"
+                "$ref": "#/definitions/consumer_secret"
               },
               {
                 "name": "access_token",
@@ -4747,7 +4726,7 @@
               },
               {
                 "name": "access_token_secret",
-                "$ref": "#/definitions/access_token_secret_description"
+                "$ref": "#/definitions/access_token_secret"
               }
             ]
           },
@@ -4757,11 +4736,11 @@
             "children": [
               {
                 "name": "username",
-                "$ref": "#/definitions/username_description"
+                "$ref": "#/definitions/username"
               },
               {
                 "name": "password",
-                "$ref": "#/definitions/password_description"
+                "$ref": "#/definitions/password"
               }
             ]
           },
@@ -4827,7 +4806,7 @@
               },
               {
                 "name": "password",
-                "$ref": "#/definitions/password_description_1"
+                "$ref": "#/definitions/password"
               },
               {
                 "name": "private_key_file",
@@ -5022,19 +5001,19 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ]
           },
@@ -5078,7 +5057,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           }
         ]
       }
@@ -5089,7 +5068,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           },
           {
             "name": "query",
@@ -5151,26 +5130,26 @@
             "children": [
               {
                 "name": "count",
-                "$ref": "#/definitions/count_description"
+                "$ref": "#/definitions/count"
               },
               {
                 "name": "byte_size",
-                "$ref": "#/definitions/byte_size_description"
+                "$ref": "#/definitions/byte_size"
               },
               {
                 "name": "period",
-                "$ref": "#/definitions/period_description"
+                "$ref": "#/definitions/period"
               },
               {
                 "name": "check",
-                "$ref": "#/definitions/check_description"
+                "$ref": "#/definitions/check"
               },
               {
                 "name": "processors",
-                "$ref": "#/definitions/processors_description"
+                "$ref": "#/definitions/processors"
               }
             ],
-            "$ref": "#/definitions/batching_description"
+            "$ref": "#/definitions/batching"
           }
         ]
       }
@@ -5181,25 +5160,25 @@
         "children": [
           {
             "name": "oauth",
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "jwt",
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           }
         ]
       }
@@ -5257,7 +5236,7 @@
           },
           {
             "name": "endpoint",
-            "$ref": "#/definitions/endpoint_description"
+            "$ref": "#/definitions/endpoint"
           },
           {
             "name": "temperature",
@@ -5288,7 +5267,7 @@
           },
           {
             "name": "endpoint",
-            "$ref": "#/definitions/endpoint_description"
+            "$ref": "#/definitions/endpoint"
           },
           {
             "name": "credentials",
@@ -5432,26 +5411,26 @@
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "$ref": "#/definitions/skip_cert_verify_description"
+                    "$ref": "#/definitions/skip_cert_verify"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "$ref": "#/definitions/enable_renegotiation_description"
+                    "$ref": "#/definitions/enable_renegotiation"
                   },
                   {
                     "name": "root_cas",
-                    "$ref": "#/definitions/root_cas_description_3"
+                    "$ref": "#/definitions/root_cas"
                   },
                   {
                     "name": "root_cas_file",
-                    "$ref": "#/definitions/root_cas_file_description_1"
+                    "$ref": "#/definitions/root_cas_file"
                   },
                   {
                     "name": "client_certs",
-                    "$ref": "#/definitions/client_certs_description"
+                    "$ref": "#/definitions/client_certs"
                   }
                 ],
-                "$ref": "#/definitions/tls_description"
+                "$ref": "#/definitions/tls"
               },
               {
                 "name": "oauth",
@@ -5459,7 +5438,7 @@
                 "children": [
                   {
                     "name": "enabled",
-                    "$ref": "#/definitions/enabled_description"
+                    "$ref": "#/definitions/enabled"
                   },
                   {
                     "name": "consumer_key",
@@ -5467,7 +5446,7 @@
                   },
                   {
                     "name": "consumer_secret",
-                    "$ref": "#/definitions/consumer_secret_description"
+                    "$ref": "#/definitions/consumer_secret"
                   },
                   {
                     "name": "access_token",
@@ -5475,7 +5454,7 @@
                   },
                   {
                     "name": "access_token_secret",
-                    "$ref": "#/definitions/access_token_secret_description"
+                    "$ref": "#/definitions/access_token_secret"
                   }
                 ]
               },
@@ -5485,11 +5464,11 @@
                 "children": [
                   {
                     "name": "username",
-                    "$ref": "#/definitions/username_description"
+                    "$ref": "#/definitions/username"
                   },
                   {
                     "name": "password",
-                    "$ref": "#/definitions/password_description"
+                    "$ref": "#/definitions/password"
                   }
                 ]
               },
@@ -5637,7 +5616,7 @@
         "children": [
           {
             "name": "credentials_json",
-            "$ref": "#/definitions/credentials_json_description"
+            "$ref": "#/definitions/credentials_json"
           }
         ]
       }
@@ -5829,10 +5808,10 @@
               },
               {
                 "name": "access_token_secret",
-                "$ref": "#/definitions/access_token_secret_description"
+                "$ref": "#/definitions/access_token_secret"
               }
             ],
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "oauth2",
@@ -5857,40 +5836,40 @@
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           },
           {
             "name": "tls",
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "extract_headers",
@@ -6005,7 +5984,7 @@
           },
           {
             "name": "password",
-            "$ref": "#/definitions/password_description_2"
+            "$ref": "#/definitions/password"
           },
           {
             "name": "operation",
@@ -6055,7 +6034,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "key",
@@ -6070,26 +6049,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -6101,7 +6080,7 @@
           {
             "name": "urls",
             "type": "array",
-            "$ref": "#/definitions/urls_description"
+            "$ref": "#/definitions/urls"
           },
           {
             "name": "subject",
@@ -6116,26 +6095,26 @@
             "children": [
               {
                 "name": "nkey",
-                "$ref": "#/definitions/nkey_description"
+                "$ref": "#/definitions/nkey"
               },
               {
                 "name": "user_credentials_file",
-                "$ref": "#/definitions/user_credentials_file_description"
+                "$ref": "#/definitions/user_credentials_file"
               },
               {
                 "name": "user_jwt",
-                "$ref": "#/definitions/user_jwt_description"
+                "$ref": "#/definitions/user_jwt"
               },
               {
                 "name": "user_nkey_seed",
-                "$ref": "#/definitions/user_nkey_seed_description"
+                "$ref": "#/definitions/user_nkey_seed"
               }
             ]
           },
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }
@@ -6347,23 +6326,23 @@
                 "children": [
                   {
                     "name": "skip_cert_verify",
-                    "$ref": "#/definitions/skip_cert_verify_description"
+                    "$ref": "#/definitions/skip_cert_verify"
                   },
                   {
                     "name": "enable_renegotiation",
-                    "$ref": "#/definitions/enable_renegotiation_description_1"
+                    "$ref": "#/definitions/enable_renegotiation"
                   },
                   {
                     "name": "root_cas",
-                    "$ref": "#/definitions/root_cas_description_3"
+                    "$ref": "#/definitions/root_cas"
                   },
                   {
                     "name": "root_cas_file",
-                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
+                    "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate."
                   },
                   {
                     "name": "client_certs",
-                    "$ref": "#/definitions/client_certs_description"
+                    "$ref": "#/definitions/client_certs"
                   }
                 ]
               },
@@ -6373,7 +6352,7 @@
                 "children": [
                   {
                     "name": "enabled",
-                    "$ref": "#/definitions/enabled_description"
+                    "$ref": "#/definitions/enabled"
                   },
                   {
                     "name": "consumer_key",
@@ -6381,7 +6360,7 @@
                   },
                   {
                     "name": "consumer_secret",
-                    "$ref": "#/definitions/consumer_secret_description"
+                    "$ref": "#/definitions/consumer_secret"
                   },
                   {
                     "name": "access_token",
@@ -6389,7 +6368,7 @@
                   },
                   {
                     "name": "access_token_secret",
-                    "$ref": "#/definitions/access_token_secret_description"
+                    "$ref": "#/definitions/access_token_secret"
                   }
                 ]
               },
@@ -6399,11 +6378,11 @@
                 "children": [
                   {
                     "name": "username",
-                    "$ref": "#/definitions/username_description"
+                    "$ref": "#/definitions/username"
                   },
                   {
                     "name": "password",
-                    "$ref": "#/definitions/password_description"
+                    "$ref": "#/definitions/password"
                   }
                 ]
               },
@@ -6583,26 +6562,26 @@
             "children": [
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "enable_renegotiation",
-                "$ref": "#/definitions/enable_renegotiation_description"
+                "$ref": "#/definitions/enable_renegotiation"
               },
               {
                 "name": "root_cas",
-                "$ref": "#/definitions/root_cas_description_3"
+                "$ref": "#/definitions/root_cas"
               },
               {
                 "name": "root_cas_file",
-                "$ref": "#/definitions/root_cas_file_description"
+                "$ref": "#/definitions/root_cas_file"
               },
               {
                 "name": "client_certs",
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ],
-            "$ref": "#/definitions/tls_description_1"
+            "$ref": "#/definitions/tls"
           },
           {
             "name": "collection_name",
@@ -6648,7 +6627,7 @@
         "children": [
           {
             "name": "input_key",
-            "$ref": "#/definitions/key_description_1"
+            "$ref": "#/definitions/key"
           }
         ]
       }
@@ -6662,7 +6641,7 @@
             "children": [
               {
                 "name": "initial_interval",
-                "$ref": "#/definitions/initial_interval_description"
+                "$ref": "#/definitions/initial_interval"
               }
             ]
           }
@@ -6696,25 +6675,25 @@
           },
           {
             "name": "oauth",
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "jwt",
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           }
         ]
       }
@@ -6733,25 +6712,25 @@
           },
           {
             "name": "oauth",
-            "$ref": "#/definitions/oauth_description"
+            "$ref": "#/definitions/oauth"
           },
           {
             "name": "jwt",
             "children": [
               {
                 "name": "private_key_file",
-                "$ref": "#/definitions/private_key_file_description"
+                "$ref": "#/definitions/private_key_file"
               },
               {
                 "name": "signing_method",
-                "$ref": "#/definitions/signing_method_description"
+                "$ref": "#/definitions/signing_method"
               },
               {
                 "name": "headers",
-                "$ref": "#/definitions/headers_description"
+                "$ref": "#/definitions/headers"
               }
             ],
-            "$ref": "#/definitions/jwt_description"
+            "$ref": "#/definitions/jwt"
           }
         ]
       }
@@ -6818,7 +6797,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           }
         ]
       }
@@ -6829,7 +6808,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           },
           {
             "name": "query",
@@ -6856,7 +6835,7 @@
         "children": [
           {
             "name": "dsn",
-            "$ref": "#/definitions/dsn_description"
+            "$ref": "#/definitions/dsn"
           }
         ]
       }
@@ -6938,11 +6917,11 @@
               },
               {
                 "name": "root_cas_file",
-                "description": "An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate."
+                "description": "An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent-trusted root certificate, to possible intermediate signing certificates, to the host certificate."
               },
               {
                 "name": "skip_cert_verify",
-                "$ref": "#/definitions/skip_cert_verify_description"
+                "$ref": "#/definitions/skip_cert_verify"
               },
               {
                 "name": "client_certs",
@@ -6968,7 +6947,7 @@
                     "description": "Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management."
                   }
                 ],
-                "$ref": "#/definitions/client_certs_description"
+                "$ref": "#/definitions/client_certs"
               }
             ]
           },
@@ -7004,7 +6983,7 @@
                   },
                   {
                     "name": "endpoint",
-                    "$ref": "#/definitions/endpoint_description"
+                    "$ref": "#/definitions/endpoint"
                   }
                 ]
               },
@@ -7058,7 +7037,7 @@
           {
             "name": "tls_handshake_first",
             "version": "4.60.0",
-            "$ref": "#/definitions/tls_handshake_first_description"
+            "$ref": "#/definitions/tls_handshake_first"
           }
         ]
       }

--- a/docs-data/overrides.json
+++ b/docs-data/overrides.json
@@ -1,13 +1,13 @@
 {
   "definitions": {
     "client_certs": {
-      "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk."
+      "description": "A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.\n\nYou must set `tls.enabled: true` for the client certificates to take effect.\n\n**Certificate pairing rules**: For each certificate item, provide either:\n\n- Inline PEM data using both `cert` *and* `key` or\n- File paths using both `cert_file` *and* `key_file`.\n\nMixing inline and file-based values within the same item is not supported."
     },
     "skip_cert_verify": {
-      "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production."
+      "description": "Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely."
     },
     "tls": {
-      "description": "Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates."
+      "description": "Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments."
     },
     "count": {
       "description": "The number of messages after which the batch is flushed. Set to `0` to disable count-based batching."
@@ -19,7 +19,7 @@
       "description": "Whether to perform the initial TLS handshake before sending the NATS INFO protocol message. This is required when connecting to some NATS servers that expect TLS to be established immediately after connection, before any protocol negotiation."
     },
     "initial_interval": {
-      "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value."
+      "description": "The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "check": {
       "description": "A xref:guides:bloblang/about.adoc[Bloblang query] that returns a boolean value indicating whether a message should end a batch."
@@ -28,79 +28,79 @@
       "description": "A list of URLs to connect to. If a list item contains commas, it will be expanded into multiple URLs."
     },
     "nkey": {
-      "description": "Your NKey seed or private key."
+      "description": "Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords."
     },
     "user_credentials_file": {
       "description": "An optional file containing user credentials which consist of a user JWT and corresponding NKey seed."
     },
     "user_jwt": {
-      "description": "An optional plain text user JWT to use along with the corresponding user NKey seed."
+      "description": "An optional plaintext user JWT to use along with the corresponding user NKey seed."
     },
     "byte_size": {
       "description": "The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching."
     },
     "period": {
-      "description": "The period of time after which an incomplete batch is flushed regardless of its size."
+      "description": "The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "user_nkey_seed": {
-      "description": "An optional plain text user NKey seed to use along with the corresponding user JWT."
+      "description": "An optional plaintext user NKey seed to use along with the corresponding user JWT."
     },
     "auto_replay_nacks": {
       "description": "Whether to automatically replay messages that are rejected (nacked) at the output level. If the cause of rejections is persistent, leaving this option enabled can result in back pressure.\n\nSet `auto_replay_nacks` to `false` to delete rejected messages. Disabling auto replays can greatly improve memory efficiency of high throughput streams, as the original shape of the data is discarded immediately upon consumption and mutation."
     },
     "oauth": {
-      "description": "Allows you to specify open authentication using OAuth version 1."
+      "description": "Configure OAuth version 1.0 authentication for secure API access."
     },
     "access_token_secret": {
-      "description": "The secret that establishes ownership of the `oauth.access_token`."
+      "description": "The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication."
     },
     "jwt": {
-      "description": "BETA: Allows you to specify JSON Web Token (JWT) authentication."
+      "description": "BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services."
     },
     "private_key_file": {
-      "description": "A file with the PEM encoded using PKCS1 or PKCS8 as private key."
+      "description": "Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field."
     },
     "signing_method": {
-      "description": "A method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+      "description": "The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field."
     },
     "headers": {
-      "description": "Add key/value headers to the JWT (optional)."
+      "description": "Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing."
     },
     "conn_idle_timeout": {
-      "description": "Define how long connections can remain idle before they are closed."
+      "description": "The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "dsn": {
-      "description": "A Data Source Name to identify the target database."
+      "description": "The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters."
     },
     "credentials_json": {
-      "description": "Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^]."
+      "description": "Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^]."
     },
     "consumer_secret": {
-      "description": "The secret used to establish ownership of the consumer key."
+      "description": "The secret that establishes ownership of the consumer key in OAuth 1.0 authentication."
     },
     "topic_lag_refresh_period": {
-      "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group."
+      "description": "The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "endpoint": {
-      "description": "Specify a custom endpoint for the AWS API."
+      "description": "A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints."
     },
     "seed_brokers": {
       "description": "A list of broker addresses to connect to in order. Use commas to separate multiple addresses in a single list item."
     },
     "metadata_max_age": {
-      "description": "The maximum period of time after which metadata is refreshed."
+      "description": "The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "instance_id": {
       "description": "When you specify a <<consumer_group,`consumer_group`>>, assign a unique value to `instance_id` to define the group\u2019s static membership, which can prevent unnecessary rebalances during reconnections. \n\nWhen you assign an instance ID, the client does not automatically leave the consumer group when it disconnects. To remove the client, you must use an external admin command on behalf of the instance ID."
     },
     "rebalance_timeout": {
-      "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required."
+      "description": "When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "session_timeout": {
-      "description": "When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.\n\nbroker"
+      "description": "When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`."
     },
     "heartbeat_interval": {
-      "description": "When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting.\n\nclient"
+      "description": "When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. \n\nYou must set `heartbeat_interval` to less than one-third of `session_timeout`.\n\nThis field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`."
     },
     "start_offset": {
       "description": "Specify the offset from which this input starts or restarts consuming messages. Restarts occur when the `OffsetOutOfRange` error is seen during a fetch."
@@ -115,13 +115,13 @@
       "description": "The maximum number of bytes that are consumed from a single partition in a fetch request. This field is equivalent to the Java setting `fetch.max.partition.bytes`.\n\nIf a single batch is larger than the `fetch_max_partition_bytes` value, the batch is still sent so that the client can make progress."
     },
     "transaction_isolation_level": {
-      "description": "Defines how transactional messages are handled."
+      "description": "The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees."
     },
     "username": {
-      "description": "The username of the account credentials to authenticate as."
+      "description": "The username of the account credentials to authenticate as. Used together with `password` for basic authentication."
     },
     "metadata": {
-      "description": "Specify which (if any) metadata values are added to messages as headers."
+      "description": "Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages."
     },
     "batching": {
       "description": "Configure a xref:configuration:batching.adoc[batching policy]."
@@ -130,22 +130,40 @@
       "description": "The maximum number of bytes this output can write to a broker connection in a single write. This field corresponds to Kafka\u2019s `socket.request.max.bytes`."
     },
     "enabled": {
-      "description": "Whether to use OAuth version 1 in requests to the schema registry."
+      "description": "Whether to enable OAuth version 1.0 authentication for requests to the schema registry."
     },
     "root_cas": {
-      "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+      "description": "Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading."
     },
     "root_cas_file": {
-      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate."
+      "description": "Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data."
     },
     "enable_renegotiation": {
       "description": "Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: \ntls: no renegotiation`."
     },
     "password": {
-      "description": "The password for the username used to authenticate with the SFTP server."
+      "description": "The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access."
     },
     "key": {
       "description": "An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions]."
+    },
+    "tls_cert": {
+      "description": "The plaintext certificate to use for TLS authentication. Must be paired with the corresponding private key in the `key` field when using inline PEM data for mTLS client certificates."
+    },
+    "tls_cert_file": {
+      "description": "The path to a file containing the certificate to use for TLS authentication. Must be paired with the corresponding private key file in the `key_file` field when using file-based configuration for mTLS client certificates."
+    },
+    "tls_key": {
+      "description": "Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field. Use this field together with `cert` when providing certificate data inline rather than through files."
+    },
+    "tls_key_file": {
+      "description": "Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field. Use this field together with `cert_file` when loading certificate data from files."
+    },
+    "tls_password": {
+      "description": "The password to use for the private key (specified in the `key` or `key_file` fields), if it is password-protected. The PKCS#1 and PKCS#8 formats are supported. Supports environment variable interpolation for secure password management.\n\nThe `pbeWithMD5AndDES-CBC` algorithm is obsolete and not supported for the PKCS#8 format. This algorithm does not authenticate the ciphertext, making it vulnerable to padding oracle attacks that can let an attacker recover the plaintext."
+    },
+    "tls_enabled": {
+      "description": "Whether to enable TLS for secure connections. Set to `true` to enable TLS encryption. Required to be `true` for other TLS options (like `client_certs`, `root_cas`, etc.) to take effect."
     }
   },
   "inputs": [
@@ -1161,7 +1179,7 @@
               },
               {
                 "name": "user_nkey_seed",
-                "description": "An optional plain text user NKey seed to use along with the user JWT."
+                "description": "An optional plaintext user NKey seed to use along with the user JWT."
               }
             ]
           },
@@ -1986,7 +2004,7 @@
           },
           {
             "name": "jwt",
-            "description": "BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from your schema registry to this component.",
+            "description": "BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from your schema registry to this component. This feature is in beta and may change in future releases.",
             "children": [
               {
                 "name": "private_key_file",
@@ -2980,7 +2998,7 @@
             "children": [
               {
                 "name": "enabled",
-                "description": "Enable custom TLS settings. By default, custom settings are disabled."
+                "$ref": "#/definitions/tls_enabled"
               },
               {
                 "name": "skip_cert_verify",
@@ -4746,7 +4764,7 @@
           },
           {
             "name": "jwt",
-            "description": "BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from this component to your schema registry.",
+            "description": "BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from this component to your schema registry. This feature is in beta and may change in future releases.",
             "children": [
               {
                 "name": "private_key_file",
@@ -5474,15 +5492,15 @@
               },
               {
                 "name": "jwt",
-                "description": "BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from your schema registry to this component.",
+                "description": "BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from your schema registry to this component. This feature is in beta and may change in future releases.",
                 "children": [
                   {
                     "name": "private_key_file",
-                    "description": "A file in PEM format encoded via PKCS1 or PKCS8 as private key."
+                    "$ref": "#/definitions/private_key_file"
                   },
                   {
                     "name": "signing_method",
-                    "description": "The method used to sign the token, such as RS256, RS384, RS512 or EdDSA."
+                    "$ref": "#/definitions/signing_method"
                   },
                   {
                     "name": "claims",
@@ -5815,7 +5833,7 @@
           },
           {
             "name": "oauth2",
-            "description": "Allows you to specify open authentication via OAuth version 2 and the client credentials token flow.",
+            "description": "Allows you to specify open authentication using OAuth version 2 and the client credentials token flow.",
             "children": [
               {
                 "name": "client_secret",
@@ -6391,11 +6409,11 @@
                 "children": [
                   {
                     "name": "private_key_file",
-                    "description": "A file in PEM format, encoded using PKCS1 or PKCS8 as private key."
+                    "$ref": "#/definitions/private_key_file"
                   },
                   {
                     "name": "signing_method",
-                    "description": "The method used to sign the token, such as RS256, RS384, RS512, or EdDSA."
+                    "$ref": "#/definitions/signing_method"
                   },
                   {
                     "name": "claims",
@@ -6928,23 +6946,23 @@
                 "children": [
                   {
                     "name": "cert",
-                    "description": "The plaintext certificate to use for TLS authentication."
+                    "$ref": "#/definitions/tls_cert"
                   },
                   {
                     "name": "cert_file",
-                    "description": "The path to a file containing the certificate to use for TLS authentication."
+                    "$ref": "#/definitions/tls_cert_file"
                   },
                   {
                     "name": "key",
-                    "description": "Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field."
+                    "$ref": "#/definitions/tls_key"
                   },
                   {
                     "name": "key_file",
-                    "description": "Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field."
+                    "$ref": "#/definitions/tls_key_file"
                   },
                   {
                     "name": "password",
-                    "description": "Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management."
+                    "$ref": "#/definitions/tls_password"
                   }
                 ],
                 "$ref": "#/definitions/client_certs"
@@ -7001,7 +7019,7 @@
                   ],
                   [
                     "PLAIN",
-                    "Plaintext authentication."
+                    "PLAIN mechanism for plaintext password authentication."
                   ],
                   [
                     "SCRAM-SHA-256",

--- a/modules/components/partials/fields/caches/redpanda.adoc
+++ b/modules/components/partials/fields/caches/redpanda.adoc
@@ -219,7 +219,7 @@ Use this field for custom TLS settings that override system defaults.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify only one of the field pairs `cert` and `key`, or `cert_file` and `key_file`. Do not include both pairs.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 
@@ -255,7 +255,7 @@ The path to a file containing the certificate to use for TLS authentication.
 
 === `tls.client_certs[].key`
 
-The plaintext private key to use for TLS authentication.
+Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -265,7 +265,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `tls.client_certs[].key_file`
 
-The path to a file containing the private key to use for TLS authentication.
+Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field.
 
 *Type*: `string`
 
@@ -273,9 +273,7 @@ The path to a file containing the private key to use for TLS authentication.
 
 === `tls.client_certs[].password`
 
-The password to use for the private key, if it is encrypted. This field is optional and only required if the private key is encrypted. The PKCS#1 and PKCS#8 formats are supported.
-
-The `pbeWithMD5AndDES-CBC` algorithm is obsolete and not supported for the PKCS#8 format. This algorithm does not authenticate the ciphertext, making it vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
+Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/caches/redpanda.adoc
+++ b/modules/components/partials/fields/caches/redpanda.adoc
@@ -213,7 +213,7 @@ seed_brokers:
 
 === `tls`
 
-Use this field for custom TLS settings that override system defaults.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
@@ -290,7 +290,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to repeatedly request renegotiation. Enable this option if you see the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -329,7 +330,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent-trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/caches/redpanda.adoc
+++ b/modules/components/partials/fields/caches/redpanda.adoc
@@ -329,7 +329,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.
+An optional file path of a root certificate authority file to use, usually with the .pem extension. This file contains a certificate chain from the parent-trusted root certificate, to possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/caches/redpanda.adoc
+++ b/modules/components/partials/fields/caches/redpanda.adoc
@@ -120,7 +120,7 @@ The token for the credentials being used. Required only when using short-term cr
 
 === `sasl[].aws.endpoint`
 
-Specify a custom endpoint for the AWS API.
+A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints.
 
 *Type*: `string`
 
@@ -153,7 +153,7 @@ The SASL mechanism to use for authentication.
 |OAuth Bearer authentication.
 
 |PLAIN
-|Plaintext authentication.
+|PLAIN mechanism for plaintext password authentication.
 
 |SCRAM-SHA-256
 |SCRAM authentication as specified in RFC5802.
@@ -213,13 +213,22 @@ seed_brokers:
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -239,7 +248,7 @@ client_certs:
 
 === `tls.client_certs[].cert`
 
-The plaintext certificate to use for TLS authentication.
+The plaintext certificate to use for TLS authentication. Must be paired with the corresponding private key in the `key` field when using inline PEM data for mTLS client certificates.
 
 *Type*: `string`
 
@@ -247,7 +256,7 @@ The plaintext certificate to use for TLS authentication.
 
 === `tls.client_certs[].cert_file`
 
-The path to a file containing the certificate to use for TLS authentication.
+The path to a file containing the certificate to use for TLS authentication. Must be paired with the corresponding private key file in the `key_file` field when using file-based configuration for mTLS client certificates.
 
 *Type*: `string`
 
@@ -255,7 +264,7 @@ The path to a file containing the certificate to use for TLS authentication.
 
 === `tls.client_certs[].key`
 
-Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field.
+Private key for mTLS client certificate as inline PEM data. Must correspond to the client certificate specified in the `cert` field. Use this field together with `cert` when providing certificate data inline rather than through files.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -265,7 +274,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `tls.client_certs[].key_file`
 
-Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field.
+Path to private key file for mTLS client certificate in PEM format. Must correspond to the client certificate specified in the `cert_file` field. Use this field together with `cert_file` when loading certificate data from files.
 
 *Type*: `string`
 
@@ -273,7 +282,9 @@ Path to private key file for mTLS client certificate in PEM format. Must corresp
 
 === `tls.client_certs[].password`
 
-Password for encrypted private key used in mTLS authentication. Supports environment variable interpolation for secure password management.
+The password to use for the private key (specified in the `key` or `key_file` fields), if it is password-protected. The PKCS#1 and PKCS#8 formats are supported. Supports environment variable interpolation for secure password management.
+
+The `pbeWithMD5AndDES-CBC` algorithm is obsolete and not supported for the PKCS#8 format. This algorithm does not authenticate the ciphertext, making it vulnerable to padding oracle attacks that can let an attacker recover the plaintext.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -330,7 +341,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -344,7 +355,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/caches/redpanda.adoc
+++ b/modules/components/partials/fields/caches/redpanda.adoc
@@ -219,7 +219,7 @@ Use this field for custom TLS settings that override system defaults.
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -343,7 +343,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/inputs/amqp_0_9.adoc
@@ -190,13 +190,22 @@ Whether to enable queue declaration.
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -290,7 +299,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -309,7 +318,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -323,7 +332,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/inputs/amqp_0_9.adoc
@@ -190,13 +190,13 @@ Whether to enable queue declaration.
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) encryption and mutual TLS (mTLS) authentication for secure connections. Supports both basic TLS encryption and mTLS with client certificate authentication.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 
@@ -290,7 +290,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Root certificate authorities as inline PEM data. Used to verify the server certificate in both TLS and mTLS configurations.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -309,7 +309,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Path to a root certificate authority file in PEM format. Used to verify the server certificate in both TLS and mTLS configurations.
 
 *Type*: `string`
 
@@ -323,7 +323,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as it reduces security.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/inputs/amqp_0_9.adoc
@@ -190,7 +190,7 @@ Whether to enable queue declaration.
 
 === `tls`
 
-Configure Transport Layer Security (TLS) encryption and mutual TLS (mTLS) authentication for secure connections. Supports both basic TLS encryption and mTLS with client certificate authentication.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
@@ -290,7 +290,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Root certificate authorities as inline PEM data. Used to verify the server certificate in both TLS and mTLS configurations.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -309,7 +309,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Path to a root certificate authority file in PEM format. Used to verify the server certificate in both TLS and mTLS configurations.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/inputs/amqp_0_9.adoc
@@ -196,7 +196,7 @@ Configure Transport Layer Security (TLS) encryption and mutual TLS (mTLS) authen
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -323,7 +323,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as it reduces security.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/aws_kinesis.adoc
+++ b/modules/components/partials/fields/inputs/aws_kinesis.adoc
@@ -250,7 +250,7 @@ The token for the AWS credentials in use. This is a required value for short-ter
 
 === `dynamodb.endpoint`
 
-Specify a custom endpoint for the AWS API.
+A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints.
 
 *Type*: `string`
 
@@ -286,7 +286,7 @@ Set the provisioned write capacity when creating the table with a `billing_mode`
 
 === `endpoint`
 
-Specify a custom endpoint for the AWS API.
+A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/cassandra.adoc
+++ b/modules/components/partials/fields/inputs/cassandra.adoc
@@ -37,7 +37,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/gcp_bigquery_select.adoc
+++ b/modules/components/partials/fields/inputs/gcp_bigquery_select.adoc
@@ -30,7 +30,7 @@ A list of columns to query.
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/gcp_cloud_storage.adoc
+++ b/modules/components/partials/fields/inputs/gcp_cloud_storage.adoc
@@ -10,7 +10,7 @@ The name of the bucket from which to download objects.
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/gcp_pubsub.adoc
+++ b/modules/components/partials/fields/inputs/gcp_pubsub.adoc
@@ -26,7 +26,7 @@ Defines the topic that the subscription should be vinculated to.
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/http_client.adoc
+++ b/modules/components/partials/fields/inputs/http_client.adoc
@@ -491,7 +491,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/http_client.adoc
+++ b/modules/components/partials/fields/inputs/http_client.adoc
@@ -604,7 +604,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/http_client.adoc
+++ b/modules/components/partials/fields/inputs/http_client.adoc
@@ -604,7 +604,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/http_client.adoc
+++ b/modules/components/partials/fields/inputs/http_client.adoc
@@ -171,7 +171,7 @@ headers:
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 *Type*: `object`
 
@@ -193,7 +193,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -201,7 +201,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -209,7 +209,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -270,7 +270,7 @@ include_prefixes:
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 *Type*: `object`
 
@@ -284,7 +284,7 @@ The value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -302,7 +302,7 @@ A value used to identify the client to the service provider.
 
 === `oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -485,13 +485,22 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -585,7 +594,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -604,7 +613,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -618,7 +627,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/http_client.adoc
+++ b/modules/components/partials/fields/inputs/http_client.adoc
@@ -485,13 +485,13 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -585,7 +585,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -618,7 +618,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/inputs/kafka_franz.adoc
@@ -575,7 +575,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/inputs/kafka_franz.adoc
@@ -66,7 +66,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -129,7 +129,7 @@ The period of time between each commit of the current partition offsets. Offsets
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -182,13 +182,11 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 === `heartbeat_interval`
 
-When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
 
 You must set `heartbeat_interval` to less than one-third of `session_timeout`.
 
-This field is equivalent to the Java `heartbeat.interval.ms` setting.
-
-client
+This field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`.
 
 *Type*: `string`
 
@@ -206,7 +204,7 @@ When you assign an instance ID, the client does not automatically leave the cons
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -230,7 +228,7 @@ A rack specifies where the client is physically located, and changes fetch reque
 
 === `rebalance_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -423,9 +421,7 @@ seed_brokers:
 
 === `session_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
-
-broker
+When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -456,13 +452,22 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -556,7 +561,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -575,7 +580,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -589,7 +594,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 
@@ -597,7 +602,7 @@ Whether to skip server-side certificate verification. Set to `true` only for tes
 
 === `topic_lag_refresh_period`
 
-The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group.
+The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -638,7 +643,7 @@ topics:
 
 === `transaction_isolation_level`
 
-Defines how transactional messages are handled.
+The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/inputs/kafka_franz.adoc
@@ -575,7 +575,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/inputs/kafka_franz.adoc
@@ -462,7 +462,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/inputs/kafka_franz.adoc
@@ -66,7 +66,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 
@@ -456,13 +456,13 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -556,7 +556,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -589,7 +589,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/mysql_cdc.adoc
+++ b/modules/components/partials/fields/inputs/mysql_cdc.adoc
@@ -67,7 +67,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/nats.adoc
+++ b/modules/components/partials/fields/inputs/nats.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/nats_jetstream.adoc
+++ b/modules/components/partials/fields/inputs/nats_jetstream.adoc
@@ -25,7 +25,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -67,7 +67,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -75,7 +75,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the user JWT.
+An optional plaintext user NKey seed to use along with the user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/nats_kv.adoc
+++ b/modules/components/partials/fields/inputs/nats_kv.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/nats_stream.adoc
+++ b/modules/components/partials/fields/inputs/nats_stream.adoc
@@ -18,7 +18,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -68,7 +68,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/inputs/ockam_kafka.adoc
@@ -323,13 +323,13 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `kafka.tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -456,7 +456,7 @@ root_cas_file: ./root_cas.pem
 
 === `kafka.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/inputs/ockam_kafka.adoc
@@ -443,7 +443,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/inputs/ockam_kafka.adoc
@@ -115,7 +115,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `kafka.batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -215,13 +215,11 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 === `kafka.heartbeat_interval`
 
-When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
 
 You must set `heartbeat_interval` to less than one-third of `session_timeout`.
 
-This field is equivalent to the Java `heartbeat.interval.ms` setting.
-
-client
+This field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`.
 
 *Type*: `string`
 
@@ -255,7 +253,7 @@ A rack identifier for this client.
 
 === `kafka.rebalance_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -290,9 +288,7 @@ seed_brokers:
 
 === `kafka.session_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
-
-broker
+When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -323,13 +319,22 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `kafka.tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -424,7 +429,7 @@ Whether custom TLS settings are enabled.
 
 === `kafka.tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -443,7 +448,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -457,7 +462,7 @@ root_cas_file: ./root_cas.pem
 
 === `kafka.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 
@@ -465,7 +470,7 @@ Whether to skip server-side certificate verification. Set to `true` only for tes
 
 === `kafka.topic_lag_refresh_period`
 
-The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group.
+The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -506,7 +511,7 @@ topics:
 
 === `kafka.transaction_isolation_level`
 
-Defines how transactional messages are handled.
+The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/inputs/ockam_kafka.adoc
@@ -403,7 +403,8 @@ password: ${KEY_PASSWORD}
 
 === `kafka.tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -442,7 +443,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/inputs/ockam_kafka.adoc
@@ -329,7 +329,7 @@ Override system defaults with custom TLS settings.
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify either the fields `cert` and `key` or `cert_file` and `key_file`.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/postgres_cdc.adoc
+++ b/modules/components/partials/fields/inputs/postgres_cdc.adoc
@@ -67,7 +67,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda.adoc
+++ b/modules/components/partials/fields/inputs/redpanda.adoc
@@ -488,7 +488,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda.adoc
+++ b/modules/components/partials/fields/inputs/redpanda.adoc
@@ -30,7 +30,7 @@ The period of time between each commit of the current partition offsets. Offsets
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -85,13 +85,11 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 === `heartbeat_interval`
 
-When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
 
 You must set `heartbeat_interval` to less than one-third of `session_timeout`.
 
-This field is equivalent to the Java `heartbeat.interval.ms` setting.
-
-client
+This field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`.
 
 *Type*: `string`
 
@@ -117,7 +115,7 @@ The maximum size (in bytes) for each batch yielded by this input. When routed to
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -143,7 +141,7 @@ A rack specifies where the client is physically located, and changes fetch reque
 
 === `rebalance_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -336,9 +334,7 @@ seed_brokers:
 
 === `session_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
-
-broker
+When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -369,13 +365,22 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -470,7 +475,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -489,7 +494,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -503,7 +508,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 
@@ -511,7 +516,7 @@ Whether to skip server-side certificate verification. Set to `true` only for tes
 
 === `topic_lag_refresh_period`
 
-The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group.
+The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -552,7 +557,7 @@ topics:
 
 === `transaction_isolation_level`
 
-Defines how transactional messages are handled.
+The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda.adoc
+++ b/modules/components/partials/fields/inputs/redpanda.adoc
@@ -369,13 +369,13 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -469,7 +469,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -488,7 +488,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 
@@ -502,7 +502,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/redpanda.adoc
+++ b/modules/components/partials/fields/inputs/redpanda.adoc
@@ -449,7 +449,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you’re seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -488,7 +489,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda.adoc
+++ b/modules/components/partials/fields/inputs/redpanda.adoc
@@ -375,7 +375,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/redpanda_common.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_common.adoc
@@ -69,13 +69,11 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 === `heartbeat_interval`
 
-When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
 
 You must set `heartbeat_interval` to less than one-third of `session_timeout`.
 
-This field is equivalent to the Java `heartbeat.interval.ms` setting.
-
-client
+This field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`.
 
 *Type*: `string`
 
@@ -119,7 +117,7 @@ A rack specifies where the client is physically located, and changes fetch reque
 
 === `rebalance_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -135,9 +133,7 @@ Whether listed topics are interpreted as regular expression patterns for matchin
 
 === `session_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
-
-broker
+When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -168,7 +164,7 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `topic_lag_refresh_period`
 
-The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group.
+The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -209,7 +205,7 @@ topics:
 
 === `transaction_isolation_level`
 
-Defines how transactional messages are handled.
+The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator.adoc
@@ -112,7 +112,7 @@ The maximum size (in bytes) for each batch yielded by this input. When routed to
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed. Reducing this value increases the frequency with which newly-created topics are identified.
+The maximum period of time after which metadata is refreshed.
 
 *Type*: `string`
 
@@ -364,13 +364,13 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -464,7 +464,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -497,7 +497,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator.adoc
@@ -483,7 +483,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator.adoc
@@ -30,7 +30,7 @@ The period of time between each commit of the current partition offsets. Offsets
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -80,13 +80,11 @@ The minimum number of bytes that a broker tries to send during a fetch. This fie
 
 === `heartbeat_interval`
 
-When you specify a <<consumer_group,`consumer_group`>>, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
+When you specify a `consumer_group`, `heartbeat_interval` sets how frequently a consumer group member should send heartbeats to Apache Kafka. Apache Kafka uses heartbeats to make sure that a group member's session is active. 
 
 You must set `heartbeat_interval` to less than one-third of `session_timeout`.
 
-This field is equivalent to the Java `heartbeat.interval.ms` setting.
-
-client
+This field is equivalent to the Java `heartbeat.interval.ms` setting and accepts Go duration format strings such as `10s` or `2m`.
 
 *Type*: `string`
 
@@ -112,7 +110,7 @@ The maximum size (in bytes) for each batch yielded by this input. When routed to
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -138,7 +136,7 @@ A rack identifier for this client.
 
 === `rebalance_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required.
+When you specify a <<consumer_group,`consumer_group`>>, `rebalance_timeout` sets a time limit for all consumer group members to complete their work and commit offsets after a rebalance has begun. The timeout excludes the time taken to detect a failed or late heartbeat, which indicates a rebalance is required. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -331,9 +329,7 @@ seed_brokers:
 
 === `session_timeout`
 
-When you specify a <<consumer_group,`consumer_group`>>, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance.
-
-broker
+When you specify a `consumer_group`, `session_timeout` sets the maximum interval between heartbeats sent by a consumer group member to the broker. If a broker doesn't receive a heartbeat from a group member before the timeout expires, it removes the member from the consumer group and initiates a rebalance. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -364,13 +360,22 @@ Specify the offset from which this input starts or restarts consuming messages. 
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -464,7 +469,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -483,7 +488,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -497,7 +502,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 
@@ -505,7 +510,7 @@ Whether to skip server-side certificate verification. Set to `true` only for tes
 
 === `topic_lag_refresh_period`
 
-The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag - the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group.
+The interval between refresh cycles. During each cycle, this input queries the Redpanda Connect server to calculate the topic lag minus the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -546,7 +551,7 @@ topics:
 
 === `transaction_isolation_level`
 
-Defines how transactional messages are handled.
+The isolation level for handling transactional messages. This setting determines how transactions are processed and affects data consistency guarantees.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator.adoc
@@ -483,7 +483,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator.adoc
@@ -370,7 +370,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
@@ -239,13 +239,22 @@ seed_brokers:
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -339,7 +348,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -358,7 +367,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -372,7 +381,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
@@ -245,7 +245,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key`, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
@@ -239,13 +239,13 @@ seed_brokers:
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -339,7 +339,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -372,7 +372,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
@@ -358,7 +358,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/inputs/redpanda_migrator_offsets.adoc
@@ -358,7 +358,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/schema_registry.adoc
+++ b/modules/components/partials/fields/inputs/schema_registry.adoc
@@ -176,7 +176,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/schema_registry.adoc
+++ b/modules/components/partials/fields/inputs/schema_registry.adoc
@@ -170,13 +170,13 @@ Include only subjects which match the regular expression filter, or leave this f
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -270,7 +270,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -289,7 +289,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 
@@ -303,7 +303,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/schema_registry.adoc
+++ b/modules/components/partials/fields/inputs/schema_registry.adoc
@@ -28,7 +28,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password of the account credentials to authenticate with.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -289,7 +289,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/schema_registry.adoc
+++ b/modules/components/partials/fields/inputs/schema_registry.adoc
@@ -289,7 +289,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/schema_registry.adoc
+++ b/modules/components/partials/fields/inputs/schema_registry.adoc
@@ -28,7 +28,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -38,7 +38,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `basic_auth.username`
 
-The username of the account credentials to authenticate as.
+The username of the account credentials to authenticate as. Used together with `password` for basic authentication.
 
 *Type*: `string`
 
@@ -66,7 +66,7 @@ Include deleted entities.
 
 === `jwt`
 
-BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from your schema registry to this component.
+BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from your schema registry to this component. This feature is in beta and may change in future releases.
 
 *Type*: `object`
 
@@ -126,7 +126,7 @@ The value this component can use to gain access to the data in the schema regist
 
 === `oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -144,7 +144,7 @@ The value used to identify this component or client to your schema registry.
 
 === `oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -170,13 +170,22 @@ Include only subjects which match the regular expression filter, or leave this f
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -270,7 +279,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -289,7 +298,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -303,7 +312,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/sftp.adoc
+++ b/modules/components/partials/fields/inputs/sftp.adoc
@@ -44,7 +44,7 @@ The path to the SFTP server's public key file, used for host key verification.
 
 === `credentials.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/inputs/spicedb_watch.adoc
+++ b/modules/components/partials/fields/inputs/spicedb_watch.adoc
@@ -61,13 +61,22 @@ max_receive_message_bytes: 50mib
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -162,7 +171,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -181,7 +190,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -195,7 +204,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/spicedb_watch.adoc
+++ b/modules/components/partials/fields/inputs/spicedb_watch.adoc
@@ -67,7 +67,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/inputs/spicedb_watch.adoc
+++ b/modules/components/partials/fields/inputs/spicedb_watch.adoc
@@ -61,13 +61,13 @@ max_receive_message_bytes: 50mib
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -141,8 +141,7 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
-tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -162,7 +161,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -195,7 +194,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/inputs/spicedb_watch.adoc
+++ b/modules/components/partials/fields/inputs/spicedb_watch.adoc
@@ -141,7 +141,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -180,7 +181,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/spicedb_watch.adoc
+++ b/modules/components/partials/fields/inputs/spicedb_watch.adoc
@@ -181,7 +181,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/sql_raw.adoc
+++ b/modules/components/partials/fields/inputs/sql_raw.adoc
@@ -59,7 +59,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/sql_select.adoc
+++ b/modules/components/partials/fields/inputs/sql_select.adoc
@@ -76,7 +76,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/inputs/websocket.adoc
+++ b/modules/components/partials/fields/inputs/websocket.adoc
@@ -63,7 +63,7 @@ max_retries: 10
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 *Type*: `object`
 
@@ -85,7 +85,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -93,7 +93,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -101,7 +101,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -109,7 +109,7 @@ A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/outputs/amqp_0_9.adoc
@@ -197,7 +197,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/outputs/amqp_0_9.adoc
@@ -137,7 +137,7 @@ Set a message ID for each message using a dynamic interpolated expression. This 
 
 === `metadata`
 
-Specify which (if any) metadata values are added to messages as headers.
+Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages.
 
 *Type*: `object`
 
@@ -191,13 +191,22 @@ The maximum period to wait for a message acknowledgment before abandoning it and
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -291,7 +300,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -310,7 +319,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -324,7 +333,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/outputs/amqp_0_9.adoc
@@ -191,13 +191,13 @@ The maximum period to wait for a message acknowledgment before abandoning it and
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -291,7 +291,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -324,7 +324,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/amqp_0_9.adoc
+++ b/modules/components/partials/fields/outputs/amqp_0_9.adoc
@@ -310,7 +310,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/aws_dynamodb.adoc
+++ b/modules/components/partials/fields/outputs/aws_dynamodb.adoc
@@ -10,7 +10,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/aws_kinesis.adoc
+++ b/modules/components/partials/fields/outputs/aws_kinesis.adoc
@@ -10,7 +10,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/aws_kinesis_firehose.adoc
+++ b/modules/components/partials/fields/outputs/aws_kinesis_firehose.adoc
@@ -10,7 +10,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/aws_sqs.adoc
+++ b/modules/components/partials/fields/outputs/aws_sqs.adoc
@@ -10,7 +10,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/cassandra.adoc
+++ b/modules/components/partials/fields/outputs/cassandra.adoc
@@ -39,7 +39,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/couchbase.adoc
+++ b/modules/components/partials/fields/outputs/couchbase.adoc
@@ -26,7 +26,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 

--- a/modules/components/partials/fields/outputs/couchbase.adoc
+++ b/modules/components/partials/fields/outputs/couchbase.adoc
@@ -56,7 +56,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/cypher.adoc
+++ b/modules/components/partials/fields/outputs/cypher.adoc
@@ -31,7 +31,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password of the account credentials to authenticate with.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -258,7 +258,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -289,7 +290,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/cypher.adoc
+++ b/modules/components/partials/fields/outputs/cypher.adoc
@@ -31,7 +31,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -49,7 +49,7 @@ The realm or process for authentication challenges.
 
 === `basic_auth.username`
 
-The username of the account credentials to authenticate as.
+The username of the account credentials to authenticate as. Used together with `password` for basic authentication.
 
 *Type*: `string`
 
@@ -109,7 +109,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -178,13 +178,22 @@ The maximum number of message batches to have in flight at a given time. Increas
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -271,7 +280,7 @@ endif::[]
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -290,7 +299,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -304,7 +313,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/cypher.adoc
+++ b/modules/components/partials/fields/outputs/cypher.adoc
@@ -79,7 +79,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -178,13 +178,13 @@ The maximum number of message batches to have in flight at a given time. Increas
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -258,8 +258,7 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message 
-`local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -271,7 +270,7 @@ endif::[]
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -304,7 +303,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/cypher.adoc
+++ b/modules/components/partials/fields/outputs/cypher.adoc
@@ -184,7 +184,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/cypher.adoc
+++ b/modules/components/partials/fields/outputs/cypher.adoc
@@ -290,7 +290,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
+++ b/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
@@ -97,7 +97,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -184,13 +184,22 @@ The routing key to use for the document. This field supports xref:configuration:
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -276,7 +285,7 @@ endif::[]
 
 === `tls.enabled`
 
-Enable custom TLS settings. By default, custom settings are disabled.
+Whether to enable TLS for secure connections. Set to `true` to enable TLS encryption. Required to be `true` for other TLS options (like `client_certs`, `root_cas`, etc.) to take effect.
 
 *Type*: `bool`
 
@@ -284,7 +293,7 @@ Enable custom TLS settings. By default, custom settings are disabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -303,7 +312,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -317,7 +326,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
+++ b/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
@@ -303,7 +303,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
+++ b/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
@@ -190,7 +190,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
+++ b/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
@@ -303,7 +303,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
+++ b/modules/components/partials/fields/outputs/elasticsearch_v8.adoc
@@ -97,7 +97,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 
@@ -184,13 +184,13 @@ The routing key to use for the document. This field supports xref:configuration:
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -284,7 +284,7 @@ Enable custom TLS settings. By default, custom settings are disabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -317,7 +317,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/gcp_bigquery.adoc
+++ b/modules/components/partials/fields/outputs/gcp_bigquery.adoc
@@ -38,7 +38,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 

--- a/modules/components/partials/fields/outputs/gcp_bigquery.adoc
+++ b/modules/components/partials/fields/outputs/gcp_bigquery.adoc
@@ -68,7 +68,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/gcp_cloud_storage.adoc
+++ b/modules/components/partials/fields/outputs/gcp_cloud_storage.adoc
@@ -140,7 +140,7 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/gcp_pubsub.adoc
+++ b/modules/components/partials/fields/outputs/gcp_pubsub.adoc
@@ -109,7 +109,7 @@ Publish a pubsub buffer when it has this many messages
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/http_client.adoc
+++ b/modules/components/partials/fields/outputs/http_client.adoc
@@ -722,7 +722,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/http_client.adoc
+++ b/modules/components/partials/fields/outputs/http_client.adoc
@@ -722,7 +722,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/http_client.adoc
+++ b/modules/components/partials/fields/outputs/http_client.adoc
@@ -609,7 +609,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/http_client.adoc
+++ b/modules/components/partials/fields/outputs/http_client.adoc
@@ -111,7 +111,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -258,7 +258,7 @@ headers:
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 *Type*: `object`
 
@@ -280,7 +280,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -288,7 +288,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -296,7 +296,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -421,7 +421,7 @@ content_type: application/bin
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 *Type*: `object`
 
@@ -435,7 +435,7 @@ The value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -453,7 +453,7 @@ A value used to identify the client to the service provider.
 
 === `oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -603,13 +603,22 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -703,7 +712,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -722,7 +731,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -736,7 +745,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/http_client.adoc
+++ b/modules/components/partials/fields/outputs/http_client.adoc
@@ -81,7 +81,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -111,7 +111,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 
@@ -603,13 +603,13 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -703,7 +703,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -736,7 +736,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/kafka.adoc
+++ b/modules/components/partials/fields/outputs/kafka.adoc
@@ -37,7 +37,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/kafka.adoc
+++ b/modules/components/partials/fields/outputs/kafka.adoc
@@ -245,8 +245,7 @@ inject_tracing_map: root.meta.span = this
 
 === `key`
 
-The key to publish messages with.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/outputs/kafka_franz.adoc
@@ -588,7 +588,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/outputs/kafka_franz.adoc
@@ -65,7 +65,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -133,7 +133,7 @@ Set an explicit compression type (optional). The default preference is to use `s
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -178,7 +178,7 @@ max_message_bytes: 50mib
 
 === `metadata`
 
-Specify which (if any) metadata values are added to messages as headers.
+Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages.
 
 *Type*: `object`
 
@@ -223,7 +223,7 @@ include_prefixes:
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -469,13 +469,22 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -569,7 +578,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -588,7 +597,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -602,7 +611,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/outputs/kafka_franz.adoc
@@ -475,7 +475,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/outputs/kafka_franz.adoc
@@ -65,7 +65,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 
@@ -469,13 +469,13 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -569,7 +569,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -602,7 +602,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/kafka_franz.adoc
+++ b/modules/components/partials/fields/outputs/kafka_franz.adoc
@@ -588,7 +588,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/mongodb.adoc
+++ b/modules/components/partials/fields/outputs/mongodb.adoc
@@ -184,7 +184,7 @@ The MongoDB database operation to perform.
 
 === `password`
 
-The password required to connect to the database.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/mongodb.adoc
+++ b/modules/components/partials/fields/outputs/mongodb.adoc
@@ -65,7 +65,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/mongodb.adoc
+++ b/modules/components/partials/fields/outputs/mongodb.adoc
@@ -65,7 +65,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -184,7 +184,7 @@ The MongoDB database operation to perform.
 
 === `password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/nats.adoc
+++ b/modules/components/partials/fields/outputs/nats.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/nats_jetstream.adoc
+++ b/modules/components/partials/fields/outputs/nats_jetstream.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/nats_kv.adoc
+++ b/modules/components/partials/fields/outputs/nats_kv.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/nats_stream.adoc
+++ b/modules/components/partials/fields/outputs/nats_stream.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/outputs/ockam_kafka.adoc
@@ -349,7 +349,7 @@ Override system defaults with custom TLS settings.
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify either the fields `cert` and `key` or `cert_file` and `key_file`.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/outputs/ockam_kafka.adoc
@@ -463,7 +463,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/outputs/ockam_kafka.adoc
@@ -423,7 +423,8 @@ password: ${KEY_PASSWORD}
 
 === `kafka.tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -462,7 +463,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/outputs/ockam_kafka.adoc
@@ -121,7 +121,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `kafka.batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -343,13 +343,22 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `kafka.tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -444,7 +453,7 @@ Whether custom TLS settings are enabled.
 
 === `kafka.tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -463,7 +472,7 @@ root_cas: |-
 
 === `kafka.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -477,7 +486,7 @@ root_cas_file: ./root_cas.pem
 
 === `kafka.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/ockam_kafka.adoc
+++ b/modules/components/partials/fields/outputs/ockam_kafka.adoc
@@ -343,13 +343,13 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `kafka.tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `kafka.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -476,7 +476,7 @@ root_cas_file: ./root_cas.pem
 
 === `kafka.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/pulsar.adoc
+++ b/modules/components/partials/fields/outputs/pulsar.adoc
@@ -82,8 +82,7 @@ Actual base64 encoded token.
 
 === `key`
 
-The key to publish messages with.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/qdrant.adoc
+++ b/modules/components/partials/fields/outputs/qdrant.adoc
@@ -160,7 +160,7 @@ payload_mapping: root = metadata()
 
 === `tls`
 
-Specify a secure TLS (HTTPS) connection to the Qdrant server.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/qdrant.adoc
+++ b/modules/components/partials/fields/outputs/qdrant.adoc
@@ -160,7 +160,7 @@ payload_mapping: root = metadata()
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/questdb.adoc
+++ b/modules/components/partials/fields/outputs/questdb.adoc
@@ -280,7 +280,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -319,7 +320,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/questdb.adoc
+++ b/modules/components/partials/fields/outputs/questdb.adoc
@@ -320,7 +320,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/questdb.adoc
+++ b/modules/components/partials/fields/outputs/questdb.adoc
@@ -206,7 +206,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/questdb.adoc
+++ b/modules/components/partials/fields/outputs/questdb.adoc
@@ -69,7 +69,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -200,13 +200,22 @@ The timestamp format, which is used when parsing timestamp string fields and use
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -301,7 +310,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -320,7 +329,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -334,7 +343,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/questdb.adoc
+++ b/modules/components/partials/fields/outputs/questdb.adoc
@@ -39,7 +39,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -200,13 +200,13 @@ The timestamp format, which is used when parsing timestamp string fields and use
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -300,7 +300,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -333,7 +333,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda.adoc
+++ b/modules/components/partials/fields/outputs/redpanda.adoc
@@ -43,7 +43,7 @@ Set an explicit compression type (optional). The default preference is to use `s
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -88,7 +88,7 @@ max_message_bytes: 50mib
 
 === `metadata`
 
-Specify which (if any) metadata values are added to messages as headers.
+Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages.
 
 *Type*: `object`
 
@@ -133,7 +133,7 @@ include_prefixes:
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -378,13 +378,22 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -479,7 +488,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -498,7 +507,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -512,7 +521,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda.adoc
+++ b/modules/components/partials/fields/outputs/redpanda.adoc
@@ -378,13 +378,13 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -478,7 +478,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -511,7 +511,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda.adoc
+++ b/modules/components/partials/fields/outputs/redpanda.adoc
@@ -384,7 +384,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/redpanda.adoc
+++ b/modules/components/partials/fields/outputs/redpanda.adoc
@@ -498,7 +498,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda.adoc
+++ b/modules/components/partials/fields/outputs/redpanda.adoc
@@ -458,7 +458,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -497,7 +498,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda_common.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_common.adoc
@@ -57,7 +57,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda_common.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_common.adoc
@@ -57,7 +57,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -108,7 +108,7 @@ The maximum number of messages to have in flight at a given time. Increase this 
 
 === `metadata`
 
-Specify which (if any) metadata values are added to messages as headers.
+Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator.adoc
@@ -43,7 +43,7 @@ Set an explicit compression type (optional). The default preference is to use `s
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -104,7 +104,7 @@ max_message_bytes: 50mib
 
 === `metadata`
 
-Specify which (if any) metadata values are added to messages as headers.
+Configure which metadata values are added to messages as headers. This allows you to pass additional context information along with your messages.
 
 *Type*: `object`
 
@@ -149,7 +149,7 @@ include_prefixes:
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -418,13 +418,22 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -518,7 +527,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -537,7 +546,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -551,7 +560,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator.adoc
@@ -537,7 +537,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator.adoc
@@ -537,7 +537,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator.adoc
@@ -426,7 +426,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator.adoc
@@ -75,9 +75,7 @@ Set this to `true` when using Serverless clusters in Redpanda Cloud.
 
 === `key`
 
-An optional key to populate for each message.
-
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 
@@ -151,7 +149,7 @@ include_prefixes:
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed. Reducing this value increases the frequency with which newly-created topics are identified.
+The maximum period of time after which metadata is refreshed.
 
 *Type*: `string`
 
@@ -420,13 +418,13 @@ timestamp_ms: ${! metadata("kafka_timestamp_ms") }
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -520,7 +518,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -553,7 +551,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
@@ -343,7 +343,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key`, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
@@ -456,7 +456,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
@@ -57,7 +57,7 @@ An identifier for the client connection.
 
 === `conn_idle_timeout`
 
-Define how long connections can remain idle before they are closed.
+The maximum duration that connections can remain idle before they are automatically closed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -96,7 +96,7 @@ The maximum number of retries before giving up on the request. If set to `0`, th
 
 === `metadata_max_age`
 
-The maximum period of time after which metadata is refreshed.
+The maximum period of time after which metadata is refreshed. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 
@@ -337,13 +337,22 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -437,7 +446,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -456,7 +465,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -470,7 +479,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
@@ -337,13 +337,13 @@ The maximum period of time to wait for message sends before abandoning the reque
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -437,7 +437,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -470,7 +470,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/components/partials/fields/outputs/redpanda_migrator_offsets.adoc
@@ -456,7 +456,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/retry.adoc
+++ b/modules/components/partials/fields/outputs/retry.adoc
@@ -10,7 +10,7 @@ Control time intervals between retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/schema_registry.adoc
+++ b/modules/components/partials/fields/outputs/schema_registry.adoc
@@ -319,7 +319,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/schema_registry.adoc
+++ b/modules/components/partials/fields/outputs/schema_registry.adoc
@@ -26,7 +26,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -36,7 +36,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `basic_auth.username`
 
-The username of the account credentials to authenticate as.
+The username of the account credentials to authenticate as. Used together with `password` for basic authentication.
 
 *Type*: `string`
 
@@ -52,7 +52,7 @@ The label of the xref:components:inputs/schema_registry.adoc[`schema_registry` i
 
 === `jwt`
 
-BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from this component to your schema registry.
+BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from this component to your schema registry. This feature is in beta and may change in future releases.
 
 *Type*: `object`
 
@@ -132,7 +132,7 @@ The value this component can use to gain access to the schema registry.
 
 === `oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -150,7 +150,7 @@ The value used to identify this component or client to your schema registry.
 
 === `oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -200,13 +200,22 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -300,7 +309,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -319,7 +328,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/schema_registry.adoc
+++ b/modules/components/partials/fields/outputs/schema_registry.adoc
@@ -200,13 +200,13 @@ This field supports xref:configuration:interpolation.adoc#bloblang-queries[inter
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -300,7 +300,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/schema_registry.adoc
+++ b/modules/components/partials/fields/outputs/schema_registry.adoc
@@ -206,7 +206,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/outputs/schema_registry.adoc
+++ b/modules/components/partials/fields/outputs/schema_registry.adoc
@@ -26,7 +26,7 @@ Whether to use basic authentication in requests.
 
 === `basic_auth.password`
 
-The password of the account credentials to authenticate with.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -319,7 +319,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/sftp.adoc
+++ b/modules/components/partials/fields/outputs/sftp.adoc
@@ -70,7 +70,7 @@ The path to the SFTP server's public key file, used for host key verification.
 
 === `credentials.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/outputs/snowflake_streaming.adoc
+++ b/modules/components/partials/fields/outputs/snowflake_streaming.adoc
@@ -99,7 +99,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period of time after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/snowflake_streaming.adoc
+++ b/modules/components/partials/fields/outputs/snowflake_streaming.adoc
@@ -69,7 +69,7 @@ batching:
 
 === `batching.byte_size`
 
-The amount of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
+The number of bytes at which the batch is flushed. Set to `0` to disable size-based batching.
 
 *Type*: `int`
 
@@ -99,7 +99,7 @@ The number of messages after which the batch is flushed. Set to `0` to disable c
 
 === `batching.period`
 
-The period after which an incomplete batch is flushed regardless of its size.
+The period of time after which an incomplete batch is flushed regardless of its size.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/sql_insert.adoc
+++ b/modules/components/partials/fields/outputs/sql_insert.adoc
@@ -157,7 +157,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/sql_raw.adoc
+++ b/modules/components/partials/fields/outputs/sql_raw.adoc
@@ -141,7 +141,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/outputs/websocket.adoc
+++ b/modules/components/partials/fields/outputs/websocket.adoc
@@ -36,7 +36,7 @@ A username to authenticate as.
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 *Type*: `object`
 
@@ -58,7 +58,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -66,7 +66,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -74,7 +74,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -82,7 +82,7 @@ A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/processors/aws_bedrock_chat.adoc
+++ b/modules/components/partials/fields/processors/aws_bedrock_chat.adoc
@@ -58,7 +58,7 @@ The token for the credentials you want to use. You must enter this value when us
 
 === `endpoint`
 
-Specify a custom endpoint for the AWS API.
+A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/aws_bedrock_embeddings.adoc
+++ b/modules/components/partials/fields/processors/aws_bedrock_embeddings.adoc
@@ -58,7 +58,7 @@ The token for the AWS credentials in use. This is a required value for short-ter
 
 === `endpoint`
 
-Specify a custom endpoint for the AWS API.
+A custom endpoint URL for AWS API requests. Use this to connect to AWS-compatible services or local testing environments instead of the standard AWS endpoints.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/cohere_chat.adoc
+++ b/modules/components/partials/fields/processors/cohere_chat.adoc
@@ -105,7 +105,7 @@ Whether to use basic authentication in requests.
 
 === `schema_registry.basic_auth.password`
 
-The password of the account credentials to authenticate with.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -311,7 +311,8 @@ password: ${KEY_PASSWORD}
 
 === `schema_registry.tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -342,7 +343,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/cohere_chat.adoc
+++ b/modules/components/partials/fields/processors/cohere_chat.adoc
@@ -231,13 +231,13 @@ The subject name to fetch the schema for.
 
 === `schema_registry.tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -311,8 +311,7 @@ password: ${KEY_PASSWORD}
 
 === `schema_registry.tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
-tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -324,7 +323,7 @@ endif::[]
 
 === `schema_registry.tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -357,7 +356,7 @@ root_cas_file: ./root_cas.pem
 
 === `schema_registry.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/cohere_chat.adoc
+++ b/modules/components/partials/fields/processors/cohere_chat.adoc
@@ -237,7 +237,7 @@ Override system defaults with custom TLS settings.
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/processors/cohere_chat.adoc
+++ b/modules/components/partials/fields/processors/cohere_chat.adoc
@@ -105,7 +105,7 @@ Whether to use basic authentication in requests.
 
 === `schema_registry.basic_auth.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -115,7 +115,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `schema_registry.basic_auth.username`
 
-The username of the account credentials to authenticate as.
+The username of the account credentials to authenticate as. Used together with `password` for basic authentication.
 
 *Type*: `string`
 
@@ -123,7 +123,7 @@ The username of the account credentials to authenticate as.
 
 === `schema_registry.jwt`
 
-BETA: Configure JSON Web Token (JWT) authentication for the secure transmission of data from your schema registry to this component.
+BETA: Configure JSON Web Token (JWT) authentication for secure data transmission from your schema registry to this component. This feature is in beta and may change in future releases.
 
 *Type*: `object`
 
@@ -153,7 +153,7 @@ The key/value pairs that identify the type of token and signing algorithm.
 
 === `schema_registry.jwt.private_key_file`
 
-A file in PEM format encoded via PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -161,7 +161,7 @@ A file in PEM format encoded via PKCS1 or PKCS8 as private key.
 
 === `schema_registry.jwt.signing_method`
 
-The method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -183,7 +183,7 @@ The value this component can use to gain access to the data in the schema regist
 
 === `schema_registry.oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -201,7 +201,7 @@ The value used to identify this component or client to your schema registry.
 
 === `schema_registry.oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -211,7 +211,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `schema_registry.oauth.enabled`
 
-Whether to use OAuth version 1 in requests to the schema registry.
+Whether to enable OAuth version 1.0 authentication for requests to the schema registry.
 
 *Type*: `bool`
 
@@ -231,13 +231,22 @@ The subject name to fetch the schema for.
 
 === `schema_registry.tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -324,7 +333,7 @@ endif::[]
 
 === `schema_registry.tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -343,7 +352,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -357,7 +366,7 @@ root_cas_file: ./root_cas.pem
 
 === `schema_registry.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/cohere_chat.adoc
+++ b/modules/components/partials/fields/processors/cohere_chat.adoc
@@ -343,7 +343,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/gcp_bigquery_select.adoc
+++ b/modules/components/partials/fields/processors/gcp_bigquery_select.adoc
@@ -22,7 +22,7 @@ A list of columns to query.
 
 === `credentials_json`
 
-Optional field to set https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google Service Account Credentials JSON^].
+Base64-encoded Google Service Account credentials in JSON format (optional). Use this field to authenticate with Google Cloud services. For more information about creating service account credentials, see https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account[Google's service account documentation^].
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/processors/http.adoc
+++ b/modules/components/partials/fields/processors/http.adoc
@@ -560,7 +560,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/http.adoc
+++ b/modules/components/partials/fields/processors/http.adoc
@@ -441,13 +441,13 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Override system defaults with custom TLS settings.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -541,7 +541,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string, representing a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -574,7 +574,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/http.adoc
+++ b/modules/components/partials/fields/processors/http.adoc
@@ -163,7 +163,7 @@ headers:
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 *Type*: `object`
 
@@ -185,7 +185,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -193,7 +193,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -201,7 +201,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -262,7 +262,7 @@ include_prefixes:
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 *Type*: `object`
 
@@ -276,7 +276,7 @@ The value used to gain access to the protected resources on behalf of the user.
 
 === `oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -312,7 +312,7 @@ Whether to use OAuth version 1 in requests.
 
 === `oauth2`
 
-Allows you to specify open authentication via OAuth version 2 and the client credentials token flow.
+Allows you to specify open authentication using OAuth version 2 and the client credentials token flow.
 
 *Type*: `object`
 
@@ -441,13 +441,22 @@ A static timeout to apply to requests.
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -541,7 +550,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -560,7 +569,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -574,7 +583,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/http.adoc
+++ b/modules/components/partials/fields/processors/http.adoc
@@ -447,7 +447,7 @@ Override system defaults with custom TLS settings.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/processors/http.adoc
+++ b/modules/components/partials/fields/processors/http.adoc
@@ -560,7 +560,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/mongodb.adoc
+++ b/modules/components/partials/fields/processors/mongodb.adoc
@@ -110,7 +110,7 @@ The MongoDB database operation to perform.
 
 === `password`
 
-The password required to connect to the database.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/processors/mongodb.adoc
+++ b/modules/components/partials/fields/processors/mongodb.adoc
@@ -110,7 +110,7 @@ The MongoDB database operation to perform.
 
 === `password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/processors/nats_kv.adoc
+++ b/modules/components/partials/fields/processors/nats_kv.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/processors/nats_request_reply.adoc
+++ b/modules/components/partials/fields/processors/nats_request_reply.adoc
@@ -10,7 +10,7 @@ Optional configuration of NATS authentication parameters.
 
 === `auth.nkey`
 
-Your NKey seed or private key.
+Your NKey seed or private key for NATS authentication. NKeys provide secure, cryptographic authentication without passwords.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -52,7 +52,7 @@ user_credentials_file: ./user.creds
 
 === `auth.user_jwt`
 
-An optional plain text user JWT to use along with the corresponding user NKey seed.
+An optional plaintext user JWT to use along with the corresponding user NKey seed.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -60,7 +60,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `auth.user_nkey_seed`
 
-An optional plain text user NKey seed to use along with the corresponding user JWT.
+An optional plaintext user NKey seed to use along with the corresponding user JWT.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 

--- a/modules/components/partials/fields/processors/openai_chat_completion.adoc
+++ b/modules/components/partials/fields/processors/openai_chat_completion.adoc
@@ -134,7 +134,7 @@ Whether to use basic authentication in requests.
 
 === `schema_registry.basic_auth.password`
 
-The password for the username used to authenticate with the SFTP server.
+The password to use for authentication. Used together with `username` for basic authentication or with encrypted private keys for secure access.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -144,7 +144,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `schema_registry.basic_auth.username`
 
-The username of the account credentials to authenticate as.
+The username of the account credentials to authenticate as. Used together with `password` for basic authentication.
 
 *Type*: `string`
 
@@ -182,7 +182,7 @@ The key/value pairs that identify the type of token and signing algorithm (optio
 
 === `schema_registry.jwt.private_key_file`
 
-A file in PEM format, encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -190,7 +190,7 @@ A file in PEM format, encoded using PKCS1 or PKCS8 as private key.
 
 === `schema_registry.jwt.signing_method`
 
-The method used to sign the token, such as RS256, RS384, RS512, or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -220,7 +220,7 @@ The value this component can use to gain access to the data in the schema regist
 
 === `schema_registry.oauth.access_token_secret`
 
-The secret that establishes ownership of the `oauth.access_token`.
+The secret that establishes ownership of the `oauth.access_token` in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -238,7 +238,7 @@ The value used to identify this component or client to your schema registry.
 
 === `schema_registry.oauth.consumer_secret`
 
-The secret used to establish ownership of the consumer key.
+The secret that establishes ownership of the consumer key in OAuth 1.0 authentication.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -248,7 +248,7 @@ include::redpanda-connect:components:partial$secret_warning.adoc[]
 
 === `schema_registry.oauth.enabled`
 
-Whether to use OAuth version 1 in requests to the schema registry.
+Whether to enable OAuth version 1.0 authentication for requests to the schema registry.
 
 *Type*: `bool`
 
@@ -268,13 +268,22 @@ The subject name used to fetch the schema from the schema registry.
 
 === `schema_registry.tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -361,7 +370,7 @@ endif::[]
 
 === `schema_registry.tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -380,7 +389,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -394,7 +403,7 @@ root_cas_file: ./root_cas.pem
 
 === `schema_registry.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/openai_chat_completion.adoc
+++ b/modules/components/partials/fields/processors/openai_chat_completion.adoc
@@ -134,7 +134,7 @@ Whether to use basic authentication in requests.
 
 === `schema_registry.basic_auth.password`
 
-The password of the account credentials to authenticate with.
+The password for the username used to authenticate with the SFTP server.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -380,7 +380,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/openai_chat_completion.adoc
+++ b/modules/components/partials/fields/processors/openai_chat_completion.adoc
@@ -274,7 +274,7 @@ Specify custom TLS settings to override system defaults.
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -361,7 +361,7 @@ endif::[]
 
 === `schema_registry.tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -394,7 +394,7 @@ root_cas_file: ./root_cas.pem
 
 === `schema_registry.tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/openai_chat_completion.adoc
+++ b/modules/components/partials/fields/processors/openai_chat_completion.adoc
@@ -268,7 +268,7 @@ The subject name used to fetch the schema from the schema registry.
 
 === `schema_registry.tls`
 
-Specify custom TLS settings to override system defaults.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
@@ -380,7 +380,7 @@ root_cas: |-
 
 === `schema_registry.tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, that contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/openai_chat_completion.adoc
+++ b/modules/components/partials/fields/processors/openai_chat_completion.adoc
@@ -274,7 +274,7 @@ Specify custom TLS settings to override system defaults.
 
 === `schema_registry.tls.client_certs[]`
 
-A list of client certificates to use. For each certificate, specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/processors/qdrant.adoc
+++ b/modules/components/partials/fields/processors/qdrant.adoc
@@ -216,7 +216,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/qdrant.adoc
+++ b/modules/components/partials/fields/processors/qdrant.adoc
@@ -96,7 +96,7 @@ Whether to include or exclude the fields specified in `payload_fields` from the 
 
 === `tls`
 
-Specify a secure TLS (HTTPS) connection to the Qdrant server.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
 
 *Type*: `object`
 
@@ -176,7 +176,8 @@ password: ${KEY_PASSWORD}
 
 === `tls.enable_renegotiation`
 
-Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: tls: no renegotiation`.
+Whether to allow the remote server to request renegotiation. Enable this option if you're seeing the error message `local error: 
+tls: no renegotiation`.
 
 ifndef::env-cloud[]
 Requires version 3.45.0 or later.
@@ -215,7 +216,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.certificate.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/qdrant.adoc
+++ b/modules/components/partials/fields/processors/qdrant.adoc
@@ -102,7 +102,7 @@ Specify a secure TLS (HTTPS) connection to the Qdrant server.
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
 
 *Type*: `object`
 
@@ -196,7 +196,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -229,7 +229,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/qdrant.adoc
+++ b/modules/components/partials/fields/processors/qdrant.adoc
@@ -96,13 +96,22 @@ Whether to include or exclude the fields specified in `payload_fields` from the 
 
 === `tls`
 
-Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates.
+Configure Transport Layer Security (TLS) settings to secure network connections. This includes options for standard TLS as well as mutual TLS (mTLS) authentication where both client and server authenticate each other using certificates. Key configuration options include `enabled` to enable TLS, `client_certs` for mTLS authentication, `root_cas`/`root_cas_file` for custom certificate authorities, and `skip_cert_verify` for development environments.
 
 *Type*: `object`
 
 === `tls.client_certs[]`
 
-A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. Each certificate entry should specify either `cert` and `key` fields for inline certificates, or `cert_file` and `key_file` fields for certificate files stored on disk.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS, authenticating the client to the server with these certificates.
+
+You must set `tls.enabled: true` for the client certificates to take effect.
+
+**Certificate pairing rules**: For each certificate item, provide either:
+
+- Inline PEM data using both `cert` *and* `key` or
+- File paths using both `cert_file` *and* `key_file`.
+
+Mixing inline and file-based values within the same item is not supported.
 
 *Type*: `object`
 
@@ -197,7 +206,7 @@ Whether custom TLS settings are enabled.
 
 === `tls.root_cas`
 
-Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify a root certificate authority to use (optional). This is a string that represents a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for inline certificate data or `root_cas_file` for file-based certificate loading.
 
 include::redpanda-connect:components:partial$secret_warning.adoc[]
 
@@ -216,7 +225,7 @@ root_cas: |-
 
 === `tls.root_cas_file`
 
-Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate.
+Specify the path to a root certificate authority file (optional). This is a file, often with a `.pem` extension, which contains a certificate chain from the parent-trusted root certificate, through possible intermediate signing certificates, to the host certificate. Use either this field for file-based certificate loading or `root_cas` for inline certificate data.
 
 *Type*: `string`
 
@@ -230,7 +239,7 @@ root_cas_file: ./root_cas.pem
 
 === `tls.skip_cert_verify`
 
-Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production.
+Whether to skip server-side certificate verification. Set to `true` only for testing environments as this reduces security by disabling certificate validation. When using self-signed certificates or in development, this may be necessary, but should never be used in production. Consider using `root_cas` or `root_cas_file` to specify trusted certificates instead of disabling verification entirely.
 
 *Type*: `bool`
 

--- a/modules/components/partials/fields/processors/qdrant.adoc
+++ b/modules/components/partials/fields/processors/qdrant.adoc
@@ -102,7 +102,7 @@ Specify a secure TLS (HTTPS) connection to the Qdrant server.
 
 === `tls.client_certs[]`
 
-A list of client certificates to use. For each certificate specify values for either the `cert` and `key` fields, or `cert_file` and `key_file` fields.
+A list of client certificates for mutual TLS (mTLS) authentication. Configure this field to enable mTLS and authenticate the client to the server using certificates. For each certificate, specify values for either the `cert` and `key` fields, or the `cert_file` and `key_file` fields.
 
 *Type*: `object`
 

--- a/modules/components/partials/fields/processors/redpanda_data_transform.adoc
+++ b/modules/components/partials/fields/processors/redpanda_data_transform.adoc
@@ -49,8 +49,7 @@ include_prefixes:
 
 === `input_key`
 
-An optional key to populate for each message.
-This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
+An optional key to populate for each message. This field supports xref:configuration:interpolation.adoc#bloblang-queries[interpolation functions].
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/retry.adoc
+++ b/modules/components/partials/fields/processors/retry.adoc
@@ -10,7 +10,7 @@ Determine time intervals and cut offs for retry attempts.
 
 === `backoff.initial_interval`
 
-The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value.
+The initial period to wait between retry attempts. The retry interval increases for each failed attempt, up to the `backoff.max_interval` value. This field accepts Go duration format strings such as `100ms`, `1s`, or `5s`.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/schema_registry_decode.adoc
+++ b/modules/components/partials/fields/processors/schema_registry_decode.adoc
@@ -180,7 +180,7 @@ cache_duration: 5m
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 ifndef::env-cloud[]
 Requires version 4.7.0 or later.
@@ -206,7 +206,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -214,7 +214,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -222,7 +222,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -230,7 +230,7 @@ A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 ifndef::env-cloud[]
 Requires version 4.7.0 or later.

--- a/modules/components/partials/fields/processors/schema_registry_encode.adoc
+++ b/modules/components/partials/fields/processors/schema_registry_encode.adoc
@@ -70,7 +70,7 @@ A username to authenticate as.
 
 === `jwt`
 
-BETA: Allows you to specify JSON Web Token (JWT) authentication.
+BETA: Configure JSON Web Token (JWT) authentication. This feature is in beta and may change in future releases. JWT tokens provide secure, stateless authentication between services.
 
 ifndef::env-cloud[]
 Requires version 4.7.0 or later.
@@ -96,7 +96,7 @@ Whether to use JWT authentication in requests.
 
 === `jwt.headers`
 
-Add key/value headers to the JWT (optional).
+Additional key-value pairs to include in the JWT header (optional). These headers provide extra metadata for JWT processing.
 
 *Type*: `object`
 
@@ -104,7 +104,7 @@ Add key/value headers to the JWT (optional).
 
 === `jwt.private_key_file`
 
-A file with the PEM encoded using PKCS1 or PKCS8 as private key.
+Path to a file containing the PEM-encoded private key using PKCS#1 or PKCS#8 format. The private key must be compatible with the algorithm specified in the `signing_method` field.
 
 *Type*: `string`
 
@@ -112,7 +112,7 @@ A file with the PEM encoded using PKCS1 or PKCS8 as private key.
 
 === `jwt.signing_method`
 
-A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
+The cryptographic algorithm used to sign the JWT token. Supported algorithms include RS256, RS384, RS512, and EdDSA. This algorithm must be compatible with the private key specified in the `private_key_file` field.
 
 *Type*: `string`
 
@@ -120,7 +120,7 @@ A method used to sign the token, such as RS256, RS384, RS512 or EdDSA.
 
 === `oauth`
 
-Allows you to specify open authentication using OAuth version 1.
+Configure OAuth version 1.0 authentication for secure API access.
 
 ifndef::env-cloud[]
 Requires version 4.7.0 or later.

--- a/modules/components/partials/fields/processors/sql_insert.adoc
+++ b/modules/components/partials/fields/processors/sql_insert.adoc
@@ -67,7 +67,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/sql_raw.adoc
+++ b/modules/components/partials/fields/processors/sql_raw.adoc
@@ -51,7 +51,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 

--- a/modules/components/partials/fields/processors/sql_select.adoc
+++ b/modules/components/partials/fields/processors/sql_select.adoc
@@ -69,7 +69,7 @@ A database <<drivers, driver>> to use.
 
 === `dsn`
 
-A Data Source Name to identify the target database.
+The Data Source Name (DSN) connection string that identifies the target database. The DSN format varies by database type and typically includes connection details like host, port, database name, and authentication parameters.
 
 *Type*: `string`
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1557

This pull request updates documentation for TLS and mutual TLS (mTLS) configuration across several input and cache modules. The changes clarify the purpose and usage of TLS-related fields, provide better guidance for secure configuration, and improve consistency in field descriptions. The most important changes are grouped below by theme.

**TLS and mTLS Documentation Improvements:**

* Updated descriptions for the `tls` and `tls.client_certs[]` fields across multiple modules (including `redpanda`, `amqp_0_9`, `http_client`, `kafka_franz`, `ockam_kafka`, and `redpanda_migrator`) to clarify that these settings support both standard TLS and mTLS, and to provide explicit instructions for configuring client certificates for mTLS authentication. [[1]](diffhunk://#diff-fb135bcba137801ab50bd7aad6a5dd9c69379982d5ab137226ff1bbf632daa3eL222-R222) [[2]](diffhunk://#diff-f5ca4c7844f05d67c60946a08b4a5f07dd042d0322289f063df0ca94bc2745f0L193-R199) [[3]](diffhunk://#diff-5e4f9e4279b3fd87ced890e33cafc910c46a6053cdafef4127cfaeeb7da340f4L488-R494) [[4]](diffhunk://#diff-3af077e5e47b51670390139d5066c41b5adc5a6c5bacdfc6829578de7ffb182fL459-R465) [[5]](diffhunk://#diff-385da2d190e0246c2060ad82ed4ef4035da59eb4e6422d6b31d61a7786892bd7L326-R332) [[6]](diffhunk://#diff-095764454a330f1e643111df0ef3dd5be8156e9aec23c7cce90f34b97d1de227L372-R378) [[7]](diffhunk://#diff-e706e5e36d90686669a8c581d91e99251d215c488e31cf6360464347f3003776L367-R373)

* Improved field descriptions for client certificate keys and key files, specifying their use as inline PEM data or file paths and emphasizing the need for correspondence between certificate and key fields. [[1]](diffhunk://#diff-fb135bcba137801ab50bd7aad6a5dd9c69379982d5ab137226ff1bbf632daa3eL258-R258) [[2]](diffhunk://#diff-fb135bcba137801ab50bd7aad6a5dd9c69379982d5ab137226ff1bbf632daa3eL268-R276)

**Security and Best Practices Guidance:**

* Enhanced the description for the `skip_cert_verify` field in all relevant modules to warn that disabling certificate verification should only be used in testing or development, as it reduces security and should not be used in production. [[1]](diffhunk://#diff-fb135bcba137801ab50bd7aad6a5dd9c69379982d5ab137226ff1bbf632daa3eL348-R346) [[2]](diffhunk://#diff-f5ca4c7844f05d67c60946a08b4a5f07dd042d0322289f063df0ca94bc2745f0L326-R326) [[3]](diffhunk://#diff-5e4f9e4279b3fd87ced890e33cafc910c46a6053cdafef4127cfaeeb7da340f4L621-R621) [[4]](diffhunk://#diff-3af077e5e47b51670390139d5066c41b5adc5a6c5bacdfc6829578de7ffb182fL592-R592) [[5]](diffhunk://#diff-385da2d190e0246c2060ad82ed4ef4035da59eb4e6422d6b31d61a7786892bd7L459-R459) [[6]](diffhunk://#diff-095764454a330f1e643111df0ef3dd5be8156e9aec23c7cce90f34b97d1de227L505-R505) [[7]](diffhunk://#diff-e706e5e36d90686669a8c581d91e99251d215c488e31cf6360464347f3003776L500-R500)

* Updated the `password` field documentation for encrypted private keys to mention support for environment variable interpolation and to provide clearer guidance on secure password management.

**Root Certificate Authority Field Clarifications:**

* Clarified the purpose and format for the `root_cas` and `root_cas_file` fields, specifying that they should contain or point to certificate chains in PEM format for verifying server certificates in both TLS and mTLS scenarios. [[1]](diffhunk://#diff-f5ca4c7844f05d67c60946a08b4a5f07dd042d0322289f063df0ca94bc2745f0L293-R293) [[2]](diffhunk://#diff-f5ca4c7844f05d67c60946a08b4a5f07dd042d0322289f063df0ca94bc2745f0L312-R312) [[3]](diffhunk://#diff-5e4f9e4279b3fd87ced890e33cafc910c46a6053cdafef4127cfaeeb7da340f4L588-R588) [[4]](diffhunk://#diff-3af077e5e47b51670390139d5066c41b5adc5a6c5bacdfc6829578de7ffb182fL559-R559) [[5]](diffhunk://#diff-095764454a330f1e643111df0ef3dd5be8156e9aec23c7cce90f34b97d1de227L472-R472) [[6]](diffhunk://#diff-095764454a330f1e643111df0ef3dd5be8156e9aec23c7cce90f34b97d1de227L491-R491) [[7]](diffhunk://#diff-e706e5e36d90686669a8c581d91e99251d215c488e31cf6360464347f3003776L467-R467)

**Minor and Editorial Updates:**

* Improved wording and consistency in field descriptions, such as clarifying the meaning of batching periods and metadata refresh intervals. [[1]](diffhunk://#diff-3af077e5e47b51670390139d5066c41b5adc5a6c5bacdfc6829578de7ffb182fL69-R69) [[2]](diffhunk://#diff-e706e5e36d90686669a8c581d91e99251d215c488e31cf6360464347f3003776L115-R115)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)