### PR TITLE
Conditionalize the http_server for use in Cloud docs

### DIFF
--- a/modules/components/pages/inputs/http_server.adoc
+++ b/modules/components/pages/inputs/http_server.adoc
@@ -37,7 +37,7 @@ include::components:example$advanced/inputs/http_server.yaml[]
 ======
 
 ifndef::env-cloud[]
-If the `address` config field is left blank the xref:components:http/about.adoc[service-wide HTTP server] will be used.
+If the `address` config field is left blank, the xref:components:http/about.adoc[service-wide HTTP server] is used.
 endif::[]
 
 The field `rate_limit` allows you to specify an optional xref:components:rate_limits/about.adoc[`rate_limit` resource], which will be applied to each HTTP request made and each websocket payload received.


### PR DESCRIPTION
## Description

This pull request updates the documentation for the HTTP server input component to clarify its description and add conditional information about the `address` configuration field.

Documentation improvements:

* Clarified the introductory description to specify that messages are received via HTTP POST requests, rather than the more general "POSTed over HTTP(S)" phrasing.
* Added a conditional note (displayed only outside the cloud environment) explaining that if the `address` field is left blank, the service-wide HTTP server will be used.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)