### PR TITLE
Add info on configuring the env variable for license using Helm

### DIFF
--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -60,14 +60,14 @@ Replace the following placeholders:
 Helm (Kubernetes)::
 +
 --
-If you are deploying Redpanda Connect on Kubernetes using Helm, create a Kubernetes Secret with your license key and reference it in your Helm values:
+To enable enterprise features, you must provide a license key as a Kubernetes Secret and reference it in your deployment configuration.
 
 . Create the Secret:
 +
 [source,bash]
 ----
 kubectl create secret generic redpanda-connect-license \
-  --from-literal=license=<your-license-key> \
+  --from-literal=REDPANDA_LICENSE=<your-license-key> \
   --namespace <namespace>
 ----
 
@@ -80,7 +80,8 @@ envFrom:
       name: redpanda-connect-license
 ----
 
-This configuration mounts the license key as an environment variable, allowing Redpanda Connect to use enterprise features.
+This configuration mounts the license key as the `REDPANDA_LICENSE` environment variable, allowing Redpanda Connect to use enterprise features.
+
 --
 ======
 
@@ -94,3 +95,8 @@ You can view the license key’s expiration date at any time in the Redpanda Con
 INFO Running main config from specified file       @service=benthos benthos_version=4.50.0 path=connect_2.yaml
 INFO Successfully loaded Redpanda license          @service=benthos expires_at="2025-04-18T15:41:56+01:00" license_org=67XXX license_type="enterprise"
 ```
+
+== Next steps
+
+- xref:get-started:quickstarts/index.adoc[Get started with Redpanda Connect].
+- xref:components:about.adoc[Explore enterprise connectors] to enhance your data pipelines.

--- a/modules/get-started/pages/licensing.adoc
+++ b/modules/get-started/pages/licensing.adoc
@@ -27,32 +27,62 @@ You need a valid Enterprise Edition license to use the following enterprise feat
 
 You can either https://www.redpanda.com/upgrade[upgrade to an Enterprise Edition license^], or http://redpanda.com/try-enterprise[generate a trial license key^] that's valid for 30 days.
 
+
 == Apply a license key to Redpanda Connect
 
-When you have downloaded the license key, you can apply it in the following ways: 
+When you have downloaded the license key, you can apply it using either the CLI (`rpk`) or Helm on Kubernetes.
 
-=== Apply the license using a license file
-
+[tabs]
+======
+rpk (local or VM)::
++
+--
 If you have a license key file, either:
 
-- Save the license key to the following directory: `/etc/redpanda/redpanda.license`. 
+- Save the license key to `/etc/redpanda/redpanda.license`.
 - Set the environment variable `REDPANDA_LICENSE_FILEPATH` to point to the file where the license key is stored.
 
-=== Apply the license using a license string
-
-If you do not have a license key file, either:
+If you have a license string, either:
 
 - Set the environment variable `REDPANDA_LICENSE` to the value of the full license string.
-- Run the following command using the full license string.
-+
+- Run the following command using the full license string:
+
 ```bash
 rpk connect run --redpanda-license <license-string> ./<connect-configuration>.yaml
 ```
-+
-Replace the following placeholders: 
+
+Replace the following placeholders:
 
   ** `<license-string>`: The full license key string.
   ** `<connect-configuration>`: The name of your Redpanda Connect configuration file.
+--
+
+Helm (Kubernetes)::
++
+--
+If you are deploying Redpanda Connect on Kubernetes using Helm, create a Kubernetes Secret with your license key and reference it in your Helm values:
+
+. Create the Secret:
++
+[source,bash]
+----
+kubectl create secret generic redpanda-connect-license \
+  --from-literal=license=<your-license-key> \
+  --namespace <namespace>
+----
+
+. Reference the license secret in your `values.yaml` or as a Helm value:
++
+[source,yaml]
+----
+envFrom:
+  - secretRef:
+      name: redpanda-connect-license
+----
+
+This configuration mounts the license key as an environment variable, allowing Redpanda Connect to use enterprise features.
+--
+======
 
 == Verify a license
 

--- a/modules/get-started/pages/quickstarts/helm-chart.adoc
+++ b/modules/get-started/pages/quickstarts/helm-chart.adoc
@@ -25,13 +25,37 @@ Common use cases for Redpanda Connect include:
 
 To deploy Redpanda Connect on Kubernetes, use the official Helm chart.
 
+You can optionally provide an enterprise license to enable enterprise connectors. If you have a license, follow these steps before installing:
+
+. Optional: Create a Kubernetes Secret with your license key:
++
+[source,bash]
+----
+kubectl create secret generic redpanda-connect-license \
+  --from-literal=license=<license-key> \
+  --namespace <namespace>
+----
+
+. Optional: Reference the license Secret in your `values.yaml` or as a Helm value:
++
+[source,yaml]
+----
+envFrom:
+  - secretRef:
+      name: redpanda-connect-license
+----
++
+This configuration mounts the license key as an environment variable, allowing Redpanda Connect to run enterprise connectors.
+
+. Install the chart:
++
 [source,bash]
 ----
 helm repo add redpanda https://charts.redpanda.com <1>
 helm repo update <2>
 helm install redpanda-connect redpanda/connect --namespace <namespace> --create-namespace <3>
 ----
-
++
 <1> Adds the Redpanda Helm repository.
 <2> Updates your local Helm repository cache.
 <3> Installs Redpanda Connect in the given namespace. You can customize this deployment by configuring values in the Helm chart.

--- a/modules/get-started/pages/quickstarts/helm-chart.adoc
+++ b/modules/get-started/pages/quickstarts/helm-chart.adoc
@@ -21,41 +21,21 @@ Common use cases for Redpanda Connect include:
 * A running Kubernetes cluster.
 * The https://kubernetes.io/docs/tasks/tools/[`kubectl` CLI] and the https://helm.sh/docs/intro/install/[`helm` CLI] installed.
 
+You can optionally provide an enterprise license to enable enterprise connectors. If you have a license, see xref:get-started:licensing.adoc[Apply a license key to Redpanda Connect] before installing.
+
 == Install with Helm
 
 To deploy Redpanda Connect on Kubernetes, use the official Helm chart.
 
-You can optionally provide an enterprise license to enable enterprise connectors. If you have a license, follow these steps before installing:
+To install the chart:
 
-. Optional: Create a Kubernetes Secret with your license key:
-+
-[source,bash]
-----
-kubectl create secret generic redpanda-connect-license \
-  --from-literal=license=<license-key> \
-  --namespace <namespace>
-----
-
-. Optional: Reference the license Secret in your `values.yaml` or as a Helm value:
-+
-[source,yaml]
-----
-envFrom:
-  - secretRef:
-      name: redpanda-connect-license
-----
-+
-This configuration mounts the license key as an environment variable, allowing Redpanda Connect to run enterprise connectors.
-
-. Install the chart:
-+
 [source,bash]
 ----
 helm repo add redpanda https://charts.redpanda.com <1>
 helm repo update <2>
 helm install redpanda-connect redpanda/connect --namespace <namespace> --create-namespace <3>
 ----
-+
+
 <1> Adds the Redpanda Helm repository.
 <2> Updates your local Helm repository cache.
 <3> Installs Redpanda Connect in the given namespace. You can customize this deployment by configuring values in the Helm chart.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-819

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)