### PR TITLE
Remove A2A processor from nav

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -130,7 +130,6 @@
 *** xref:components:scanners/tar.adoc[]
 *** xref:components:scanners/to_the_end.adoc[]
 ** xref:components:processors/about.adoc[]
-*** xref:components:processors/a2a_message.adoc[]
 *** xref:components:processors/archive.adoc[]
 *** xref:components:processors/avro.adoc[]
 *** xref:components:processors/awk.adoc[]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)