### PR TITLE
Fix templating docs

### DIFF
--- a/modules/configuration/pages/templating.adoc
+++ b/modules/configuration/pages/templating.adoc
@@ -289,14 +289,12 @@ fields:
 
 A xref:guides:bloblang/about.adoc[Bloblang] mapping that translates the fields of the template into a valid Redpanda Connect configuration for the target component type.
 
-TIP: You can also add the metadata field `@label` within a template mapping to retrieve the `label` set in the corresponding configuration.
-
 
 === `metrics_mapping`
 
 An optional xref:guides:bloblang/about.adoc[Bloblang mapping] that allows you to rename or prevent certain metrics paths from being exported. For more information check out the xref:components:metrics/about.adoc#metric-mapping[metrics documentation]. When metric paths are created, renamed and dropped a trace log is written, enabling TRACE level logging is therefore a good way to diagnose path mappings.
 
-Invocations of this mapping are able to reference a variable `$label` in order to obtain the value of the label provided to the template configuration. This allows you to match labels with the root of the configuration.
+Invocations of this mapping are able to reference a metadata field `@label` in order to obtain the value of the label provided to the template configuration. This allows you to match labels with the root of the configuration.
 
 
 *Type*: `string`


### PR DESCRIPTION
## Description

I noticed some duplication here and also the second reference incorrectly says `$label` variable instead of `@label` metadata field. I must’ve missed this when we added it earlier this year.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)