### PR TITLE
Fix duplicate nav tree entry for Elasticsearch

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -246,7 +246,6 @@
 *** xref:components:outputs/drop.adoc[]
 *** xref:components:outputs/drop_on.adoc[]
 *** xref:components:outputs/dynamic.adoc[]
-*** xref:components:outputs/elasticsearch.adoc[]
 *** xref:components:outputs/elasticsearch_v8.adoc[]
 *** xref:components:outputs/fallback.adoc[]
 *** xref:components:outputs/file.adoc[]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)