### PR TITLE
Update to Bump API doc URLs

### DIFF
--- a/modules/components/partials/components/inputs/gateway.adoc
+++ b/modules/components/partials/components/inputs/gateway.adoc
@@ -23,7 +23,7 @@ This component is fully managed and available in the following Redpanda Cloud de
 
 When a pipeline with a `gateway` input is deployed, Redpanda Cloud provisions a secure URL that you can use to send HTTP requests. You can post raw payloads, JSON messages, or stream events in real time.
 
-Authentication and access control are handled through standard Redpanda Cloud API tokens. For more information, see xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[].
+Authentication and access control are handled through standard Redpanda Cloud API tokens. For more information, see link:/api/doc/cloud-dataplane/authentication[Cloud API Authentication].
 
 Network access:
 

--- a/modules/guides/partials/cloud/gateway.adoc
+++ b/modules/guides/partials/cloud/gateway.adoc
@@ -192,4 +192,4 @@ You can see any errors that occur during processing.
 
 - xref:components:inputs/gateway.adoc[`gateway` input reference]
 - xref:configuration:interpolation.adoc[Bloblang functions]
-- xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[Redpanda Cloud API authentication]
+- link:/api/doc/cloud-dataplane/authentication[Redpanda Cloud API authentication]


### PR DESCRIPTION
## Description

This pull request updates references to the Redpanda Cloud API authentication documentation to use direct links instead of xref syntax. This change improves documentation clarity and ensures users are directed to the correct resource.

Documentation updates:

* Updated the authentication and access control reference in `gateway.adoc` to use a direct link to the Cloud API Authentication documentation instead of an xref.
* Changed the Redpanda Cloud API authentication reference in the guides partial to a direct link for consistency and accuracy.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)