### PR TITLE
Add npm/npx installation link to MCP quickstart prerequisites

### DIFF
--- a/modules/ai-agents/pages/mcp-server/quickstart.adoc
+++ b/modules/ai-agents/pages/mcp-server/quickstart.adoc
@@ -26,6 +26,7 @@ You'll need the following to complete this quickstart:
 
 - xref:ROOT:get-started:rpk-install.adoc[Redpanda CLI (`rpk`)]
 - link:https://docs.anthropic.com/en/docs/claude-code/setup[Claude Code^]
+- link:https://docs.npmjs.com/downloading-and-installing-node-js-and-npm[Node.js and npm^] (required for running `npx` commands)
 
 == Initialize an MCP server project
 


### PR DESCRIPTION
Adds Node.js and npm installation link to prerequisites since the tutorial uses `npx mcp-remote`.

Fixes https://redpandadata.atlassian.net/browse/DOC-1932