### PR TITLE
DOC-1543 Redpanda Migrator does not support serverless

### DIFF
--- a/modules/cookbooks/pages/redpanda_migrator.adoc
+++ b/modules/cookbooks/pages/redpanda_migrator.adoc
@@ -23,6 +23,10 @@ For convenience, these components are bundled together into the following:
 
 This cookbook shows how to use the bundled components.
 
+== Limitations
+
+The Redpanda Migrator cannot migrate schemas between multi-tenant clusters.
+
 ifndef::env-cloud[]
 
 == Create the Docker containers
@@ -626,8 +630,6 @@ rpk connect run read_data_destination.yaml
 ----
 
 It's worth clarifying that the `source` cluster consumer uses the same `foobar` consumer group. As you can see, this consumer resumes reading messages from where the `source` consumer left off.
-
-And you're all done!
 
 Due to the mechanics of the Kafka protocol, Redpanda Migrator needs to perform offset remapping when migrating consumer group offsets to the `destination` cluster. While more sophisticated approaches are possible, Redpanda chose to use a simple timestamp-based approach. So, for each migrated offset, the `destination` cluster is queried to find the latest offset before the received offset timestamp. Redpanda Migrator then writes this offset as the `destination` consumer group offset for the corresponding topic and partition pair.
 

--- a/modules/cookbooks/pages/redpanda_migrator.adoc
+++ b/modules/cookbooks/pages/redpanda_migrator.adoc
@@ -25,8 +25,7 @@ This cookbook shows how to use the bundled components.
 
 == Limitations
 
-The Redpanda Migrator cannot migrate schemas between multi-tenant clusters.
-
+The Redpanda Migrator does not support migrations to or from Redpanda Cloud serverless (multi-tenant) clusters.
 ifndef::env-cloud[]
 
 == Create the Docker containers


### PR DESCRIPTION
## Description
This pull request updates the `redpanda_migrator.adoc` documentation to add a new "Limitations" section specifying that Redpanda Migrator cannot migrate schemas between multi-tenant clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1543
Review deadline:

## Page previews
[Redpanda Migrator](https://deploy-preview-289--redpanda-connect.netlify.app/redpanda-connect/cookbooks/redpanda_migrator/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)