### PR TITLE
Fix docs automation and create issues on failure

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -253,11 +253,21 @@ jobs:
             echo "- **Generated At:** \`$(date -u +'%Y-%m-%d %H:%M:%S UTC')\`"
             echo "- **Node Version:** \`${{ env.NODE_VERSION }}\`"
             echo ""
-            echo "<details><summary>📋 Full Generation Output</summary>"
+            echo "<details><summary>📋 Generation Output (last 200 lines)</summary>"
             echo ""
             echo '```'
-            cat full_output.txt
+            # Truncate to last 200 lines to avoid PR body size limits (65536 chars)
+            TOTAL_LINES=$(wc -l < full_output.txt)
+            if [ "$TOTAL_LINES" -gt 200 ]; then
+              echo "... (output truncated, showing last 200 of $TOTAL_LINES lines)"
+              echo ""
+              tail -200 full_output.txt
+            else
+              cat full_output.txt
+            fi
             echo '```'
+            echo ""
+            echo "_Full logs available in [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
             echo ""
             echo "</details>"
             echo "EOF"
@@ -326,8 +336,8 @@ jobs:
         with:
           github-token: ${{ env.ACTIONS_BOT_TOKEN }}
           script: |
-            const failureType = '${{ steps.setup.outputs.failure_type || steps.generate.outputs.failure_type || 'unknown' }}';
-            const failureMessage = `${{ steps.setup.outputs.failure_message || steps.generate.outputs.failure_message || '' }}`.trim();
+            const failureType = ${{ toJSON(steps.setup.outputs.failure_type || steps.generate.outputs.failure_type || 'unknown') }};
+            const failureMessage = ${{ toJSON(steps.setup.outputs.failure_message || steps.generate.outputs.failure_message || '') }}.trim();
 
             // Default message if no specific failure was captured
             let issueBody = failureMessage || `## Workflow Failure


### PR DESCRIPTION
## Description

This pull request significantly refactors and improves the `.github/workflows/update-docs.yml` workflow for updating RPCN connector documentation. The changes focus on making the workflow more robust, maintainable, and user-friendly by improving error handling, adding detailed notifications, optimizing job steps, and enhancing logging and output for easier troubleshooting and review.

**Key improvements include better concurrency handling, enhanced error notifications (including automated GitHub issue creation on failure), improved branch and conflict management, more informative PR summaries, and general modernization of workflow steps.**

The most important changes are:

---

**Workflow robustness and error handling**
* Added a workflow timeout and improved permissions, including the ability to create issues for failure notifications. Now, if the workflow fails (e.g., due to conflicts or doc generation errors), it will automatically create or update a GitHub issue with detailed diagnostics and required actions. [[1]](diffhunk://#diff-6cb924cb587613a1d83384b44ca0c806ccf512202b3f29f529fc6825cef21de2L5-R36) [[2]](diffhunk://#diff-6cb924cb587613a1d83384b44ca0c806ccf512202b3f29f529fc6825cef21de2L150-R399)
* Improved concurrency control: the workflow now cancels in-progress runs when a new one starts to avoid conflicts on the same branch.

**Branch and conflict management**
* Enhanced branch setup: the workflow now attempts a rebase first, then a merge as a fallback if rebase fails due to conflicts. If both fail, it captures conflict details and notifies maintainers with actionable instructions.
* Improved detection and reporting of manual commits on the auto-docs branch, with clearer output and inclusion in the PR body.

**Documentation generation and PR creation**
* Modernized Node.js and tool setup steps, including deterministic installs with `npm ci` and caching of rpk connect components for faster runs.
* Improved doc generation step: now captures and reports errors more clearly, and includes a richer, more informative PR body with review guides and generation details.
* Refactored change detection and PR creation: simplified logic, improved status output, and added more descriptive labels and assignees to PRs.

**Notifications and logging**
* Added a comprehensive "PR Result" step that summarizes the outcome of the workflow, including PR URLs or reasons for no PR creation, and emits GitHub workflow notices for visibility.
* On workflow failure, notifies maintainers via both GitHub issues and error logs, ensuring failures are visible and actionable.

---

These changes make the documentation update process more reliable, transparent, and easier to maintain.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)