### PR TITLE
Correct outdated performance tuning guidance in redpanda_migrator input and output documentation

### DIFF
--- a/modules/components/pages/inputs/redpanda_migrator.adoc
+++ b/modules/components/pages/inputs/redpanda_migrator.adoc
@@ -56,12 +56,22 @@ For capabilities, guarantees, scheduling, and examples, see the output documenta
 When using multiple migrator pairs in a single pipeline, coordination is based on the `label` field. The label of the input and output must match exactly for correct pairing. If labels do not match, migration fails for that pair.
 
 == Performance tuning for high throughput
-For workloads with high message rates or large messages, adjust these fields:
 
-- `partition_buffer_bytes`: Increase to 10MB or higher (default: 1MB)
-- `max_yield_batch_bytes`: Increase to 100MB or higher (default: 10MB)
+For workloads with high message rates or large messages, adjust the following settings to optimize throughput:
 
-Increasing these values allows the consumer to buffer more data per partition and yield larger batches, reducing overhead and improving throughput. Higher values increase memory usage—monitor system resources accordingly.
+On this input component:
+
+- `partition_buffer_bytes`: Set to 2MB to increase per-partition buffer size
+- `max_yield_batch_bytes`: Set to 1MB to allow larger batches to be yielded
+
+On the paired `redpanda_migrator` output component:
+
+- `max_in_flight`: Set to the total number of partitions being copied in parallel (up to all partitions in the cluster)
+
+[NOTE]
+====
+Setting `max_yield_batch_bytes` over 1MB is counter-productive unless you change the broker settings to allow bigger messages or batches. The `partition_buffer_bytes` setting allows for partition readahead.
+====
 
 == Metrics
 This input emits an `input_redpanda_migrator_lag` metric with `topic` and `partition` labels for each consumed topic. This metric records the number of produced messages that remain to be read from each topic/partition pair by the specified consumer group. Monitor this metric to track migration progress and detect bottlenecks.

--- a/modules/components/pages/outputs/redpanda_migrator.adoc
+++ b/modules/components/pages/outputs/redpanda_migrator.adoc
@@ -48,7 +48,16 @@ When using multiple migrator pairs in a pipeline, match the `label` field exactl
 
 == Performance tuning
 
-For high-throughput workloads, adjust buffer sizes on the input component. xref:components:inputs/redpanda_migrator.adoc#performance-tuning[See input docs for tuning advice.]
+For high-throughput workloads, adjust the following settings:
+
+On this output component:
+
+- `max_in_flight`: Set to the total number of partitions being copied in parallel (up to all partitions in the cluster)
+
+On the paired xref:components:inputs/redpanda_migrator.adoc#performance-tuning[`redpanda_migrator` input component]:
+
+- `partition_buffer_bytes`: Set to 2MB to increase per-partition buffer size
+- `max_yield_batch_bytes`: Set to 1MB to allow larger batches to be yielded
 
 == Synchronization details
 


### PR DESCRIPTION
## Description

Corrects outdated performance tuning guidance in redpanda_migrator input and output documentation:

  - partition_buffer_bytes: 10MB+ → 2MB
  - max_yield_batch_bytes: 100MB+ → 1MB 
  - Add max_in_flight guidance for output component
  - Add note explaining max_yield_batch_bytes >1MB is counter-productive
    unless broker settings are changed

These values are based on benchmarks and align with the source repository guidance. Previous recommendations required extensive tuning for basic throughput scenarios.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)