### PR TITLE
Fix templating docs

### DIFF
--- a/modules/configuration/pages/templating.adoc
+++ b/modules/configuration/pages/templating.adoc
@@ -281,7 +281,7 @@ fields:
     type: string_annotated_enum
     options:
       at_least_once: "May duplicate messages but never loses them."
-      exactly_once: "Stronger guarantees; higher cost and constraints."
+      exactly_once: "Stronger guarantees but with a higher cost and constraints."
 ```
 
 


### PR DESCRIPTION
## Description

Add extra `options` field required when setting `type` to `string_enum` or `string_annotated_enum`.

This is a follow-up to #278.

Fixes https://github.com/redpanda-data/connect/issues/3588.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)