### PR TITLE
Remove panda from homepage

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -17,7 +17,7 @@ asciidoc:
       Redpanda Connect is a data streaming service for building scalable, high-performance data pipelines that drive
       real-time analytics and actionable business insights. Integrate data across systems with hundreds of prebuilt
       connectors, change data capture (CDC) capabilities, and YAML-configurable pipelines.
-    page-home-image: connect.svg
+    #page-home-image: connect.svg
     page-home-intro-learn-more: get-started:about.adoc
     page-home-primary-row-title: Deploy
     page-home-primary-row:


### PR DESCRIPTION
Part of https://github.com/redpanda-data/docs-ui/pull/341

## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1722

This pull request comments out the `page-home-image` property under the asciidoc: section, which previously referenced `panda.png`. This will remove the homepage image.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)