### PR TITLE
Fix MCP quickstart

### DIFF
--- a/modules/ai-agents/pages/mcp-server/quickstart.adoc
+++ b/modules/ai-agents/pages/mcp-server/quickstart.adoc
@@ -77,7 +77,7 @@ try: <2>
       meta query_string = "q=" + root.query.escape_url_query() + "&limit=%v".format(root.limit)
       root = ""
   - http:
-      url: "https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts?${! @query_string }"
+      url: "https://api.bsky.app/xrpc/app.bsky.feed.searchposts?${! @query_string }"
       verb: GET
   - mapping: 'root = this.posts'
   - unarchive:


### PR DESCRIPTION
## Description

I get 403 authentication errors coming back with the `public` subdomain but not without it. This PR fixes the quickstart to avoid these 403 errors.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)