### PR TITLE
Document interpolation with YAML tags

### DIFF
--- a/modules/configuration/pages/interpolation.adoc
+++ b/modules/configuration/pages/interpolation.adoc
@@ -27,6 +27,30 @@ If a literal string is required that matches this pattern (`+${foo}+`) you can e
 
 When an environment variable interpolation is found within a config, does not have a default value specified, and the environment variable is not defined a linting error will be reported. In order to avoid this it is possible to specify environment variable interpolations with an explicit empty default value by adding the colon without a following value, i.e. `${FOO:}` would be equivalent to `+${FOO}+` and would not trigger a linting error should `FOO` not be defined.
 
+== YAML tags
+
+By default, Redpanda Connect interpolates environment variables as strings.
+
+You can use link:https://yaml.org/spec/1.2.2/#24-tags[YAML tags^] to interpret values as another scalar type, such as integers.
+
+[source,yaml]
+----
+output:
+  redpanda:
+    # ...
+    batching:
+      count: !!int ${BATCHING_COUNT:500}
+      period: "${BATCHING_PERIOD:1s}"
+----
+
+Redpanda Connect supports the link:https://yaml.org/spec/1.2.2/#103-core-schema[core schema tags^] for scalar types:
+
+* `null`
+* `bool`
+* `int`
+* `float`
+* `str` (default)
+
 == Bloblang queries
 
 Some Redpanda Connect fields also support xref:guides:bloblang/about.adoc[Bloblang] function interpolations, which are much more powerful expressions that allow you to query the contents of messages and perform arithmetic. The syntax of a function interpolation is `${!<bloblang expression>}`, where the contents are a bloblang query (the right-hand-side of a bloblang map) including a range of xref:guides:bloblang/about.adoc#functions[functions]. For example, with the following config:


### PR DESCRIPTION
Like most YAML parsers, the yaml package supports casting string values to other types using tags.

This is useful for tweaking some settings like batching configurations.