### PR TITLE
Improve Redpanda tracer docs

### DIFF
--- a/modules/components/pages/tracers/redpanda.adoc
+++ b/modules/components/pages/tracers/redpanda.adoc
@@ -3,103 +3,32 @@
 :type: tracer
 :status: experimental
 :categories: []
-:description: Send tracing events to a Redpanda Message Broker.
+:description: Send tracing events to a Redpanda topic.
 
 component_type_dropdown::[]
 
-Send tracing events to a Redpanda Message Broker.
-
+Export distributed tracing data to a Redpanda topic, enabling you to monitor and debug your Redpanda Connect pipelines. Traces are exported in OpenTelemetry format as JSON, allowing integration with observability platforms like Jaeger, Grafana Tempo, or custom trace consumers.
 [tabs]
 ======
 Common::
 +
 --
-```yaml
-tracer:
-  label: ""
-  redpanda:
-    seed_brokers: [] # No default (required)
-    topic: otel-traces
-    service: redpanda-connect
-    sampling:
-      enabled: false
-      ratio: "" # No default (optional)
+
+```yml
+include::components:example$common/tracers/redpanda.yaml[]
 ```
+
 --
 Advanced::
 +
 --
-```yaml
-tracer:
-  label: ""
-  redpanda:
-    seed_brokers: [] # No default (required)
-    client_id: redpanda-connect
-    tls:
-      enabled: false
-      skip_cert_verify: false
-      enable_renegotiation: false
-      root_cas: ""
-      root_cas_file: ""
-      client_certs:
-        cert: ""
-        key: ""
-        cert_file: ""
-        key_file: ""
-        password: ""
-    sasl:
-      mechanism: "" # No default (required)
-      username: ""
-      password: ""
-      token: ""
-      extensions: "" # No default (optional)
-      aws:
-        region: "" # No default (optional)
-        endpoint: "" # No default (optional)
-        tcp:
-          connect_timeout: 0s
-          keep_alive:
-            idle: 15s
-            interval: 15s
-            count: 9
-          tcp_user_timeout: 0s
-        credentials:
-          profile: "" # No default (optional)
-          id: "" # No default (optional)
-          secret: "" # No default (optional)
-          token: "" # No default (optional)
-          from_ec2_role: "" # No default (optional)
-          role: "" # No default (optional)
-          role_external_id: "" # No default (optional)
-    metadata_max_age: 1m
-    request_timeout_overhead: 10s
-    conn_idle_timeout: 20s
-    tcp:
-      connect_timeout: 0s
-      keep_alive:
-        idle: 15s
-        interval: 15s
-        count: 9
-      tcp_user_timeout: 0s
-    partitioner: "" # No default (optional)
-    idempotent_write: true
-    compression: "" # No default (optional)
-    allow_auto_topic_creation: true
-    timeout: 10s
-    max_message_bytes: 1MiB
-    broker_write_max_bytes: 100MiB
-    topic: otel-traces
-    format: json
-    service: redpanda-connect
-    tags: {}
-    sampling:
-      enabled: false
-      ratio: "" # No default (optional)
+
+```yml
+include::components:example$advanced/tracers/redpanda.yaml[]
 ```
+
 --
 ======
-
-The Redpanda tracer exports distributed tracing data to a Redpanda topic, enabling you to monitor and debug your Redpanda Connect pipelines. Traces are exported in OpenTelemetry format as JSON, allowing integration with observability platforms like Jaeger, Grafana Tempo, or custom trace consumers.
 
 This tracer automatically captures trace spans as messages flow through your pipeline, recording timing information, component metadata, and error details. Use this to:
 


### PR DESCRIPTION

## Description

Uses single-sourcing to include the examples from partials


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)