### PR TITLE
Switch Bloblang examples to dedicated syntax highlighter with interactive features

### DIFF
--- a/modules/components/pages/processors/mapping.adoc
+++ b/modules/components/pages/processors/mapping.adoc
@@ -32,10 +32,12 @@ Note: This processor is equivalent to the xref:components:processors/bloblang.ad
 
 Mapping operates by creating an entirely new object during assignments, this has the advantage of treating the original referenced document as immutable and therefore queryable at any stage of your mapping. For example, with the following mapping:
 
-```coffeescript
+```bloblang
 root.id = this.id
 root.invitees = this.invitees.filter(i -> i.mood >= 0.5)
 root.rejected = this.invitees.filter(i -> i.mood < 0.5)
+
+# In: {"id":"party-2024","invitees":[{"name":"Alice","mood":0.8},{"name":"Bob","mood":0.3},{"name":"Carol","mood":0.9}]}
 ```
 
 Notice that we mutate the value of `invitees` in the resulting document by filtering out objects with a lower mood. However, even after doing so we're still able to reference the unchanged original contents of this value from the input document in order to populate a second field. Within this mapping we also have the flexibility to reference the mutable mapped document by using the keyword `root` (i.e. `root.invitees`) on the right-hand side instead.

--- a/modules/components/pages/processors/mutation.adoc
+++ b/modules/components/pages/processors/mutation.adoc
@@ -30,16 +30,20 @@ If your mapping is large and you'd prefer for it to live in a separate file then
 
 A mutation is a mapping that transforms input documents directly, this has the advantage of reducing the need to copy the data fed into the mapping. However, this also means that the referenced document is mutable and therefore changes throughout the mapping. For example, with the following Bloblang:
 
-```coffeescript
+```bloblang
 root.rejected = this.invitees.filter(i -> i.mood < 0.5)
 root.invitees = this.invitees.filter(i -> i.mood >= 0.5)
+
+# In: {"invitees":[{"name":"Alice","mood":0.8},{"name":"Bob","mood":0.3},{"name":"Carol","mood":0.9}]}
 ```
 
 Notice that we create a field `rejected` by copying the array field `invitees` and filtering out objects with a high mood. We then overwrite the field `invitees` by filtering out objects with a low mood, resulting in two array fields that are each a subset of the original. If we were to reverse the ordering of these assignments like so:
 
-```coffeescript
+```bloblang
 root.invitees = this.invitees.filter(i -> i.mood >= 0.5)
 root.rejected = this.invitees.filter(i -> i.mood < 0.5)
+
+# In: {"invitees":[{"name":"Alice","mood":0.8},{"name":"Bob","mood":0.3},{"name":"Carol","mood":0.9}]}
 ```
 
 Then the new field `rejected` would be empty as we have already mutated `invitees` to exclude the objects that it would be populated by. We can solve this problem either by carefully ordering our assignments or by capturing the original array using a variable (`let invitees = this.invitees`).

--- a/modules/configuration/pages/metadata.adoc
+++ b/modules/configuration/pages/metadata.adoc
@@ -24,14 +24,14 @@ pipeline:
 
 You can also use xref:guides:bloblang/about.adoc[Bloblang] to delete individual metadata keys with:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 meta foo = deleted()
 ----
 
 Or do more interesting things like remove all metadata keys with a certain prefix:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 meta = @.filter(kv -> !kv.key.has_prefix("kafka_"))
 ----
@@ -68,6 +68,7 @@ pipeline:
                 this.document.bar,
                 @kafka_topic,
               ]
+              # In:  {"document":{"foo":"value1","bar":"value2"}}
 ----
 
 == Restricting metadata

--- a/modules/configuration/pages/unit_testing.adoc
+++ b/modules/configuration/pages/unit_testing.adoc
@@ -73,7 +73,7 @@ Sometimes when working with large {bloblang-url}[Bloblang mappings] it's preferr
 
 For example, if we were to have a file `cities.blobl` containing a mapping:
 
-```coffeescript
+```bloblang
 root.Cities = this.locations.
                 filter(loc -> loc.state == "WA").
                 map_each(loc -> loc.name).

--- a/modules/guides/pages/bloblang/about.adoc
+++ b/modules/guides/pages/bloblang/about.adoc
@@ -25,7 +25,7 @@ A Bloblang mapping expresses how to create a new document by extracting data fro
 
 The keyword `root` on the left-hand side refers to the root of the new document, the keyword `this` on the right-hand side refers to the current context of the query, which is the read-only input document when querying from the root of a mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.id = this.thing.id
 root.type = "yo"
@@ -34,18 +34,16 @@ root.type = "yo"
 content = thing.doc.message
 
 # In:  {"thing":{"id":"wat1","doc":{"title":"wut","message":"hello world"}}}
-# Out: {"content":"hello world","id":"wat1","type":"yo"}
 ----
 
 Since the document being created starts off empty it is sometimes useful to begin a mapping by copying the entire contents of the input document, which can be expressed by assigning `this` to `root`.
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.foo = "added value"
 
 # In:  {"id":"wat1","message":"hello world"}
-# Out: {"id":"wat1","message":"hello world","foo":"added value"}
 ----
 
 If the new document `root` is never assigned to or otherwise mutated then the original document remains unchanged.
@@ -54,37 +52,34 @@ If the new document `root` is never assigned to or otherwise mutated then the or
 
 Quotes can be used to describe sections of a field path that contain whitespace, dots or other special characters:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Use quotes around a path segment in order to include whitespace or dots within
 # the path
 root."foo.bar".baz = this."buz bev".fub
 
 # In:  {"buz bev":{"fub":"hello world"}}
-# Out: {"foo.bar":{"baz":"hello world"}}
 ----
 
 === Non-structured data
 
 Bloblang is able to map data that is unstructured, whether it's a log line or a binary blob, by referencing it with the xref:guides:bloblang/functions.adoc#content[`content` function], which returns the raw bytes of the input document:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Parse a base64 encoded JSON document
 root = content().decode("base64").parse_json()
 
 # In:  eyJmb28iOiJiYXIifQ==
-# Out: {"foo":"bar"}
 ----
 
 And your newly mapped document can also be unstructured, simply assign a value type to the `root` of your document:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.foo
 
 # In:  {"foo":"hello world"}
-# Out: hello world
 ----
 
 And the resulting message payload will be the raw value you've assigned.
@@ -93,20 +88,19 @@ And the resulting message payload will be the raw value you've assigned.
 
 It's possible to selectively delete fields from an object by assigning the function `deleted()` to the field path:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.bar = deleted()
 
 # In:  {"id":"wat1","message":"hello world","bar":"remove me"}
-# Out: {"id":"wat1","message":"hello world"}
 ----
 
 === Variables
 
 Another type of assignment is a `let` statement, which creates a variable that can be referenced elsewhere within a mapping. Variables are discarded at the end of the mapping and are mostly useful for query reuse. Variables are referenced within queries with `$`:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Set a temporary variable
 let foo = "yo"
@@ -118,7 +112,7 @@ root.new_doc.type = $foo
 
 Redpanda Connect messages contain metadata that is separate from the main payload, in Bloblang you can modify the metadata of the resulting message with the `meta` assignment keyword. Metadata values of the resulting message are referenced within queries with the `@` operator or the xref:guides:bloblang/functions.adoc#metadata[`metadata()` function]:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Reference a metadata value
 root.new_doc.bar = @kafka_topic # Or `@.kafka_topic` or `metadata("kafka_topic")`
@@ -140,18 +134,15 @@ root.meta_obj = @ # Or `metadata()`
 
 The pipe operator (`|`) used within brackets allows you to coalesce multiple candidates for a path segment. The first field that exists and has a non-null value will be selected:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.new_doc.type = this.thing.(article | comment | this).type
 
 # In:  {"thing":{"article":{"type":"foo"}}}
-# Out: {"new_doc":{"type":"foo"}}
 
 # In:  {"thing":{"comment":{"type":"bar"}}}
-# Out: {"new_doc":{"type":"bar"}}
 
 # In:  {"thing":{"type":"baz"}}
-# Out: {"new_doc":{"type":"baz"}}
 ----
 
 Opening brackets on a field begins a query where the context of `this` changes to value of the path it is opened upon, therefore in the above example `this` within the brackets refers to the contents of `this.thing`.
@@ -160,7 +151,7 @@ Opening brackets on a field begins a query where the context of `this` changes t
 
 Bloblang supports number, boolean, string, null, array and object literals:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = [
   7, false, "string", null, {
@@ -173,7 +164,6 @@ string"""
 ]
 
 # In:  {}
-# Out: [7,false,"string",null,{"first":11,"second":{"foo":"bar"},"third":"multiple\nlines on this\nstring"}]
 ----
 
 The values within literal arrays and objects can be dynamic query expressions, as well as the keys of object literals.
@@ -182,7 +172,7 @@ The values within literal arrays and objects can be dynamic query expressions, a
 
 You might've already spotted, comments are started with a hash (`#`) and end with a line break:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.some.value # And now this is a comment
 ----
@@ -191,16 +181,14 @@ root = this.some.value # And now this is a comment
 
 Bloblang supports a range of boolean operators `!`, `>`, `>=`, `==`, `<`, `+<=+`, `&&`, `||` and mathematical operators `+`, `-`, `*`, `/`, `%`:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.is_big = this.number > 100
 root.multiplied = this.number * 7
 
 # In:  {"number":50}
-# Out: {"is_big":false,"multiplied":350}
 
 # In:  {"number":150}
-# Out: {"is_big":true,"multiplied":1050}
 ----
 
 For more information about these operators and how they work check out xref:guides:bloblang/arithmetic.adoc[the arithmetic page].
@@ -209,7 +197,7 @@ For more information about these operators and how they work check out xref:guid
 
 Use `if` as either a statement or an expression in order to perform maps conditionally:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 
@@ -221,15 +209,13 @@ if this.foo.type() == "string" {
 }
 
 # In:  {"foo":"FooBar"}
-# Out: {"foo":"FooBar","lower_foo":"foobar","upper_foo":"FOOBAR"}
 
 # In:  {"foo":["foo","bar"]}
-# Out: {"foo":["foo","bar"],"sorted_foo":["bar","foo"]}
 ----
 
 And add as many `else if` queries as you like, followed by an optional final fallback `else`:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.sound = if this.type == "cat" {
   this.cat.meow
@@ -240,20 +226,17 @@ root.sound = if this.type == "cat" {
 }
 
 # In:  {"type":"cat","cat":{"meow":"meeeeooooow!"}}
-# Out: {"sound":"meeeeooooow!"}
 
 # In:  {"type":"dog","dog":{"woof":"guurrrr woof woof!"}}
-# Out: {"sound":"GUURRRR WOOF WOOF!"}
 
 # In:  {"type":"caterpillar","caterpillar":{"name":"oleg"}}
-# Out: {"sound":"sweet sweet silence"}
 ----
 
 == Pattern matching
 
 A `match` expression allows you to perform conditional mappings on a value, each case should be either a boolean expression, a literal value to compare against the target value, or an underscore (`_`) which captures values that have not matched a prior case:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.new_doc = match this.doc {
   this.type == "article" => this.article
@@ -262,31 +245,27 @@ root.new_doc = match this.doc {
 }
 
 # In:  {"doc":{"type":"article","article":{"id":"foo","content":"qux"}}}
-# Out: {"new_doc":{"id":"foo","content":"qux"}}
 
 # In:  {"doc":{"type":"comment","comment":{"id":"bar","content":"quz"}}}
-# Out: {"new_doc":{"id":"bar","content":"quz"}}
 
 # In:  {"doc":{"type":"neither","content":"some other stuff unchanged"}}
-# Out: {"new_doc":{"type":"neither","content":"some other stuff unchanged"}}
 ----
 
 Within a match block the context of `this` changes to the pattern matched expression, therefore `this` within the match expression above refers to `this.doc`.
 
 Match cases can specify a literal value for simple comparison:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.type = match this.type { "doc" => "document", "art" => "article", _ => this }
 
 # In:  {"type":"doc","foo":"bar"}
-# Out: {"type":"document","foo":"bar"}
 ----
 
 The match expression can also be left unset which means the context remains unchanged, and the catch-all case can also be omitted:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.new_doc = match {
   this.doc.type == "article" => this.doc.article
@@ -294,7 +273,6 @@ root.new_doc = match {
 }
 
 # In:  {"doc":{"type":"neither","content":"some other stuff unchanged"}}
-# Out: {"doc":{"type":"neither","content":"some other stuff unchanged"}}
 ----
 
 If no case matches then the mapping is skipped entirely, hence we would end up with the original document in this case.
@@ -303,7 +281,7 @@ If no case matches then the mapping is skipped entirely, hence we would end up w
 
 Functions can be placed anywhere and allow you to extract information from your environment, generate values, or access data from the underlying message being mapped:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.doc.id = uuid_v4()
 root.doc.received_at = now()
@@ -312,10 +290,12 @@ root.doc.host = hostname()
 
 Functions support both named and nameless style arguments:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.values_one = range(start: 0, stop: this.max, step: 2)
 root.values_two = range(0, this.max, 2)
+
+# In:  {"max":10}
 ----
 
 You can find a full list of functions and their parameters in xref:guides:bloblang/functions.adoc[the functions page].
@@ -324,7 +304,7 @@ You can find a full list of functions and their parameters in xref:guides:blobla
 
 Methods are similar to functions but enact upon a target value, these provide most of the power in Bloblang as they allow you to augment query values and can be added to any expression (including other methods):
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.doc.id = this.thing.id.string().catch(uuid_v4())
 root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
@@ -333,14 +313,18 @@ root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
   num - 10
 })
 root.has_good_taste = ["pikachu","mewtwo","magmar"].contains(this.user.fav_pokemon)
+
+# In:  {"thing":{"id":123,"nums":[5,12,8,15,20]},"user":{"fav_pokemon":"pikachu"}}
 ----
 
 Methods also support both named and nameless style arguments:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo_one = this.(bar | baz).trim().replace_all(old: "dog", new: "cat")
 root.foo_two = this.(bar | baz).trim().replace_all("dog", "cat")
+
+# In:  {"bar":"  I love my dog  "}
 ----
 
 You can find a full list of methods and their parameters in xref:guides:bloblang/methods.adoc[the methods page].
@@ -349,7 +333,7 @@ You can find a full list of methods and their parameters in xref:guides:bloblang
 
 Defining named maps allows you to reuse common mappings on values with the xref:guides:bloblang/methods.adoc#apply[`apply` method]:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map things {
   root.first  = this.thing_one
@@ -360,7 +344,6 @@ root.foo = this.value_one.apply("things")
 root.bar = this.value_two.apply("things")
 
 # In:  {"value_one":{"thing_one":"hey","thing_two":"yo"},"value_two":{"thing_one":"sup","thing_two":"waddup"}}
-# Out: {"foo":{"first":"hey","second":"yo"},"bar":{"first":"sup","second":"waddup"}}
 ----
 
 Within a map the keyword `root` refers to a newly created document that will replace the target of the map, and `this` refers to the original value of the target. The argument of `apply` is a string, which allows you to dynamically resolve the mapping to apply.
@@ -369,12 +352,14 @@ Within a map the keyword `root` refers to a newly created document that will rep
 
 It's possible to import maps defined in a file with an `import` statement:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 import "./common_maps.blobl"
 
 root.foo = this.value_one.apply("things")
 root.bar = this.value_two.apply("things")
+
+# In:  {"value_one":{"thing_one":"hey","thing_two":"yo"},"value_two":{"thing_one":"sup","thing_two":"waddup"}}
 ----
 
 Imports from a Bloblang mapping within a Redpanda Connect config are relative to the process running the config. Imports from an imported file are relative to the file that is importing it.
@@ -383,33 +368,45 @@ Imports from a Bloblang mapping within a Redpanda Connect config are relative to
 
 By assigning the root of a mapped document to the `deleted()` function you can delete a message entirely:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Filter all messages that have fewer than 10 URLs.
 root = if this.doc.urls.length() < 10 { deleted() }
+
+# In:  {"doc":{"urls":["a","b","c"]}}
+
+# In:  {"doc":{"urls":["a","b","c","d","e","f","g","h","i","j"]}}
 ----
 
 == Error handling
 
 Functions and methods can fail under certain circumstances, such as when they receive types they aren't able to act upon. These failures, when not caught, will cause the entire mapping to fail. However, the xref:guides:bloblang/methods.adoc#catch[method `catch`] can be used in order to return a value when a failure occurs instead:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Map an empty array to `foo` if the field `bar` is not a string.
 root.foo = this.bar.split(",").catch([])
+
+# In:  {"bar":"a,b,c"}
+
+# In:  {"bar":123}
 ----
 
 Since `catch` is a method it can also be attached to bracketed map expressions:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Map `false` if any of the operations in this boolean query fail.
 root.thing = ( this.foo > this.bar && this.baz.contains("wut") ).catch(false)
+
+# In:  {"foo":10,"bar":5,"baz":"wut wut"}
+
+# In:  {"foo":"not a number","bar":5,"baz":"wut wut"}
 ----
 
 And one of the more powerful features of Bloblang is that a single `catch` method at the end of a chain of methods can recover errors from any method in the chain:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Catch errors caused by:
 # - foo not existing
@@ -419,15 +416,23 @@ root.things = this.foo.split(",").map_each( ele -> ele.parse_json() ).catch([])
 
 # Specifically catch a JSON parse error
 root.things = this.foo.split(",").map_each( ele -> ele.parse_json().catch({}) )
+
+# In:  {"foo":"{\"a\":1},{\"b\":2}"}
+
+# In:  {"foo":"not valid json"}
 ----
 
 However, the `catch` method only acts on errors, sometimes it's also useful to set a fall back value when a query returns `null` in which case the xref:guides:bloblang/methods.adoc#or[method `or`] can be used the same way:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 # Map "default" if either the element index 5 does not exist, or the underlying
 # element is `null`.
 root.foo = this.bar.index(5).or("default")
+
+# In:  {"bar":["a","b","c"]}
+
+# In:  {"bar":["a","b","c","d","e","f","g"]}
 ----
 
 == Unit testing

--- a/modules/guides/pages/bloblang/advanced.adoc
+++ b/modules/guides/pages/bloblang/advanced.adoc
@@ -6,7 +6,7 @@
 
 A map definition only has one input parameter, which is the context that it is called upon:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map formatting {
   root = "(%v)".format(this)
@@ -16,12 +16,11 @@ root.a = this.a.apply("formatting")
 root.b = this.b.apply("formatting")
 
 # In:  {"a":"foo","b":"bar"}
-# Out: {"a":"(foo)","b":"(bar)"}
 ----
 
 However, we can use object literals in order to provide multiple map parameters. Imagine if we wanted a map that is the exact same as above except the pattern is `[%v]` instead, with the potential for even more patterns in the future. To do that we can pass an object with a field `value` with our target to map and a field `pattern` which allows us to specify the pattern to apply:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map formatting {
   root = this.pattern.format(this.value)
@@ -38,14 +37,13 @@ root.b = {
 }.apply("formatting")
 
 # In:  {"a":"foo","b":"bar","pattern":"[%v]"}
-# Out: {"a":"[foo]","b":"[bar]"}
 ----
 
 == Walking the tree
 
 Sometimes it's necessary to perform a mapping on all values within an unknown tree structure. You can do that easily with recursive mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map unescape_values {
   root = match {
@@ -59,7 +57,6 @@ map unescape_values {
 root = this.apply("unescape_values")
 
 # In:  {"first":{"nested":"foo &amp; bar"},"second":10,"third":["1 &lt; 2",{"also_nested":"2 &gt; 1"}]}
-# Out: {"first":{"nested":"foo & bar"},"second":10,"third":["1 < 2",{"also_nested":"2 > 1"}]}
 ----
 
 == Message expansion
@@ -91,23 +88,21 @@ pipeline:
 
 However, most of the time we also need to map the elements before expanding them, and often that includes copying fields outside of our target array. We can do that with methods such as `map_each` and `merge`:
 
-[source,coffeescript]
+[source,bloblang]
 ----
-root = this.items.map_each(ele -> this.without("items").merge(ele))
-
 # In:  {"id":"foobar","items":[{"content":"foo"},{"content":"bar"},{"content":"baz"}]}
-# Out: [{"content":"foo","id":"foobar"},{"content":"bar","id":"foobar"},{"content":"baz","id":"foobar"}]
+
+root = this.items.map_each(ele -> this.without("items").merge(ele))
 ----
 
 However, the above mapping is slightly inefficient as we would create a copy of our source object for each element with the `this.without("items")` part. A more efficient way to do this would be to capture that query within a variable:
 
-[source,coffeescript]
+[source,bloblang]
 ----
+# In:  {"id":"foobar","items":[{"content":"foo"},{"content":"bar"},{"content":"baz"}]}
+
 let doc_root = this.without("items")
 root = this.items.map_each($doc_root.merge(this))
-
-# In:  {"id":"foobar","items":[{"content":"foo"},{"content":"bar"},{"content":"baz"}]}
-# Out: [{"content":"foo","id":"foobar"},{"content":"bar","id":"foobar"},{"content":"baz","id":"foobar"}]
 ----
 
 Also note that when we set `doc_root` we remove the field `items` from the target document. The full config would now be:
@@ -129,8 +124,11 @@ Redpanda Connect has a few different ways of outputting a stream of CSV data. Ho
 
 A common and simple use case is to simply flatten documents and write out the column values in alphabetical order. The first row we generate should also be prefixed with a row containing those column names. Here's a mapping that achieves this by using a `count` function to detect the very first invocation of the mapping in a stream pipeline:
 
-[source,coffeescript]
+[source,bloblang]
 ----
+# In:  {"name":"foo","address":"123 Main St, Apt 2"}
+#      foo,"123 Main St, Apt 2"
+
 map escape_csv {
   root = if this.re_match("[\"\n,]+") {
     "\"" + this.replace_all("\"", "\"\"") + "\""

--- a/modules/guides/pages/bloblang/functions.adoc
+++ b/modules/guides/pages/bloblang/functions.adoc
@@ -7,7 +7,7 @@
 
 Functions can be placed anywhere and allow you to extract information from your environment, generate values, or access data from the underlying message being mapped:
 
-```coffeescript
+```bloblang
 root.doc.id = uuid_v4()
 root.doc.received_at = now()
 root.doc.host = hostname()
@@ -15,9 +15,11 @@ root.doc.host = hostname()
 
 Functions support both named and nameless style arguments:
 
-```coffeescript
+```bloblang
 root.values_one = range(start: 0, stop: this.max, step: 2)
 root.values_two = range(0, this.max, 2)
+
+# In:  {"max":10}
 ```
 
 == General
@@ -33,18 +35,16 @@ Creates a new byte array of a specified length that is zero-initialized. This fu
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.buffer = bytes(10)
 
 # In:  {}
-# Out: {"buffer":"AAAAAAAAAA=="}
 ```
 
-```coffeescript
+```bloblang
 root.data = bytes(this.size)
 
 # In:  {"size":5}
-# Out: {"data":"AAAAAA=="}
 ```
 
 === `counter`
@@ -64,19 +64,17 @@ Returns a non-negative integer that increments each time it is resolved, yieldin
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.id = counter()
 
 # In:  {}
-# Out: {"id":1}
 
 # In:  {}
-# Out: {"id":2}
 ```
 
 It's possible to increment a counter multiple times within a single mapping invocation using a map.
 
-```coffeescript
+```bloblang
 
 map foos {
   root = counter()
@@ -87,46 +85,36 @@ root.woof_id = null.apply("foos")
 
 
 # In:  {}
-# Out: {"meow_id":1,"woof_id":2}
 
 # In:  {}
-# Out: {"meow_id":3,"woof_id":4}
 ```
 
 By specifying an optional `set` parameter it is possible to dynamically reset the counter based on input data.
 
-```coffeescript
+```bloblang
 root.consecutive_doggos = counter(min: 1, set: if !this.sound.lowercase().contains("woof") { 0 })
 
 # In:  {"sound":"woof woof"}
-# Out: {"consecutive_doggos":1}
 
 # In:  {"sound":"woofer wooooo"}
-# Out: {"consecutive_doggos":2}
 
 # In:  {"sound":"meow"}
-# Out: {"consecutive_doggos":0}
 
 # In:  {"sound":"uuuuh uh uh woof uhhhhhh"}
-# Out: {"consecutive_doggos":1}
 ```
 
 The `set` parameter can also be utilized to peek at the counter without mutating it by returning `null`.
 
-```coffeescript
+```bloblang
 root.things = counter(set: if this.id == null { null })
 
 # In:  {"id":"a"}
-# Out: {"things":1}
 
 # In:  {"id":"b"}
-# Out: {"things":2}
 
 # In:  {"what":"just checking"}
-# Out: {"things":2}
 
 # In:  {"id":"c"}
-# Out: {"things":3}
 ```
 
 === `deleted`
@@ -136,21 +124,19 @@ A function that returns a result indicating that the mapping target should be de
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this
 root.bar = deleted()
 
 # In:  {"bar":"bar_value","baz":"baz_value","foo":"foo value"}
-# Out: {"baz":"baz_value","foo":"foo value"}
 ```
 
 Since the result is a value it can be used to do things like remove elements of an array within `map_each`.
 
-```coffeescript
+```bloblang
 root.new_nums = this.nums.map_each(num -> if num < 10 { deleted() } else { num - 10 })
 
 # In:  {"nums":[3,11,4,17]}
-# Out: {"new_nums":[1,7]}
 ```
 
 === `ksuid`
@@ -160,7 +146,7 @@ Generates a new ksuid each time it is invoked and prints a string representation
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.id = ksuid()
 ```
 
@@ -176,19 +162,19 @@ Generates a new nanoid each time it is invoked and prints a string representatio
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.id = nanoid()
 ```
 
 It is possible to specify an optional length parameter.
 
-```coffeescript
+```bloblang
 root.id = nanoid(54)
 ```
 
 It is also possible to specify an optional custom alphabet after the length parameter.
 
-```coffeescript
+```bloblang
 root.id = nanoid(54, "abcde")
 ```
 
@@ -199,18 +185,16 @@ Returns the value of the mathematical constant Pi.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.radians = this.degrees * (pi() / 180)
 
 # In:  {"degrees":45}
-# Out: {"radians":0.7853981633974483}
 ```
 
-```coffeescript
+```bloblang
 root.degrees = this.radians * (180 / pi())
 
 # In:  {"radians":0.78540}
-# Out: {"degrees":45.00010522957486}
 ```
 
 === `random_int`
@@ -229,7 +213,7 @@ Optional `min` and `max` arguments can be provided in order to only generate num
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.first = random_int()
 root.second = random_int(1)
 root.third = random_int(max:20)
@@ -241,7 +225,7 @@ root.sixth = random_int(seed:timestamp_unix_nano(), max:20)
 
 It is possible to specify a dynamic seed argument, in which case the argument will only be resolved once during the lifetime of the mapping.
 
-```coffeescript
+```bloblang
 root.first = random_int(timestamp_unix_nano())
 ```
 
@@ -258,13 +242,12 @@ The `range` function creates an array of integers following a range between a st
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.a = range(0, 10)
 root.b = range(start: 0, stop: this.max, step: 2) # Using named params
 root.c = range(0, -this.max, -2)
 
 # In:  {"max":10}
-# Out: {"a":[0,1,2,3,4,5,6,7,8,9],"b":[0,2,4,6,8],"c":[0,-2,-4,-6,-8]}
 ```
 
 === `snowflake_id`
@@ -278,13 +261,13 @@ Generate a new snowflake ID each time it is invoked and prints a string represen
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.id = snowflake_id()
 ```
 
 It is possible to specify the node_id.
 
-```coffeescript
+```bloblang
 root.id = snowflake_id(2)
 ```
 
@@ -299,7 +282,7 @@ Throws an error similar to a regular mapping error. This is useful for abandonin
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.type = match {
   this.exists("header.id") => "foo"
   this.exists("body.data") => "bar"
@@ -308,10 +291,8 @@ root.doc.type = match {
 root.doc.contents = (this.body.content | this.thing.body)
 
 # In:  {"header":{"id":"first"},"thing":{"body":"hello world"}}
-# Out: {"doc":{"contents":"hello world","type":"foo"}}
 
 # In:  {"nothing":"matches"}
-# Out: Error("failed assignment (line 1): unknown type")
 ```
 
 === `ulid`
@@ -332,19 +313,19 @@ Generate a random ULID.
 
 Using the defaults of Crockford Base32 encoding and secure random source
 
-```coffeescript
+```bloblang
 root.id = ulid()
 ```
 
 ULIDs can be hex-encoded too.
 
-```coffeescript
+```bloblang
 root.id = ulid("hex")
 ```
 
 They can be generated using a fast, but unsafe, random source for use cases that are not security-sensitive.
 
-```coffeescript
+```bloblang
 root.id = ulid("crockford", "fast_random")
 ```
 
@@ -355,7 +336,7 @@ Generates a new RFC-4122 UUID each time it is invoked and prints a string repres
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.id = uuid_v4()
 ```
 
@@ -369,13 +350,13 @@ Generates a new time-ordered UUID each time it is invoked and prints a string re
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.id = uuid_v7()
 ```
 
 You can also specify the timestamp for the `uuid_v7`.
 
-```coffeescript
+```bloblang
 root.id = uuid_v7(now().ts_sub_iso8601("PT1M"))
 ```
 
@@ -390,12 +371,14 @@ Prepends a 5-byte Schema Registry header to a message. The header consists of a 
 
 ==== Examples
 
-```coffeescript
+```bloblang
+# Skip: true
 # Add header with schema ID 123
 root = with_schema_registry_header(123, content())
 ```
 
-```coffeescript
+```bloblang
+# Skip: true
 # Add header with schema ID from metadata
 root = with_schema_registry_header(meta("schema_id").number(), content())
 ```
@@ -409,7 +392,7 @@ Returns the index of the mapped message within a batch. This is useful for apply
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = if batch_index() > 0 { deleted() }
 ```
 
@@ -420,7 +403,7 @@ Returns the size of the message batch.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = batch_size()
 ```
 
@@ -431,11 +414,10 @@ Returns the full raw contents of the mapping target message as a byte array. Whe
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = content().string()
 
 # In:  {"foo":"bar"}
-# Out: {"doc":"{\"foo\":\"bar\"}"}
 ```
 
 === `error`
@@ -445,7 +427,7 @@ If an error occurs during the processing of a message, this function returns the
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.error = error()
 ```
 
@@ -455,7 +437,7 @@ Returns the label of the component that raised the error during the processing o
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.doc.error_source_label = error_source_label()
 ```
 
@@ -465,7 +447,7 @@ Returns the name of the component that raised the error during the processing of
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.doc.error_source_name = error_source_name()
 ```
 
@@ -475,7 +457,7 @@ Returns the path of the component that raised the error during the processing of
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.doc.error_source_path = error_source_path()
 ```
 
@@ -486,7 +468,7 @@ Returns a boolean value indicating whether an error has occurred during the proc
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.status = if errored() { 400 } else { 200 }
 ```
 
@@ -501,20 +483,18 @@ Returns the value of a field within a JSON message located by a [dot path][field
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.mapped = json("foo.bar")
 
 # In:  {"foo":{"bar":"hello world"}}
-# Out: {"mapped":"hello world"}
 ```
 
 The path argument is optional and if omitted the entire JSON payload is returned.
 
-```coffeescript
+```bloblang
 root.doc = json()
 
 # In:  {"foo":{"bar":"hello world"}}
-# Out: {"doc":{"foo":{"bar":"hello world"}}}
 ```
 
 === `metadata`
@@ -528,13 +508,13 @@ Returns the value of a metadata key from the input message, or `null` if the key
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.topic = metadata("kafka_topic")
 ```
 
 The key parameter is optional and if omitted the entire metadata contents are returned as an object.
 
-```coffeescript
+```bloblang
 root.all_metadata = metadata()
 ```
 
@@ -549,7 +529,7 @@ Provides the message trace id. The returned value will be zeroed if the message 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 meta trace_id = tracing_id()
 ```
 
@@ -564,11 +544,10 @@ Provides the message tracing span xref:components:tracers/about.adoc[(created vi
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.headers.traceparent = tracing_span().traceparent
 
 # In:  {"some_stuff":"just can't be explained by science"}
-# Out: {"headers":{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}
 ```
 
 == Environment
@@ -585,17 +564,19 @@ Returns the value of an environment variable, or `null` if the environment varia
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.thing.key = env("key").or("default value")
 ```
 
-```coffeescript
+```bloblang
 root.thing.key = env(this.thing.key_name)
+
+# In:  {"thing":{"key_name":"API_KEY"}}
 ```
 
 When the name parameter is static this function will only resolve once and yield the same result for each invocation as an optimization, this means that updates to env vars during runtime will not be reflected. You can disable this cache with the optional parameter `no_cache`, which when set to `true` will cause the variable lookup to be performed for each execution of the mapping.
 
-```coffeescript
+```bloblang
 root.thing.key = env(name: "key", no_cache: true)
 ```
 
@@ -611,20 +592,18 @@ Reads a file and returns its contents. Relative paths are resolved from the dire
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = file(env("BENTHOS_TEST_BLOBLANG_FILE")).parse_json()
 
 # In:  {}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
 When the path parameter is static this function will only read the specified file once and yield the same result for each invocation as an optimization, this means that updates to files during runtime will not be reflected. You can disable this cache with the optional parameter `no_cache`, which when set to `true` will cause the file to be read for each execution of the mapping.
 
-```coffeescript
+```bloblang
 root.doc = file(path: env("BENTHOS_TEST_BLOBLANG_FILE"), no_cache: true).parse_json()
 
 # In:  {}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
 === `file_rel`
@@ -639,20 +618,18 @@ Reads a file and returns its contents. Relative paths are resolved from the dire
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = file_rel(env("BENTHOS_TEST_BLOBLANG_FILE")).parse_json()
 
 # In:  {}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
 When the path parameter is static this function will only read the specified file once and yield the same result for each invocation as an optimization, this means that updates to files during runtime will not be reflected. You can disable this cache with the optional parameter `no_cache`, which when set to `true` will cause the file to be read for each execution of the mapping.
 
-```coffeescript
+```bloblang
 root.doc = file_rel(path: env("BENTHOS_TEST_BLOBLANG_FILE"), no_cache: true).parse_json()
 
 # In:  {}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
 === `hostname`
@@ -662,7 +639,7 @@ Returns a string matching the hostname of the machine running Benthos.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.thing.host = hostname()
 ```
 
@@ -673,11 +650,11 @@ Returns the current timestamp as a string in RFC 3339 format with the local time
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.received_at = now()
 ```
 
-```coffeescript
+```bloblang
 root.received_at = now().ts_format("Mon Jan 2 15:04:05 -0700 MST 2006", "UTC")
 ```
 
@@ -688,7 +665,7 @@ Returns the current unix timestamp in seconds.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.received_at = timestamp_unix()
 ```
 
@@ -699,7 +676,7 @@ Returns the current unix timestamp in microseconds.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.received_at = timestamp_unix_micro()
 ```
 
@@ -710,7 +687,7 @@ Returns the current unix timestamp in milliseconds.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.received_at = timestamp_unix_milli()
 ```
 
@@ -721,7 +698,7 @@ Returns the current unix timestamp in nanoseconds.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.received_at = timestamp_unix_nano()
 ```
 
@@ -744,25 +721,25 @@ Takes in a string that maps to a https://github.com/go-faker/faker[faker^] funct
 
 Use `time_string` to generate a time in the format `00:00:00`:
 
-```coffeescript
+```bloblang
 root.time = fake("time_string")
 ```
 
 Use `email` to generate a string in email address format:
 
-```coffeescript
+```bloblang
 root.email = fake("email")
 ```
 
 Use `jwt` to generate a JWT token:
 
-```coffeescript
+```bloblang
 root.jwt = fake("jwt")
 ```
 
 Use `uuid_hyphenated` to generate a hyphenated UUID:
 
-```coffeescript
+```bloblang
 root.uuid = fake("uuid_hyphenated")
 ```
 
@@ -779,15 +756,13 @@ The `count` function is a counter starting at 1 which increments after each time
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this
 root.id = count("bloblang_function_example")
 
 # In:  {"message":"foo"}
-# Out: {"id":1,"message":"foo"}
 
 # In:  {"message":"bar"}
-# Out: {"id":2,"message":"bar"}
 ```
 
 === `meta`
@@ -801,13 +776,13 @@ Returns the value of a metadata key from the input message as a string, or `null
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.topic = meta("kafka_topic")
 ```
 
 The key parameter is optional and if omitted the entire metadata contents are returned as an object.
 
-```coffeescript
+```bloblang
 root.all_metadata = meta()
 ```
 
@@ -822,13 +797,13 @@ Returns the value of a metadata key from the new message being created as a stri
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.topic = root_meta("kafka_topic")
 ```
 
 The key parameter is optional and if omitted the entire metadata contents are returned as an object.
 
-```coffeescript
+```bloblang
 root.all_metadata = root_meta()
 ```
 

--- a/modules/guides/pages/bloblang/methods.adoc
+++ b/modules/guides/pages/bloblang/methods.adoc
@@ -7,7 +7,7 @@
 
 Methods provide most of the power in Bloblang as they allow you to augment values and can be added to any expression (including other methods):
 
-```coffeescript
+```bloblang
 root.doc.id = this.thing.id.string().catch(uuid_v4())
 root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
   deleted()
@@ -15,13 +15,17 @@ root.doc.reduced_nums = this.thing.nums.map_each(num -> if num < 10 {
   num - 10
 })
 root.has_good_taste = ["pikachu","mewtwo","magmar"].contains(this.user.fav_pokemon)
+
+# In:  {"thing":{"id":123,"nums":[5,12,18,7,25]},"user":{"fav_pokemon":"pikachu"}}
 ```
 
 Methods support both named and nameless style arguments:
 
-```coffeescript
+```bloblang
 root.foo_one = this.(bar | baz).trim().replace_all(old: "dog", new: "cat")
 root.foo_two = this.(bar | baz).trim().replace_all("dog", "cat")
+
+# In:  {"bar":"  I love my dog  "}
 ```
 
 == General
@@ -37,7 +41,7 @@ Apply a declared mapping to a target value.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 map thing {
   root.inner = this.first
 }
@@ -45,10 +49,9 @@ map thing {
 root.foo = this.doc.apply("thing")
 
 # In:  {"doc":{"first":"hello world"}}
-# Out: {"foo":{"inner":"hello world"}}
 ```
 
-```coffeescript
+```bloblang
 map create_foo {
   root.name = "a foo"
   root.purpose = "to be a foo"
@@ -58,7 +61,6 @@ root = this
 root.foo = null.apply("create_foo")
 
 # In:  {"id":"1234"}
-# Out: {"foo":{"name":"a foo","purpose":"to be a foo"},"id":"1234"}
 ```
 
 === `catch`
@@ -72,29 +74,28 @@ If the result of a target query fails (due to incorrect types, failed parsing, e
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.id = this.thing.id.string().catch(uuid_v4())
+
+# In:  {"thing":{"id":42}}
 ```
 
 The fallback argument can be a mapping, allowing you to capture the error string and yield structured data back.
 
-```coffeescript
+```bloblang
 root.url = this.url.parse_url().catch(err -> {"error":err,"input":this.url})
 
 # In:  {"url":"invalid %&# url"}
-# Out: {"url":{"error":"field `this.url`: parse \"invalid %&\": invalid URL escape \"%&\"","input":"invalid %&# url"}}
 ```
 
 When the input document is not structured attempting to reference structured fields with `this` will result in an error. Therefore, a convenient way to delete non-structured data is with a catch.
 
-```coffeescript
+```bloblang
 root = this.catch(deleted())
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {"doc":{"foo":"bar"}}
 
 # In:  not structured data
-# Out: <Message deleted>
 ```
 
 === `exists`
@@ -108,17 +109,14 @@ Checks that a field, identified via a xref:configuration:field_paths.adoc[dot pa
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.result = this.foo.exists("bar.baz")
 
 # In:  {"foo":{"bar":{"baz":"yep, I exist"}}}
-# Out: {"result":true}
 
 # In:  {"foo":{"bar":{}}}
-# Out: {"result":false}
 
 # In:  {"foo":{}}
-# Out: {"result":false}
 ```
 
 === `from`
@@ -134,9 +132,11 @@ Modifies a target query such that certain functions are executed from the perspe
 
 For example, the following map extracts the contents of the JSON field `foo` specifically from message index `1` of a batch, effectively overriding the field `foo` for all messages of a batch to that of message 1:
 
-```coffeescript
+```bloblang
 root = this
 root.foo = json("foo").from(1)
+
+# In:  [{"foo":"first"},{"foo":"second"},{"foo":"third"}]
 ```
 
 === `from_all`
@@ -146,9 +146,11 @@ Modifies a target query such that certain functions are executed from the perspe
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this
 root.foo_summed = json("foo").from_all().sum()
+
+# In:  [{"foo":10},{"foo":20},{"foo":30}]
 ```
 
 === `or`
@@ -162,8 +164,10 @@ If the result of the target query fails or resolves to `null`, returns the argum
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.id = this.thing.id.or(uuid_v4())
+
+# In:  {"thing":{"id":"abc123"}}
 ```
 
 == String Manipulation
@@ -175,11 +179,10 @@ Takes a string value and returns a copy with all Unicode letters that begin word
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.title = this.title.capitalize()
 
 # In:  {"title":"the foo bar"}
-# Out: {"title":"The Foo Bar"}
 ```
 
 === `compare_argon2`
@@ -193,18 +196,16 @@ Checks whether a string matches a hashed secret using Argon2.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.match = this.secret.compare_argon2("$argon2id$v=19$m=4096,t=3,p=1$c2FsdHktbWNzYWx0ZmFjZQ$RMUMwgtS32/mbszd+ke4o4Ej1jFpYiUqY6MHWa69X7Y")
 
 # In:  {"secret":"there-are-many-blobs-in-the-sea"}
-# Out: {"match":true}
 ```
 
-```coffeescript
+```bloblang
 root.match = this.secret.compare_argon2("$argon2id$v=19$m=4096,t=3,p=1$c2FsdHktbWNzYWx0ZmFjZQ$RMUMwgtS32/mbszd+ke4o4Ej1jFpYiUqY6MHWa69X7Y")
 
 # In:  {"secret":"will-i-ever-find-love"}
-# Out: {"match":false}
 ```
 
 === `compare_bcrypt`
@@ -218,18 +219,16 @@ Checks whether a string matches a hashed secret using bcrypt.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")
 
 # In:  {"secret":"there-are-many-blobs-in-the-sea"}
-# Out: {"match":true}
 ```
 
-```coffeescript
+```bloblang
 root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")
 
 # In:  {"secret":"will-i-ever-find-love"}
-# Out: {"match":false}
 ```
 
 === `contains`
@@ -243,14 +242,12 @@ Checks whether a string contains a substring and returns a boolean result.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.has_foo = this.thing.contains("foo")
 
 # In:  {"thing":"this foo that"}
-# Out: {"has_foo":true}
 
 # In:  {"thing":"this bar that"}
-# Out: {"has_foo":false}
 ```
 
 === `escape_html`
@@ -260,11 +257,10 @@ Escapes a string so that special characters like `<` to become `&lt;`. It escape
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.escaped = this.value.escape_html()
 
 # In:  {"value":"foo & bar"}
-# Out: {"escaped":"foo &amp; bar"}
 ```
 
 === `escape_url_query`
@@ -274,11 +270,10 @@ Escapes a string so that it can be safely placed within a URL query.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.escaped = this.value.escape_url_query()
 
 # In:  {"value":"foo & bar"}
-# Out: {"escaped":"foo+%26+bar"}
 ```
 
 === `filepath_join`
@@ -288,11 +283,10 @@ Joins an array of path elements into a single file path. The separator depends o
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.path = this.path_elements.filepath_join()
 
 # In:  {"path_elements":["/foo/","bar.txt"]}
-# Out: {"path":"/foo/bar.txt"}
 ```
 
 === `filepath_split`
@@ -302,14 +296,12 @@ Splits a file path immediately following the final Separator, separating it into
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.path_sep = this.path.filepath_split()
 
 # In:  {"path":"/foo/bar.txt"}
-# Out: {"path_sep":["/foo/","bar.txt"]}
 
 # In:  {"path":"baz.txt"}
-# Out: {"path_sep":["","baz.txt"]}
 ```
 
 === `format`
@@ -319,11 +311,10 @@ Use a value string as a format specifier in order to produce a new string, using
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = "%s(%v): %v".format(this.name, this.age, this.fingers)
 
 # In:  {"name":"lance","age":37,"fingers":13}
-# Out: {"foo":"lance(37): 13"}
 ```
 
 === `has_prefix`
@@ -337,12 +328,11 @@ Checks whether a string has a prefix argument and returns a bool.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.t1 = this.v1.has_prefix("foo")
 root.t2 = this.v2.has_prefix("foo")
 
 # In:  {"v1":"foobar","v2":"barfoo"}
-# Out: {"t1":true,"t2":false}
 ```
 
 === `has_suffix`
@@ -356,12 +346,11 @@ Checks whether a string has a suffix argument and returns a bool.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.t1 = this.v1.has_suffix("foo")
 root.t2 = this.v2.has_suffix("foo")
 
 # In:  {"v1":"foobar","v2":"barfoo"}
-# Out: {"t1":false,"t2":true}
 ```
 
 === `index_of`
@@ -375,18 +364,16 @@ Returns the starting index of the argument substring in a string target, or `-1`
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.index = this.thing.index_of("bar")
 
 # In:  {"thing":"foobar"}
-# Out: {"index":3}
 ```
 
-```coffeescript
+```bloblang
 root.index = content().index_of("meow")
 
 # In:  the cat meowed, the dog woofed
-# Out: {"index":8}
 ```
 
 === `length`
@@ -396,11 +383,10 @@ Returns the length of a string.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_len = this.foo.length()
 
 # In:  {"foo":"hello world"}
-# Out: {"foo_len":11}
 ```
 
 === `lowercase`
@@ -410,11 +396,10 @@ Convert a string value into lowercase.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.lowercase()
 
 # In:  {"foo":"HELLO WORLD"}
-# Out: {"foo":"hello world"}
 ```
 
 === `quote`
@@ -424,11 +409,10 @@ Quotes a target string using escape sequences (`\t`, `\n`, `\xFF`, `\u0100`) for
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.quoted = this.thing.quote()
 
 # In:  {"thing":"foo\nbar"}
-# Out: {"quoted":"\"foo\\nbar\""}
 ```
 
 === `replace_all`
@@ -443,11 +427,10 @@ Replaces all occurrences of the first argument in a target string with the secon
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.replace_all("foo","dog")
 
 # In:  {"value":"The foo ate my homework"}
-# Out: {"new_value":"The dog ate my homework"}
 ```
 
 === `replace_all_many`
@@ -461,7 +444,7 @@ For each pair of strings in an argument array, replaces all occurrences of the f
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.replace_all_many([
   "<b>", "&lt;b&gt;",
   "</b>", "&lt;/b&gt;",
@@ -470,7 +453,6 @@ root.new_value = this.value.replace_all_many([
 ])
 
 # In:  {"value":"<i>Hello</i> <b>World</b>"}
-# Out: {"new_value":"&lt;i&gt;Hello&lt;/i&gt; &lt;b&gt;World&lt;/b&gt;"}
 ```
 
 === `repeat`
@@ -484,25 +466,22 @@ Returns a string consisting of the target string repeated a specified number of 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.repeated = this.value.repeat(3)
 
 # In:  {"value":"hello"}
-# Out: {"repeated":"hellohellohello"}
 ```
 
-```coffeescript
+```bloblang
 root.border = "-".repeat(20)
 
 # In:  {}
-# Out: {"border":"--------------------"}
 ```
 
-```coffeescript
+```bloblang
 root.dynamic = this.char.repeat(this.count)
 
 # In:  {"char":"*","count":5}
-# Out: {"dynamic":"*****"}
 ```
 
 === `reverse`
@@ -512,18 +491,16 @@ Returns the target string in reverse order.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.reversed = this.thing.reverse()
 
 # In:  {"thing":"backwards"}
-# Out: {"reversed":"sdrawkcab"}
 ```
 
-```coffeescript
+```bloblang
 root = content().reverse()
 
 # In:  {"thing":"backwards"}
-# Out: }"sdrawkcab":"gniht"{
 ```
 
 === `slice`
@@ -539,22 +516,20 @@ Extract a slice from a string by specifying two indices, a low and high bound, w
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.beginning = this.value.slice(0, 2)
 root.end = this.value.slice(4)
 
 # In:  {"value":"foo bar"}
-# Out: {"beginning":"fo","end":"bar"}
 ```
 
 A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.
 
-```coffeescript
+```bloblang
 root.last_chunk = this.value.slice(-4)
 root.the_rest = this.value.slice(0, -4)
 
 # In:  {"value":"foo bar"}
-# Out: {"last_chunk":" bar","the_rest":"foo"}
 ```
 
 === `slug`
@@ -576,20 +551,18 @@ endif::[]
 
 Creates a slug from an English string
 
-```coffeescript
+```bloblang
 root.slug = this.value.slug()
 
 # In:  {"value":"Gopher & Benthos"}
-# Out: {"slug":"gopher-and-benthos"}
 ```
 
 Creates a slug from a French string
 
-```coffeescript
+```bloblang
 root.slug = this.value.slug("fr")
 
 # In:  {"value":"Gaufre & Poisson d'Eau Profonde"}
-# Out: {"slug":"gaufre-et-poisson-deau-profonde"}
 ```
 
 === `split`
@@ -603,11 +576,10 @@ Split a string value into an array of strings by splitting it on a string separa
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.split(",")
 
 # In:  {"value":"foo,bar,baz"}
-# Out: {"new_value":["foo","bar","baz"]}
 ```
 
 === `strip_html`
@@ -621,20 +593,18 @@ Attempts to remove all HTML tags from a target string.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.stripped = this.value.strip_html()
 
 # In:  {"value":"<p>the plain <strong>old text</strong></p>"}
-# Out: {"stripped":"the plain old text"}
 ```
 
 It's also possible to provide an explicit list of element types to preserve in the output.
 
-```coffeescript
+```bloblang
 root.stripped = this.value.strip_html(["article"])
 
 # In:  {"value":"<article><p>the plain <strong>old text</strong></p></article>"}
-# Out: {"stripped":"<article>the plain old text</article>"}
 ```
 
 === `trim`
@@ -648,12 +618,11 @@ Remove all leading and trailing characters from a string that are contained with
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.title = this.title.trim("!?")
 root.description = this.description.trim()
 
 # In:  {"description":"  something happened and its amazing! ","title":"!!!watch out!?"}
-# Out: {"description":"something happened and its amazing!","title":"watch out"}
 ```
 
 === `trim_prefix`
@@ -671,12 +640,11 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.name = this.name.trim_prefix("foobar_")
 root.description = this.description.trim_prefix("foobar_")
 
 # In:  {"description":"unchanged","name":"foobar_blobton"}
-# Out: {"description":"unchanged","name":"blobton"}
 ```
 
 === `trim_suffix`
@@ -694,12 +662,11 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.name = this.name.trim_suffix("_foobar")
 root.description = this.description.trim_suffix("_foobar")
 
 # In:  {"description":"unchanged","name":"blobton_foobar"}
-# Out: {"description":"unchanged","name":"blobton"}
 ```
 
 === `unescape_html`
@@ -709,11 +676,10 @@ Unescapes a string so that entities like `&lt;` become `<`. It unescapes a large
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.unescaped = this.value.unescape_html()
 
 # In:  {"value":"foo &amp; bar"}
-# Out: {"unescaped":"foo & bar"}
 ```
 
 === `unescape_url_query`
@@ -723,11 +689,10 @@ Expands escape sequences from a URL query string.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.unescaped = this.value.unescape_url_query()
 
 # In:  {"value":"foo+%26+bar"}
-# Out: {"unescaped":"foo & bar"}
 ```
 
 === `unicode_segments`
@@ -744,27 +709,24 @@ Splits a string into segments using https://hexdocs.pm/unicode_string/readme.htm
 
 * Splits a string into separate sentences.
 +
-```coffeescript
+```bloblang
 root.sentences = this.value.unicode_segments("sentence")
 
 # In:  {"value":"This is sentence 1.0. And this is sentence two."}
-# Out: {"sentences":["This is sentence 1.0.","And this is sentence two."]}
 ```
 * Splits a string into separate graphemes.
 +
-```coffeescript
+```bloblang
 root.graphemes = this.value.unicode_segments("grapheme")
 
 # In:  {"value":"🐕‍🦺 🫠"}
-# Out: {"graphemes":["🐕‍🦺"," ","🫠"]}
 ```
 * Tokenizes a string based on Unicode word segmentation rules, including punctuation and spaces.
 +
-```coffeescript
+```bloblang
 root.words = this.value.unicode_segments("word")
 
 # In:  {"value":"Hello, world!"}
-# Out: {"words":["Hello",","," ","world","!"]}
 ```
 
 === `unquote`
@@ -774,11 +736,10 @@ Unquotes a target string, expanding any escape sequences (`\t`, `\n`, `\xFF`, `\
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.unquoted = this.thing.unquote()
 
 # In:  {"thing":"\"foo\\nbar\""}
-# Out: {"unquoted":"foo\nbar"}
 ```
 
 === `uppercase`
@@ -788,11 +749,10 @@ Convert a string value into uppercase.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.uppercase()
 
 # In:  {"foo":"hello world"}
-# Out: {"foo":"HELLO WORLD"}
 ```
 
 == Regular Expressions
@@ -808,11 +768,10 @@ Returns an array containing all successive matches of a regular expression in a 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_all("a.")
 
 # In:  {"value":"paranormal"}
-# Out: {"matches":["ar","an","al"]}
 ```
 
 === `re_find_all_object`
@@ -826,18 +785,16 @@ Returns an array of objects containing all matches of the regular expression and
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_all_object("a(?P<foo>x*)b")
 
 # In:  {"value":"-axxb-ab-"}
-# Out: {"matches":[{"0":"axxb","foo":"xx"},{"0":"ab","foo":""}]}
 ```
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_all_object("(?m)(?P<key>\\w+):\\s+(?P<value>\\w+)$")
 
 # In:  {"value":"option1: value1\noption2: value2\noption3: value3"}
-# Out: {"matches":[{"0":"option1: value1","key":"option1","value":"value1"},{"0":"option2: value2","key":"option2","value":"value2"},{"0":"option3: value3","key":"option3","value":"value3"}]}
 ```
 
 === `re_find_all_submatch`
@@ -851,11 +808,10 @@ Returns an array of arrays containing all successive matches of the regular expr
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_all_submatch("a(x*)b")
 
 # In:  {"value":"-axxb-ab-"}
-# Out: {"matches":[["axxb","xx"],["ab",""]]}
 ```
 
 === `re_find_object`
@@ -869,18 +825,16 @@ Returns an object containing the first match of the regular expression and the m
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_object("a(?P<foo>x*)b")
 
 # In:  {"value":"-axxb-ab-"}
-# Out: {"matches":{"0":"axxb","foo":"xx"}}
 ```
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_find_object("(?P<key>\\w+):\\s+(?P<value>\\w+)")
 
 # In:  {"value":"option1: value1"}
-# Out: {"matches":{"0":"option1: value1","key":"option1","value":"value1"}}
 ```
 
 === `re_match`
@@ -894,14 +848,12 @@ Checks whether a regular expression matches against any part of a string and ret
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.matches = this.value.re_match("[0-9]")
 
 # In:  {"value":"there are 10 puppies"}
-# Out: {"matches":true}
 
 # In:  {"value":"there are ten puppies"}
-# Out: {"matches":false}
 ```
 
 === `re_replace_all`
@@ -916,11 +868,10 @@ Replaces all occurrences of the argument regular expression in a string with a v
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.re_replace_all("ADD ([0-9]+)","+($1)")
 
 # In:  {"value":"foo ADD 70"}
-# Out: {"new_value":"foo +(70)"}
 ```
 
 == Number Manipulation
@@ -932,13 +883,12 @@ Returns the absolute value of an int64 or float64 number. As a special case, whe
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.outs = this.ins.map_each(ele -> ele.abs())
 
 
 # In:  {"ins":[9,-18,1.23,-4.56]}
-# Out: {"outs":[9,18,1.23,4.56]}
 ```
 
 === `bitwise_and`
@@ -959,17 +909,14 @@ This operation is often used for masking bits.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.bitwise_and(6)
 
 # In:  {"value":12}
-# Out: {"new_value":4}
 
 # In:  {"value":0}
-# Out: {"new_value":0}
 
 # In:  {"value":-4}
-# Out: {"new_value":4}
 ```
 
 === `bitwise_or`
@@ -991,17 +938,14 @@ This operation is useful for setting or combining flags.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.bitwise_or(6)
 
 # In:  {"value":12}
-# Out: {"new_value":14}
 
 # In:  {"value":0}
-# Out: {"new_value":6}
 
 # In:  {"value":-2}
-# Out: {"new_value":-2}
 ```
 
 === `bitwise_xor`
@@ -1015,17 +959,14 @@ Returns the result of bitwise XOR between the input number and a specified value
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.bitwise_xor(6)
 
 # In:  {"value":12}
-# Out: {"new_value":10}
 
 # In:  {"value":0}
-# Out: {"new_value":6}
 
 # In:  {"value":-2}
-# Out: {"new_value":-8}
 ```
 
 === `ceil`
@@ -1035,14 +976,12 @@ Returns the least integer value greater than or equal to a number. If the result
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.ceil()
 
 # In:  {"value":5.3}
-# Out: {"new_value":6}
 
 # In:  {"value":-5.9}
-# Out: {"new_value":-5}
 ```
 
 === `cos`
@@ -1052,17 +991,14 @@ Calculates the cosine of a given angle specified in radians.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = (this.value * (pi() / 180)).cos()
 
 # In:  {"value":45}
-# Out: {"new_value":0.7071067811865476}
 
 # In:  {"value":0}
-# Out: {"new_value":1}
 
 # In:  {"value":180}
-# Out: {"new_value":-1}
 ```
 
 === `float32`
@@ -1075,13 +1011,12 @@ If the value is a string then an attempt will be made to parse it as a 32-bit fl
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.out = this.in.float32()
 
 
 # In:  {"in":"6.674282313423543523453425345e-11"}
-# Out: {"out":6.674283e-11}
 ```
 
 === `float64`
@@ -1094,13 +1029,12 @@ If the value is a string then an attempt will be made to parse it as a 64-bit fl
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.out = this.in.float64()
 
 
 # In:  {"in":"6.674282313423543523453425345e-11"}
-# Out: {"out":6.674282313423544e-11}
 ```
 
 === `floor`
@@ -1110,11 +1044,10 @@ Returns the greatest integer value less than or equal to the target number. If t
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.floor()
 
 # In:  {"value":5.7}
-# Out: {"new_value":5}
 ```
 
 === `int16`
@@ -1127,7 +1060,7 @@ If the value is a string then an attempt will be made to parse it as a 16-bit si
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.int16()
 root.b = this.b.round().int16()
@@ -1136,16 +1069,14 @@ root.d = this.d.int16().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":-12}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.int16()
 
 
 # In:  "0xDE"
-# Out: 222
 ```
 
 === `int32`
@@ -1158,7 +1089,7 @@ If the value is a string then an attempt will be made to parse it as a 32-bit si
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.int32()
 root.b = this.b.round().int32()
@@ -1167,16 +1098,14 @@ root.d = this.d.int32().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":-12}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.int32()
 
 
 # In:  "0xDEAD"
-# Out: 57005
 ```
 
 === `int64`
@@ -1189,7 +1118,7 @@ If the value is a string then an attempt will be made to parse it as a 64-bit si
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.int64()
 root.b = this.b.round().int64()
@@ -1198,16 +1127,14 @@ root.d = this.d.int64().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":-12}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.int64()
 
 
 # In:  "0xDEADBEEF"
-# Out: 3735928559
 ```
 
 === `int8`
@@ -1220,7 +1147,7 @@ If the value is a string then an attempt will be made to parse it as a 8-bit sig
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.int8()
 root.b = this.b.round().int8()
@@ -1229,16 +1156,14 @@ root.d = this.d.int8().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":-12}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.int8()
 
 
 # In:  "0xD"
-# Out: 13
 ```
 
 === `log`
@@ -1248,14 +1173,12 @@ Returns the natural logarithm of a number.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.log().round()
 
 # In:  {"value":1}
-# Out: {"new_value":0}
 
 # In:  {"value":2.7183}
-# Out: {"new_value":1}
 ```
 
 === `log10`
@@ -1265,14 +1188,12 @@ Returns the decimal logarithm of a number.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.log10()
 
 # In:  {"value":100}
-# Out: {"new_value":2}
 
 # In:  {"value":1000}
-# Out: {"new_value":3}
 ```
 
 === `max`
@@ -1282,21 +1203,18 @@ Returns the largest numerical value found within an array. All values must be nu
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.biggest = this.values.max()
 
 # In:  {"values":[0,3,2.5,7,5]}
-# Out: {"biggest":7}
 ```
 
-```coffeescript
+```bloblang
 root.new_value = [0,this.value].max()
 
 # In:  {"value":-1}
-# Out: {"new_value":0}
 
 # In:  {"value":7}
-# Out: {"new_value":7}
 ```
 
 === `min`
@@ -1306,21 +1224,18 @@ Returns the smallest numerical value found within an array. All values must be n
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.smallest = this.values.min()
 
 # In:  {"values":[0,3,-2.5,7,5]}
-# Out: {"smallest":-2.5}
 ```
 
-```coffeescript
+```bloblang
 root.new_value = [10,this.value].min()
 
 # In:  {"value":2}
-# Out: {"new_value":2}
 
 # In:  {"value":23}
-# Out: {"new_value":10}
 ```
 
 === `pow`
@@ -1334,18 +1249,16 @@ Returns the number raised to the specified exponent.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value * 10.pow(-2)
 
 # In:  {"value":2}
-# Out: {"new_value":0.02}
 ```
 
-```coffeescript
+```bloblang
 root.new_value = this.value.pow(-2)
 
 # In:  {"value":2}
-# Out: {"new_value":0.25}
 ```
 
 === `round`
@@ -1355,14 +1268,12 @@ Rounds numbers to the nearest integer, rounding half away from zero. If the resu
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = this.value.round()
 
 # In:  {"value":5.3}
-# Out: {"new_value":5}
 
 # In:  {"value":5.9}
-# Out: {"new_value":6}
 ```
 
 === `sin`
@@ -1372,17 +1283,14 @@ Calculates the sine of a given angle specified in radians.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = (this.value * (pi() / 180)).sin()
 
 # In:  {"value":45}
-# Out: {"new_value":0.7071067811865475}
 
 # In:  {"value":0}
-# Out: {"new_value":0}
 
 # In:  {"value":90}
-# Out: {"new_value":1}
 ```
 
 === `tan`
@@ -1392,17 +1300,14 @@ Calculates the tangent of a given angle specified in radians.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_value = "%f".format((this.value * (pi() / 180)).tan())
 
 # In:  {"value":0}
-# Out: {"new_value":"0.000000"}
 
 # In:  {"value":45}
-# Out: {"new_value":"1.000000"}
 
 # In:  {"value":180}
-# Out: {"new_value":"-0.000000"}
 ```
 
 === `uint16`
@@ -1415,7 +1320,7 @@ If the value is a string then an attempt will be made to parse it as a 16-bit un
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.uint16()
 root.b = this.b.round().uint16()
@@ -1424,16 +1329,14 @@ root.d = this.d.uint16().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":0}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.uint16()
 
 
 # In:  "0xDE"
-# Out: 222
 ```
 
 === `uint32`
@@ -1446,7 +1349,7 @@ If the value is a string then an attempt will be made to parse it as a 32-bit un
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.uint32()
 root.b = this.b.round().uint32()
@@ -1455,16 +1358,14 @@ root.d = this.d.uint32().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":0}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.uint32()
 
 
 # In:  "0xDEAD"
-# Out: 57005
 ```
 
 === `uint64`
@@ -1477,7 +1378,7 @@ If the value is a string then an attempt will be made to parse it as a 64-bit un
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.uint64()
 root.b = this.b.round().uint64()
@@ -1486,16 +1387,14 @@ root.d = this.d.uint64().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":0}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.uint64()
 
 
 # In:  "0xDEADBEEF"
-# Out: 3735928559
 ```
 
 === `uint8`
@@ -1508,7 +1407,7 @@ If the value is a string then an attempt will be made to parse it as a 8-bit uns
 ==== Examples
 
 
-```coffeescript
+```bloblang
 
 root.a = this.a.uint8()
 root.b = this.b.round().uint8()
@@ -1517,16 +1416,14 @@ root.d = this.d.uint8().catch(0)
 
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
-# Out: {"a":12,"b":12,"c":12,"d":0}
 ```
 
-```coffeescript
+```bloblang
 
 root = this.uint8()
 
 
 # In:  "0xD"
-# Out: 13
 ```
 
 == Timestamp Manipulation
@@ -1538,18 +1435,16 @@ Attempts to parse a string as a duration and returns an integer of nanoseconds. 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.delay_for_ns = this.delay_for.parse_duration()
 
 # In:  {"delay_for":"50us"}
-# Out: {"delay_for_ns":50000}
 ```
 
-```coffeescript
+```bloblang
 root.delay_for_s = this.delay_for.parse_duration() / 1000000000
 
 # In:  {"delay_for":"2h"}
-# Out: {"delay_for_s":7200}
 ```
 
 === `parse_duration_iso8601`
@@ -1563,29 +1458,26 @@ Attempts to parse a string using ISO-8601 rules as a duration and returns an int
 
 Arbitrary ISO-8601 duration string to nanoseconds:
 
-```coffeescript
+```bloblang
 root.delay_for_ns = this.delay_for.parse_duration_iso8601()
 
 # In:  {"delay_for":"P3Y6M4DT12H30M5S"}
-# Out: {"delay_for_ns":110839937000000000}
 ```
 
 Two hours ISO-8601 duration string to seconds:
 
-```coffeescript
+```bloblang
 root.delay_for_s = this.delay_for.parse_duration_iso8601() / 1000000000
 
 # In:  {"delay_for":"PT2H"}
-# Out: {"delay_for_s":7200}
 ```
 
 Two and a half seconds ISO-8601 duration string to seconds:
 
-```coffeescript
+```bloblang
 root.delay_for_s = this.delay_for.parse_duration_iso8601() / 1000000000
 
 # In:  {"delay_for":"PT2.5S"}
-# Out: {"delay_for_s":2.5}
 ```
 
 === `ts_add_iso8601`
@@ -1614,38 +1506,38 @@ The output format is defined by showing how the reference time, defined to be Mo
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.something_at = (this.created_at + 300).ts_format()
+
+# In:  {"created_at":1597405526}
 ```
 
 An optional string argument can be used in order to specify the output format of the timestamp. The format is defined by showing how the reference time, defined to be Mon Jan 2 15:04:05 -0700 MST 2006, would be displayed if it were the value.
 
-```coffeescript
+```bloblang
 root.something_at = (this.created_at + 300).ts_format("2006-Jan-02 15:04:05")
+
+# In:  {"created_at":1597405526}
 ```
 
 A second optional string argument can also be used in order to specify a timezone, otherwise the timezone of the input string is used, or in the case of unix timestamps the local timezone is used.
 
-```coffeescript
+```bloblang
 root.something_at = this.created_at.ts_format(format: "2006-Jan-02 15:04:05", tz: "UTC")
 
 # In:  {"created_at":1597405526}
-# Out: {"something_at":"2020-Aug-14 11:45:26"}
 
 # In:  {"created_at":"2020-08-14T11:50:26.371Z"}
-# Out: {"something_at":"2020-Aug-14 11:50:26"}
 ```
 
 And `ts_format` supports up to nanosecond precision with floating point timestamp values.
 
-```coffeescript
+```bloblang
 root.something_at = this.created_at.ts_format("2006-Jan-02 15:04:05.999999", "UTC")
 
 # In:  {"created_at":1597405526.123456}
-# Out: {"something_at":"2020-Aug-14 11:45:26.123456"}
 
 # In:  {"created_at":"2020-08-14T11:50:26.371Z"}
-# Out: {"something_at":"2020-Aug-14 11:50:26.371"}
 ```
 
 === `ts_parse`
@@ -1663,11 +1555,10 @@ The input format is defined by showing how the reference time, defined to be Mon
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc.timestamp = this.doc.timestamp.ts_parse("2006-Jan-02")
 
 # In:  {"doc":{"timestamp":"2020-Aug-14"}}
-# Out: {"doc":{"timestamp":"2020-08-14T00:00:00Z"}}
 ```
 
 === `ts_round`
@@ -1689,11 +1580,10 @@ endif::[]
 
 Use the method `parse_duration` to convert a duration string into an integer argument.
 
-```coffeescript
+```bloblang
 root.created_at_hour = this.created_at.ts_round("1h".parse_duration())
 
 # In:  {"created_at":"2020-08-14T05:54:23Z"}
-# Out: {"created_at_hour":"2020-08-14T06:00:00Z"}
 ```
 
 === `ts_strftime`
@@ -1712,32 +1602,30 @@ Attempts to format a timestamp value as a string according to a specified strfti
 
 The format consists of zero or more conversion specifiers and ordinary characters (except `%`). All ordinary characters are copied to the output string without modification. Each conversion specification begins with `%` character followed by the character that determines the behavior of the specifier. Please refer to https://linux.die.net/man/3/strftime[man 3 strftime] for the list of format specifiers.
 
-```coffeescript
+```bloblang
 root.something_at = (this.created_at + 300).ts_strftime("%Y-%b-%d %H:%M:%S")
+
+# In:  {"created_at":1597405526}
 ```
 
 A second optional string argument can also be used in order to specify a timezone, otherwise the timezone of the input string is used, or in the case of unix timestamps the local timezone is used.
 
-```coffeescript
+```bloblang
 root.something_at = this.created_at.ts_strftime("%Y-%b-%d %H:%M:%S", "UTC")
 
 # In:  {"created_at":1597405526}
-# Out: {"something_at":"2020-Aug-14 11:45:26"}
 
 # In:  {"created_at":"2020-08-14T11:50:26.371Z"}
-# Out: {"something_at":"2020-Aug-14 11:50:26"}
 ```
 
 As an extension provided by the underlying formatting library, https://github.com/itchyny/timefmt-go[itchyny/timefmt-go], the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.
 
-```coffeescript
+```bloblang
 root.something_at = this.created_at.ts_strftime("%Y-%b-%d %H:%M:%S.%f", "UTC")
 
 # In:  {"created_at":1597405526}
-# Out: {"something_at":"2020-Aug-14 11:45:26.000000"}
 
 # In:  {"created_at":"2020-08-14T11:50:26.371Z"}
-# Out: {"something_at":"2020-Aug-14 11:50:26.371000"}
 ```
 
 === `ts_strptime`
@@ -1755,20 +1643,18 @@ Attempts to parse a string as a timestamp following a specified strptime-compati
 
 The format consists of zero or more conversion specifiers and ordinary characters (except `%`). All ordinary characters are copied to the output string without modification. Each conversion specification begins with a `%` character followed by the character that determines the behavior of the specifier. Please refer to https://linux.die.net/man/3/strptime[man 3 strptime] for the list of format specifiers.
 
-```coffeescript
+```bloblang
 root.doc.timestamp = this.doc.timestamp.ts_strptime("%Y-%b-%d")
 
 # In:  {"doc":{"timestamp":"2020-Aug-14"}}
-# Out: {"doc":{"timestamp":"2020-08-14T00:00:00Z"}}
 ```
 
 As an extension provided by the underlying formatting library, https://github.com/itchyny/timefmt-go[itchyny/timefmt-go], the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.
 
-```coffeescript
+```bloblang
 root.doc.timestamp = this.doc.timestamp.ts_strptime("%Y-%b-%d %H:%M:%S.%f")
 
 # In:  {"doc":{"timestamp":"2020-Aug-14 11:50:26.371000"}}
-# Out: {"doc":{"timestamp":"2020-08-14T11:50:26.371Z"}}
 ```
 
 === `ts_sub`
@@ -1790,11 +1676,10 @@ endif::[]
 
 Use the `.abs()` method in order to calculate an absolute duration between two timestamps.
 
-```coffeescript
+```bloblang
 root.between = this.started_at.ts_sub("2020-08-14T05:54:23Z").abs()
 
 # In:  {"started_at":"2020-08-13T05:54:23Z"}
-# Out: {"between":86400000000000}
 ```
 
 === `ts_sub_iso8601`
@@ -1824,11 +1709,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.created_at_utc = this.created_at.ts_tz("UTC")
 
 # In:  {"created_at":"2021-02-03T17:05:06+01:00"}
-# Out: {"created_at_utc":"2021-02-03T16:05:06Z"}
 ```
 
 === `ts_unix`
@@ -1840,11 +1724,10 @@ Attempts to format a timestamp value as a unix timestamp. Timestamp values can e
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.created_at_unix = this.created_at.ts_unix()
 
 # In:  {"created_at":"2009-11-10T23:00:00Z"}
-# Out: {"created_at_unix":1257894000}
 ```
 
 === `ts_unix_micro`
@@ -1856,11 +1739,10 @@ Attempts to format a timestamp value as a unix timestamp with microsecond precis
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.created_at_unix = this.created_at.ts_unix_micro()
 
 # In:  {"created_at":"2009-11-10T23:00:00Z"}
-# Out: {"created_at_unix":1257894000000000}
 ```
 
 === `ts_unix_milli`
@@ -1872,11 +1754,10 @@ Attempts to format a timestamp value as a unix timestamp with millisecond precis
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.created_at_unix = this.created_at.ts_unix_milli()
 
 # In:  {"created_at":"2009-11-10T23:00:00Z"}
-# Out: {"created_at_unix":1257894000000}
 ```
 
 === `ts_unix_nano`
@@ -1888,11 +1769,10 @@ Attempts to format a timestamp value as a unix timestamp with nanosecond precisi
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.created_at_unix = this.created_at.ts_unix_nano()
 
 # In:  {"created_at":"2009-11-10T23:00:00Z"}
-# Out: {"created_at_unix":1257894000000000000}
 ```
 
 == Type Coercion
@@ -1904,11 +1784,10 @@ Return an array containing the target value. If the value is already an array it
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.my_array = this.name.array()
 
 # In:  {"name":"foobar bazson"}
-# Out: {"my_array":["foobar bazson"]}
 ```
 
 === `bool`
@@ -1922,9 +1801,11 @@ Attempt to parse a value into a boolean. An optional argument can be provided, i
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.thing.bool()
 root.bar = this.thing.bool(true)
+
+# In:  {"thing":"true"}
 ```
 
 === `bytes`
@@ -1934,11 +1815,10 @@ Marshal a value into a byte array. If the value is already a byte array it is un
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.first_byte = this.name.bytes().index(0)
 
 # In:  {"name":"foobar bazson"}
-# Out: {"first_byte":102}
 ```
 
 === `not_empty`
@@ -1948,26 +1828,20 @@ Ensures that the given string, array or object value is not empty, and if so ret
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.a = this.a.not_empty()
 
 # In:  {"a":"foo"}
-# Out: {"a":"foo"}
 
 # In:  {"a":""}
-# Out: Error("failed assignment (line 1): field `this.a`: string value is empty")
 
 # In:  {"a":["foo","bar"]}
-# Out: {"a":["foo","bar"]}
 
 # In:  {"a":[]}
-# Out: Error("failed assignment (line 1): field `this.a`: array value is empty")
 
 # In:  {"a":{"b":"foo","c":"bar"}}
-# Out: {"a":{"b":"foo","c":"bar"}}
 
 # In:  {"a":{}}
-# Out: Error("failed assignment (line 1): field `this.a`: object value is empty")
 ```
 
 === `not_null`
@@ -1977,14 +1851,12 @@ Ensures that the given value is not `null`, and if so returns it, otherwise an e
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.a = this.a.not_null()
 
 # In:  {"a":"foobar","b":"barbaz"}
-# Out: {"a":"foobar"}
 
 # In:  {"b":"barbaz"}
-# Out: Error("failed assignment (line 1): field `this.a`: value is null")
 ```
 
 === `number`
@@ -1998,9 +1870,11 @@ Attempt to parse a value into a number. An optional argument can be provided, in
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.thing.number() + 10
 root.bar = this.thing.number(5) * 10
+
+# In:  {"thing":"25"}
 ```
 
 === `string`
@@ -2009,18 +1883,16 @@ Marshal a value into a string. If the value is already a string it is unchanged.
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.nested_json = this.string()
 
 # In:  {"foo":"bar"}
-# Out: {"nested_json":"{\"foo\":\"bar\"}"}
 ```
 
-```coffeescript
+```bloblang
 root.id = this.id.string()
 
 # In:  {"id":228930314431312345}
-# Out: {"id":"228930314431312345"}
 ```
 
 === `timestamp`
@@ -2039,9 +1911,11 @@ You can also provide an optional argument, which is returned when the value cann
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.creation_time = this.ts.timestamp()
 root.default_time = this.none.timestamp(1734443120.timestamp())
+
+# In:  {"ts":1734443120}
 ```
 
 === `type`
@@ -2051,48 +1925,39 @@ Returns the type of a value as a string, providing one of the following values: 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.bar_type = this.bar.type()
 root.foo_type = this.foo.type()
 
 # In:  {"bar":10,"foo":"is a string"}
-# Out: {"bar_type":"number","foo_type":"string"}
 ```
 
-```coffeescript
+```bloblang
 root.type = this.type()
 
 # In:  "foobar"
-# Out: {"type":"string"}
 
 # In:  666
-# Out: {"type":"number"}
 
 # In:  false
-# Out: {"type":"bool"}
 
 # In:  ["foo", "bar"]
-# Out: {"type":"array"}
 
 # In:  {"foo": "bar"}
-# Out: {"type":"object"}
 
 # In:  null
-# Out: {"type":"null"}
 ```
 
-```coffeescript
+```bloblang
 root.type = content().type()
 
 # In:  foobar
-# Out: {"type":"bytes"}
 ```
 
-```coffeescript
+```bloblang
 root.type = this.ts_parse("2006-01-02").type()
 
 # In:  "2022-06-06"
-# Out: {"type":"timestamp"}
 ```
 
 == Object & Array Manipulation
@@ -2108,14 +1973,12 @@ Checks each element of an array against a query and returns true if all elements
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.all_over_21 = this.patrons.all(patron -> patron.age >= 21)
 
 # In:  {"patrons":[{"id":"1","age":18},{"id":"2","age":23}]}
-# Out: {"all_over_21":false}
 
 # In:  {"patrons":[{"id":"1","age":45},{"id":"2","age":23}]}
-# Out: {"all_over_21":true}
 ```
 
 === `any`
@@ -2129,14 +1992,12 @@ Checks the elements of an array against a query and returns true if any element 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.any_over_21 = this.patrons.any(patron -> patron.age >= 21)
 
 # In:  {"patrons":[{"id":"1","age":18},{"id":"2","age":23}]}
-# Out: {"any_over_21":true}
 
 # In:  {"patrons":[{"id":"1","age":10},{"id":"2","age":12}]}
-# Out: {"any_over_21":false}
 ```
 
 === `append`
@@ -2146,11 +2007,10 @@ Returns an array with new elements appended to the end.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.append("and", "this")
 
 # In:  {"foo":["bar","baz"]}
-# Out: {"foo":["bar","baz","and","this"]}
 ```
 
 === `assign`
@@ -2164,11 +2024,10 @@ Merge a source object into an existing destination object. When a collision is f
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.foo.assign(this.bar)
 
 # In:  {"foo":{"first_name":"fooer","likes":"bars"},"bar":{"second_name":"barer","likes":"foos"}}
-# Out: {"first_name":"fooer","likes":"foos","second_name":"barer"}
 ```
 
 === `collapse`
@@ -2182,20 +2041,18 @@ Collapse an array or object into an object of key/value pairs for each field, wh
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.result = this.collapse()
 
 # In:  {"foo":[{"bar":"1"},{"bar":{}},{"bar":"2"},{"bar":[]}]}
-# Out: {"result":{"foo.0.bar":"1","foo.2.bar":"2"}}
 ```
 
 An optional boolean parameter can be set to true in order to include empty objects and arrays.
 
-```coffeescript
+```bloblang
 root.result = this.collapse(include_empty: true)
 
 # In:  {"foo":[{"bar":"1"},{"bar":{}},{"bar":"2"},{"bar":[]}]}
-# Out: {"result":{"foo.0.bar":"1","foo.1.bar":{},"foo.2.bar":"2","foo.3.bar":[]}}
 ```
 
 === `concat`
@@ -2205,11 +2062,10 @@ Concatenates an array value with one or more argument arrays.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.concat(this.bar, this.baz)
 
 # In:  {"foo":["a","b"],"bar":["c"],"baz":["d","e","f"]}
-# Out: {"foo":["a","b","c","d","e","f"]}
 ```
 
 === `contains`
@@ -2223,24 +2079,20 @@ Checks whether an array contains an element matching the argument, or an object 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.has_foo = this.thing.contains("foo")
 
 # In:  {"thing":["this","foo","that"]}
-# Out: {"has_foo":true}
 
 # In:  {"thing":["this","bar","that"]}
-# Out: {"has_foo":false}
 ```
 
-```coffeescript
+```bloblang
 root.has_bar = this.thing.contains(20)
 
 # In:  {"thing":[10.3,20.0,"huh",3]}
-# Out: {"has_bar":true}
 
 # In:  {"thing":[2,3,40,67]}
-# Out: {"has_bar":false}
 ```
 
 === `diff`
@@ -2264,11 +2116,10 @@ Converts an array into a new array of objects, where each object has a field ind
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.enumerated()
 
 # In:  {"foo":["bar","baz"]}
-# Out: {"foo":[{"index":0,"value":"bar"},{"index":1,"value":"baz"}]}
 ```
 
 === `explode`
@@ -2286,22 +2137,20 @@ Explodes an array or object at a xref:configuration:field_paths.adoc[field path]
 
 Exploding arrays results in an array containing elements matching the original document, where the target field of each element is an element of the exploded array:
 
-```coffeescript
+```bloblang
 root = this.explode("value")
 
 # In:  {"id":1,"value":["foo","bar","baz"]}
-# Out: [{"id":1,"value":"foo"},{"id":1,"value":"bar"},{"id":1,"value":"baz"}]
 ```
 
 ##### On objects
 
 Exploding objects results in an object where the keys match the target object, and the values match the original document but with the target field replaced by the exploded value:
 
-```coffeescript
+```bloblang
 root = this.explode("value")
 
 # In:  {"id":1,"value":{"foo":2,"bar":[3,4],"baz":{"bev":5}}}
-# Out: {"bar":{"id":1,"value":[3,4]},"baz":{"id":1,"value":{"bev":5}},"foo":{"id":1,"value":2}}
 ```
 
 === `filter`
@@ -2315,22 +2164,20 @@ Executes a mapping query argument for each element of an array or key/value pair
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_nums = this.nums.filter(num -> num > 10)
 
 # In:  {"nums":[3,11,4,17]}
-# Out: {"new_nums":[11,17]}
 ```
 
 ##### On objects
 
 When filtering objects the mapping query argument is provided a context with a field `key` containing the value key, and a field `value` containing the value.
 
-```coffeescript
+```bloblang
 root.new_dict = this.dict.filter(item -> item.value.contains("foo"))
 
 # In:  {"dict":{"first":"hello foo","second":"world","third":"this foo is great"}}
-# Out: {"new_dict":{"first":"hello foo","third":"this foo is great"}}
 ```
 
 === `find`
@@ -2346,18 +2193,16 @@ Returns the index of the first occurrence of a value in an array. `-1` is return
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.index = this.find("bar")
 
 # In:  ["foo", "bar", "baz"]
-# Out: {"index":1}
 ```
 
-```coffeescript
+```bloblang
 root.index = this.things.find(this.goal)
 
 # In:  {"goal":"bar","things":["foo", "bar", "baz"]}
-# Out: {"index":1}
 ```
 
 === `find_all`
@@ -2373,18 +2218,16 @@ Returns an array containing the indexes of all occurrences of a value in an arra
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.index = this.find_all("bar")
 
 # In:  ["foo", "bar", "baz", "bar"]
-# Out: {"index":[1,3]}
 ```
 
-```coffeescript
+```bloblang
 root.indexes = this.things.find_all(this.goal)
 
 # In:  {"goal":"bar","things":["foo", "bar", "baz", "bar", "buz"]}
-# Out: {"indexes":[1,3]}
 ```
 
 === `find_all_by`
@@ -2400,11 +2243,10 @@ Returns an array containing the indexes of all occurrences of an array where the
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.index = this.find_all_by(v -> v != "bar")
 
 # In:  ["foo", "bar", "baz"]
-# Out: {"index":[0,2]}
 ```
 
 === `find_by`
@@ -2420,11 +2262,10 @@ Returns the index of the first occurrence of an array where the provided query r
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.index = this.find_by(v -> v != "bar")
 
 # In:  ["foo", "bar", "baz"]
-# Out: {"index":0}
 ```
 
 === `flatten`
@@ -2434,11 +2275,10 @@ Iterates an array and any element that is itself an array is removed and has its
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.result = this.flatten()
 
 # In:  ["foo",["bar","baz"],"buz"]
-# Out: {"result":["foo","bar","baz","buz"]}
 ```
 
 === `fold`
@@ -2455,27 +2295,24 @@ The first argument is the value that `tally` will have on the first call.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.sum = this.foo.fold(0, item -> item.tally + item.value)
 
 # In:  {"foo":[3,8,11]}
-# Out: {"sum":22}
 ```
 
-```coffeescript
+```bloblang
 root.result = this.foo.fold("", item -> "%v%v".format(item.tally, item.value))
 
 # In:  {"foo":["hello ", "world"]}
-# Out: {"result":"hello world"}
 ```
 
 You can use fold to merge an array of objects together:
 
-```coffeescript
+```bloblang
 root.smoothie = this.fruits.fold({}, item -> item.tally.merge(item.value))
 
 # In:  {"fruits":[{"apple":5},{"banana":3},{"orange":8}]}
-# Out: {"smoothie":{"apple":5,"banana":3,"orange":8}}
 ```
 
 === `get`
@@ -2489,14 +2326,12 @@ Extract a field value, identified via a xref:configuration:field_paths.adoc[dot 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.result = this.foo.get(this.target)
 
 # In:  {"foo":{"bar":"from bar","baz":"from baz"},"target":"bar"}
-# Out: {"result":"from bar"}
 
 # In:  {"foo":{"bar":"from bar","baz":"from baz"},"target":"baz"}
-# Out: {"result":"from baz"}
 ```
 
 === `index`
@@ -2510,20 +2345,18 @@ Extract an element from an array by an index. The index can be negative, and if 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.last_name = this.names.index(-1)
 
 # In:  {"names":["rachel","stevens"]}
-# Out: {"last_name":"stevens"}
 ```
 
 It is also possible to use this method on byte arrays, in which case the selected element will be returned as an integer.
 
-```coffeescript
+```bloblang
 root.last_byte = this.name.bytes().index(-1)
 
 # In:  {"name":"foobar bazson"}
-# Out: {"last_byte":110}
 ```
 
 === `join`
@@ -2537,12 +2370,11 @@ Join an array of strings with an optional delimiter into a single string.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.joined_words = this.words.join()
 root.joined_numbers = this.numbers.map_each(this.string()).join(",")
 
 # In:  {"words":["hello","world"],"numbers":[3,8,11]}
-# Out: {"joined_numbers":"3,8,11","joined_words":"helloworld"}
 ```
 
 === `json_path`
@@ -2561,21 +2393,18 @@ Executes the given JSONPath expression on an object or array and returns the res
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.all_names = this.json_path("$..name")
 
 # In:  {"name":"alice","foo":{"name":"bob"}}
-# Out: {"all_names":["alice","bob"]}
 
 # In:  {"thing":["this","bar",{"name":"alice"}]}
-# Out: {"all_names":["alice"]}
 ```
 
-```coffeescript
+```bloblang
 root.text_objects = this.json_path("$.body[?(@.type=='text')]")
 
 # In:  {"body":[{"type":"image","id":"foo"},{"type":"text","id":"bar"}]}
-# Out: {"text_objects":[{"id":"bar","type":"text"}]}
 ```
 
 === `json_schema`
@@ -2591,7 +2420,7 @@ Checks a https://json-schema.org/[JSON schema^] against a value and returns the 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.json_schema("""{
   "type":"object",
   "properties":{
@@ -2602,16 +2431,16 @@ root = this.json_schema("""{
 }""")
 
 # In:  {"foo":"bar"}
-# Out: {"foo":"bar"}
 
 # In:  {"foo":5}
-# Out: Error("failed assignment (line 1): field `this`: foo invalid type. expected: string, given: integer")
 ```
 
 In order to load a schema from a file use the `file` function.
 
-```coffeescript
+```bloblang
 root = this.json_schema(file(env("BENTHOS_TEST_BLOBLANG_SCHEMA_FILE")))
+
+# In:  {"foo":"bar"}
 ```
 
 === `key_values`
@@ -2621,11 +2450,10 @@ Returns the key/value pairs of an object as an array, where each element is an o
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_key_values = this.foo.key_values().sort_by(pair -> pair.key)
 
 # In:  {"foo":{"bar":1,"baz":2}}
-# Out: {"foo_key_values":[{"key":"bar","value":1},{"key":"baz","value":2}]}
 ```
 
 === `keys`
@@ -2635,11 +2463,10 @@ Returns the keys of an object as an array.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_keys = this.foo.keys()
 
 # In:  {"foo":{"bar":1,"baz":2}}
-# Out: {"foo_keys":["bar","baz"]}
 ```
 
 === `length`
@@ -2649,14 +2476,12 @@ Returns the length of an array or object (number of keys).
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_len = this.foo.length()
 
 # In:  {"foo":["first","second"]}
-# Out: {"foo_len":2}
 
 # In:  {"foo":{"first":"bar","second":"baz"}}
-# Out: {"foo_len":2}
 ```
 
 === `map_each`
@@ -2674,7 +2499,7 @@ root.foo_len = this.foo.length()
 
 Apply a mapping to each element of an array and replace the element with the result. Within the argument mapping the context is the value of the element being mapped.
 
-```coffeescript
+```bloblang
 root.new_nums = this.nums.map_each(num -> if num < 10 {
   deleted()
 } else {
@@ -2682,18 +2507,16 @@ root.new_nums = this.nums.map_each(num -> if num < 10 {
 })
 
 # In:  {"nums":[3,11,4,17]}
-# Out: {"new_nums":[1,7]}
 ```
 
 ##### On objects
 
 Apply a mapping to each value of an object and replace the value with the result. Within the argument mapping the context is an object with a field `key` containing the value key, and a field `value`.
 
-```coffeescript
+```bloblang
 root.new_dict = this.dict.map_each(item -> item.value.uppercase())
 
 # In:  {"dict":{"foo":"hello","bar":"world"}}
-# Out: {"new_dict":{"bar":"WORLD","foo":"HELLO"}}
 ```
 
 === `map_each_key`
@@ -2707,18 +2530,16 @@ Apply a mapping to each key of an object, and replace the key with the result, w
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.new_dict = this.dict.map_each_key(key -> key.uppercase())
 
 # In:  {"dict":{"keya":"hello","keyb":"world"}}
-# Out: {"new_dict":{"KEYA":"hello","KEYB":"world"}}
 ```
 
-```coffeescript
+```bloblang
 root = this.map_each_key(key -> if key.contains("kafka") { "_" + key })
 
 # In:  {"amqp_key":"foo","kafka_key":"bar","kafka_topic":"baz"}
-# Out: {"_kafka_key":"bar","_kafka_topic":"baz","amqp_key":"foo"}
 ```
 
 === `merge`
@@ -2732,11 +2553,10 @@ Merge a source object into an existing destination object. When a collision is f
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.foo.merge(this.bar)
 
 # In:  {"foo":{"first_name":"fooer","likes":"bars"},"bar":{"second_name":"barer","likes":"foos"}}
-# Out: {"first_name":"fooer","likes":["bars","foos"],"second_name":"barer"}
 ```
 
 === `patch`
@@ -2765,22 +2585,20 @@ Extract a slice from an array by specifying two indices, a low and high bound, w
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.beginning = this.value.slice(0, 2)
 root.end = this.value.slice(4)
 
 # In:  {"value":["foo","bar","baz","buz","bev"]}
-# Out: {"beginning":["foo","bar"],"end":["bev"]}
 ```
 
 A negative low index can be used, indicating an offset from the end of the sequence. If the low index is greater than the length of the sequence then an empty result is returned.
 
-```coffeescript
+```bloblang
 root.last_chunk = this.value.slice(-2)
 root.the_rest = this.value.slice(0, -2)
 
 # In:  {"value":["foo","bar","baz","buz","bev"]}
-# Out: {"last_chunk":["buz","bev"],"the_rest":["foo","bar","baz"]}
 ```
 
 === `sort`
@@ -2794,20 +2612,18 @@ Attempts to sort the values of an array in increasing order. The type of all val
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.sorted = this.foo.sort()
 
 # In:  {"foo":["bbb","ccc","aaa"]}
-# Out: {"sorted":["aaa","bbb","ccc"]}
 ```
 
 It's also possible to specify a mapping argument, which is provided an object context with fields `left` and `right`, the mapping must return a boolean indicating whether the `left` value is less than `right`. This allows you to sort arrays containing non-string or non-number values.
 
-```coffeescript
+```bloblang
 root.sorted = this.foo.sort(item -> item.left.v < item.right.v)
 
 # In:  {"foo":[{"id":"foo","v":"bbb"},{"id":"bar","v":"ccc"},{"id":"baz","v":"aaa"}]}
-# Out: {"sorted":[{"id":"baz","v":"aaa"},{"id":"foo","v":"bbb"},{"id":"bar","v":"ccc"}]}
 ```
 
 === `sort_by`
@@ -2821,11 +2637,10 @@ Attempts to sort the elements of an array, in increasing order, by a value emitt
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.sorted = this.foo.sort_by(ele -> ele.id)
 
 # In:  {"foo":[{"id":"bbb","message":"bar"},{"id":"aaa","message":"foo"},{"id":"ccc","message":"baz"}]}
-# Out: {"sorted":[{"id":"aaa","message":"foo"},{"id":"bbb","message":"bar"},{"id":"ccc","message":"baz"}]}
 ```
 
 === `squash`
@@ -2835,11 +2650,10 @@ Squashes an array of objects into a single object, where key collisions result i
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.locations = this.locations.map_each(loc -> {loc.state: [loc.name]}).squash()
 
 # In:  {"locations":[{"name":"Seattle","state":"WA"},{"name":"New York","state":"NY"},{"name":"Bellevue","state":"WA"},{"name":"Olympia","state":"WA"}]}
-# Out: {"locations":{"NY":["New York"],"WA":["Seattle","Bellevue","Olympia"]}}
 ```
 
 === `sum`
@@ -2849,11 +2663,10 @@ Sum the numerical values of an array.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.sum = this.foo.sum()
 
 # In:  {"foo":[3,8,4]}
-# Out: {"sum":15}
 ```
 
 === `unique`
@@ -2867,11 +2680,10 @@ Attempts to remove duplicate values from an array. The array may contain a combi
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.uniques = this.foo.unique()
 
 # In:  {"foo":["a","b","a","c"]}
-# Out: {"uniques":["a","b","c"]}
 ```
 
 === `values`
@@ -2881,11 +2693,10 @@ Returns the values of an object as an array. The order of the resulting array wi
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_vals = this.foo.values().sort()
 
 # In:  {"foo":{"bar":1,"baz":2}}
-# Out: {"foo_vals":[1,2]}
 ```
 
 === `with`
@@ -2897,11 +2708,10 @@ If a key within a nested path does not exist then it is ignored.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.with("inner.a","inner.c","d")
 
 # In:  {"inner":{"a":"first","b":"second","c":"third"},"d":"fourth","e":"fifth"}
-# Out: {"d":"fourth","inner":{"a":"first","c":"third"}}
 ```
 
 === `without`
@@ -2913,11 +2723,10 @@ If a key within a nested path does not exist or is not an object then it is not 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.without("inner.a","inner.c","d")
 
 # In:  {"inner":{"a":"first","b":"second","c":"third"},"d":"fourth","e":"fifth"}
-# Out: {"e":"fifth","inner":{"b":"second"}}
 ```
 
 === `zip`
@@ -2927,11 +2736,10 @@ Zip an array value with one or more argument arrays. Each array must match in le
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo = this.foo.zip(this.bar, this.baz)
 
 # In:  {"foo":["a","b","c"],"bar":[1,2,3],"baz":[4,5,6]}
-# Out: {"foo":[["a",1,4],["b",2,5],["c",3,6]]}
 ```
 
 == Parsing
@@ -2949,14 +2757,12 @@ Executes an argument Bloblang mapping on the target. This method can be used in 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.body = this.body.bloblang(this.mapping)
 
 # In:  {"body":{"foo":"hello world"},"mapping":"root.foo = this.foo.uppercase()"}
-# Out: {"body":{"foo":"HELLO WORLD"}}
 
 # In:  {"body":{"foo":"hello world 2"},"mapping":"root.foo = this.foo.capitalize()"}
-# Out: {"body":{"foo":"Hello World 2"}}
 ```
 
 === `format_json`
@@ -2974,22 +2780,20 @@ Serializes a target value into a pretty-printed JSON byte array (with 4 space in
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.doc.format_json()
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {
 #          "foo": "bar"
 #      }
 ```
 
 Pass a string to the `indent` parameter in order to customise the indentation.
 
-```coffeescript
+```bloblang
 root = this.format_json("  ")
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {
 #        "doc": {
 #          "foo": "bar"
 #        }
@@ -2998,29 +2802,26 @@ root = this.format_json("  ")
 
 Use the `.string()` method in order to coerce the result into a string.
 
-```coffeescript
+```bloblang
 root.doc = this.doc.format_json().string()
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {"doc":"{\n    \"foo\": \"bar\"\n}"}
 ```
 
 Set the `no_indent` parameter to true to disable indentation. The result is equivalent to calling `bytes()`.
 
-```coffeescript
+```bloblang
 root = this.doc.format_json(no_indent: true)
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {"foo":"bar"}
 ```
 
 Escapes problematic HTML characters.
 
-```coffeescript
+```bloblang
 root = this.doc.format_json()
 
 # In:  {"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}
-# Out: {
 #          "email": "foo\u0026bar@benthos.dev",
 #          "name": "foo\u003ebar"
 #      }
@@ -3028,11 +2829,10 @@ root = this.doc.format_json()
 
 Set the `escape_html` parameter to false to disable escaping of problematic HTML characters.
 
-```coffeescript
+```bloblang
 root = this.doc.format_json(escape_html: false)
 
 # In:  {"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}
-# Out: {
 #          "email": "foo&bar@benthos.dev",
 #          "name": "foo>bar"
 #      }
@@ -3045,18 +2845,16 @@ Formats data as a https://msgpack.org/[MessagePack^] message in bytes format.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.format_msgpack().encode("hex")
 
 # In:  {"foo":"bar"}
-# Out: 81a3666f6fa3626172
 ```
 
-```coffeescript
+```bloblang
 root.encoded = this.format_msgpack().encode("base64")
 
 # In:  {"foo":"bar"}
-# Out: {"encoded":"gaNmb2+jYmFy"}
 ```
 
 === `format_xml`
@@ -3075,11 +2873,10 @@ Serializes a target value into an XML byte array.
 
 Serializes a target value into a pretty-printed XML byte array (with 4 space indentation by default).
 
-```coffeescript
+```bloblang
 root = this.format_xml()
 
 # In:  {"foo":{"bar":{"baz":"foo bar baz"}}}
-# Out: <foo>
 #          <bar>
 #              <baz>foo bar baz</baz>
 #          </bar>
@@ -3088,11 +2885,10 @@ root = this.format_xml()
 
 Pass a string to the `indent` parameter in order to customise the indentation.
 
-```coffeescript
+```bloblang
 root = this.format_xml("  ")
 
 # In:  {"foo":{"bar":{"baz":"foo bar baz"}}}
-# Out: <foo>
 #        <bar>
 #          <baz>foo bar baz</baz>
 #        </bar>
@@ -3101,20 +2897,18 @@ root = this.format_xml("  ")
 
 Use the `.string()` method in order to coerce the result into a string.
 
-```coffeescript
+```bloblang
 root.doc = this.format_xml("").string()
 
 # In:  {"foo":{"bar":{"baz":"foo bar baz"}}}
-# Out: {"doc":"<foo>\n<bar>\n<baz>foo bar baz</baz>\n</bar>\n</foo>"}
 ```
 
 Set the `no_indent` parameter to true to disable indentation.
 
-```coffeescript
+```bloblang
 root = this.format_xml(no_indent: true)
 
 # In:  {"foo":{"bar":{"baz":"foo bar baz"}}}
-# Out: <foo><bar><baz>foo bar baz</baz></bar></foo>
 ```
 
 === `format_yaml`
@@ -3124,20 +2918,18 @@ Serializes a target value into a YAML byte array.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.doc.format_yaml()
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: foo: bar
 ```
 
 Use the `.string()` method in order to coerce the result into a string.
 
-```coffeescript
+```bloblang
 root.doc = this.doc.format_yaml().string()
 
 # In:  {"doc":{"foo":"bar"}}
-# Out: {"doc":"foo: bar\n"}
 ```
 
 === `infer_schema`
@@ -3146,11 +2938,10 @@ Attempts to infer the schema of a given value. The resulting schema can then be 
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.schema = this.infer_schema()
 
 # In: {"id":1,"name":"Alice","tags":["admin","user"]}
-# Out: {"schema":{"children":[{"name":"id","type":"STRING"},{"name":"name","type":"STRING"},{"children":[{"type":"STRING"}],"name":"tags","type":"ARRAY"}],"type":"OBJECT"}}
 ```
 
 === `parse_csv`
@@ -3168,38 +2959,34 @@ Attempts to parse a string into an array of objects by following the CSV format 
 
 Parses CSV data with a header row
 
-```coffeescript
+```bloblang
 root.orders = this.orders.parse_csv()
 
 # In:  {"orders":"foo,bar\nfoo 1,bar 1\nfoo 2,bar 2"}
-# Out: {"orders":[{"bar":"bar 1","foo":"foo 1"},{"bar":"bar 2","foo":"foo 2"}]}
 ```
 
 Parses CSV data without a header row
 
-```coffeescript
+```bloblang
 root.orders = this.orders.parse_csv(false)
 
 # In:  {"orders":"foo 1,bar 1\nfoo 2,bar 2"}
-# Out: {"orders":[["foo 1","bar 1"],["foo 2","bar 2"]]}
 ```
 
 Parses CSV data delimited by dots
 
-```coffeescript
+```bloblang
 root.orders = this.orders.parse_csv(delimiter:".")
 
 # In:  {"orders":"foo.bar\nfoo 1.bar 1\nfoo 2.bar 2"}
-# Out: {"orders":[{"bar":"bar 1","foo":"foo 1"},{"bar":"bar 2","foo":"foo 2"}]}
 ```
 
 Parses CSV data containing a quote in an unquoted field
 
-```coffeescript
+```bloblang
 root.orders = this.orders.parse_csv(lazy_quotes:true)
 
 # In:  {"orders":"foo,bar\nfoo 1,bar 1\nfoo\" \"2,bar\" \"2"}
-# Out: {"orders":[{"bar":"bar 1","foo":"foo 1"},{"bar":"bar\" \"2","foo":"foo\" \"2"}]}
 ```
 
 === `parse_form_url_encoded`
@@ -3209,11 +2996,10 @@ Attempts to parse a url-encoded query string (from an x-www-form-urlencoded requ
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.values = this.body.parse_form_url_encoded()
 
 # In:  {"body":"noise=meow&animal=cat&fur=orange&fur=fluffy"}
-# Out: {"values":{"animal":"cat","fur":["orange","fluffy"],"noise":"meow"}}
 ```
 
 === `parse_json`
@@ -3227,18 +3013,16 @@ Attempts to parse a string as a JSON document and returns the result.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_json()
 
 # In:  {"doc":"{\"foo\":\"bar\"}"}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_json(use_number: true)
 
 # In:  {"doc":"{\"foo\":\"11380878173205700000000000000000000000000000000\"}"}
-# Out: {"doc":{"foo":"11380878173205700000000000000000000000000000000"}}
 ```
 
 === `parse_msgpack`
@@ -3248,18 +3032,16 @@ Parses a https://msgpack.org/[MessagePack^] message into a structured document.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = content().decode("hex").parse_msgpack()
 
 # In:  81a3666f6fa3626172
-# Out: {"foo":"bar"}
 ```
 
-```coffeescript
+```bloblang
 root = this.encoded.decode("base64").parse_msgpack()
 
 # In:  {"encoded":"gaNmb2+jYmFy"}
-# Out: {"foo":"bar"}
 ```
 
 === `parse_parquet`
@@ -3273,7 +3055,7 @@ Decodes a https://parquet.apache.org/docs/[Parquet file^] into an array of objec
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = content().parse_parquet()
 ```
 
@@ -3284,21 +3066,18 @@ Attempts to parse a URL from a string value, returning a structured result that 
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.foo_url = this.foo_url.parse_url()
 
 # In:  {"foo_url":"https://docs.redpanda.com/redpanda-connect/guides/bloblang/about/"}
-# Out: {"foo_url":{"fragment":"","host":"docs.redpanda.com","opaque":"","path":"/redpanda-connect/guides/bloblang/about/","raw_fragment":"","raw_path":"","raw_query":"","scheme":"https"}}
 ```
 
-```coffeescript
+```bloblang
 root.username = this.url.parse_url().user.name | "unknown"
 
 # In:  {"url":"amqp://foo:bar@127.0.0.1:5672/"}
-# Out: {"username":"foo"}
 
 # In:  {"url":"redis://localhost:6379"}
-# Out: {"username":"unknown"}
 ```
 
 === `parse_xml`
@@ -3320,25 +3099,22 @@ Attempts to parse a string as an XML document and returns a structured result, w
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_xml()
 
 # In:  {"doc":"<root><title>This is a title</title><content>This is some content</content></root>"}
-# Out: {"doc":{"root":{"content":"This is some content","title":"This is a title"}}}
 ```
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_xml(cast: false)
 
 # In:  {"doc":"<root><title>This is a title</title><number id=99>123</number><bool>True</bool></root>"}
-# Out: {"doc":{"root":{"bool":"True","number":{"#text":"123","-id":"99"},"title":"This is a title"}}}
 ```
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_xml(cast: true)
 
 # In:  {"doc":"<root><title>This is a title</title><number id=99>123</number><bool>True</bool></root>"}
-# Out: {"doc":{"root":{"bool":true,"number":{"#text":123,"-id":99},"title":"This is a title"}}}
 ```
 
 === `parse_yaml`
@@ -3348,11 +3124,10 @@ Attempts to parse a string as a single YAML document and returns the result.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.doc = this.doc.parse_yaml()
 
 # In:  {"doc":"foo: bar"}
-# Out: {"doc":{"foo":"bar"}}
 ```
 
 == Encoding and Encryption
@@ -3369,21 +3144,19 @@ Compresses a string or byte array value according to a specified algorithm.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 let long_content = range(0, 1000).map_each(content()).join(" ")
 root.a_len = $long_content.length()
 root.b_len = $long_content.compress("gzip").length()
 
 
 # In:  hello world this is some content
-# Out: {"a_len":32999,"b_len":161}
 ```
 
-```coffeescript
+```bloblang
 root.compressed = content().compress("lz4").encode("base64")
 
 # In:  hello world I love space
-# Out: {"compressed":"BCJNGGRwuRgAAIBoZWxsbyB3b3JsZCBJIGxvdmUgc3BhY2UAAAAAGoETLg=="}
 ```
 
 === `decode`
@@ -3399,18 +3172,16 @@ Available schemes are: `base64`, `base64url` https://rfc-editor.org/rfc/rfc4648.
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.decoded = this.value.decode("hex").string()
 
 # In:  {"value":"68656c6c6f20776f726c64"}
-# Out: {"decoded":"hello world"}
 ```
 
-```coffeescript
+```bloblang
 root = this.encoded.decode("ascii85")
 
 # In:  {"encoded":"FD,B0+DGm>FDl80Ci\"A>F`)8BEckl6F`M&(+Cno&@/"}
-# Out: this is totally unstructured data
 ```
 
 === `decompress`
@@ -3424,20 +3195,18 @@ Decompresses a string or byte array value according to a specified algorithm. Th
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root = this.compressed.decode("base64").decompress("lz4")
 
 # In:  {"compressed":"BCJNGGRwuRgAAIBoZWxsbyB3b3JsZCBJIGxvdmUgc3BhY2UAAAAAGoETLg=="}
-# Out: hello world I love space
 ```
 
 Use the `.string()` method in order to coerce the result into a string, this makes it possible to place the data within a JSON document without automatic base64 encoding.
 
-```coffeescript
+```bloblang
 root.result = this.compressed.decode("base64").decompress("lz4").string()
 
 # In:  {"compressed":"BCJNGGRwuRgAAIBoZWxsbyB3b3JsZCBJIGxvdmUgc3BhY2UAAAAAGoETLg=="}
-# Out: {"result":"hello world I love space"}
 ```
 
 === `decrypt_aes`
@@ -3453,13 +3222,12 @@ Decrypts an encrypted string or byte array target according to a chosen AES encr
 ==== Examples
 
 
-```coffeescript
+```bloblang
 let key = "2b7e151628aed2a6abf7158809cf4f3c".decode("hex")
 let vector = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff".decode("hex")
 root.decrypted = this.value.decode("hex").decrypt_aes("ctr", $key, $vector).string()
 
 # In:  {"value":"84e9b31ff7400bdf80be7254"}
-# Out: {"decrypted":"hello world!"}
 ```
 
 === `encode`
@@ -3473,18 +3241,16 @@ Encodes a string or byte array target according to a chosen scheme and returns a
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.encoded = this.value.encode("hex")
 
 # In:  {"value":"hello world"}
-# Out: {"encoded":"68656c6c6f20776f726c64"}
 ```
 
-```coffeescript
+```bloblang
 root.encoded = content().encode("ascii85")
 
 # In:  this is totally unstructured data
-# Out: {"encoded":"FD,B0+DGm>FDl80Ci\"A>F`)8BEckl6F`M&(+Cno&@/"}
 ```
 
 === `encrypt_aes`
@@ -3500,13 +3266,12 @@ Encrypts a string or byte array target according to a chosen AES encryption meth
 ==== Examples
 
 
-```coffeescript
+```bloblang
 let key = "2b7e151628aed2a6abf7158809cf4f3c".decode("hex")
 let vector = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff".decode("hex")
 root.encrypted = this.value.encrypt_aes("ctr", $key, $vector).encode("hex")
 
 # In:  {"value":"hello world!"}
-# Out: {"encrypted":"84e9b31ff7400bdf80be7254"}
 ```
 
 === `hash`
@@ -3526,22 +3291,20 @@ The following algorithms require a key, which is specified as a second argument:
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.h1 = this.value.hash("sha1").encode("hex")
 root.h2 = this.value.hash("hmac_sha1","static-key").encode("hex")
 
 # In:  {"value":"hello world"}
-# Out: {"h1":"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed","h2":"d87e5f068fa08fe90bb95bc7c8344cb809179d76"}
 ```
 
 The `crc32` algorithm supports options for the polynomial.
 
-```coffeescript
+```bloblang
 root.h1 = this.value.hash(algorithm: "crc32", polynomial: "Castagnoli").encode("hex")
 root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex")
 
 # In:  {"value":"hello world"}
-# Out: {"h1":"c99465aa","h2":"df373d3c"}
 ```
 
 === `uuid_v5`
@@ -3556,7 +3319,7 @@ If omitted, the nil UUID is used as the default namespace.
 
 ==== Examples
 
-```coffeescript
+```bloblang
 root.id = "example".uuid_v5()
 
 root.id = "example".uuid_v5("x500")
@@ -3582,13 +3345,15 @@ endif::[]
 
 Create a vector from an array literal.
 
-```coffeescript
+```bloblang
 root.embeddings = [1.2, 0.6, 0.9].vector()
 ```
 Create a vector from an array.
 
-```coffeescript
+```bloblang
 root.embedding_vector = this.embedding_array.vector()
+
+# In:  {"embedding_array":[0.1,0.2,0.3,0.4]}
 ```
 
 == JSON Web Tokens
@@ -3608,14 +3373,13 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_es256("""-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGtLqIBePHmIhQcf0JLgc+F/4W/oI
 dp0Gta53G35VerNDgUUXmp78J2kfh4qLdh0XtmOMI587tCaqjvDAXfs//w==
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.GIRajP9JJbpTlqSCdNEz4qpQkRvzX4Q51YnTwVyxLDM9tKjR_a8ggHWn9CWj7KG0x8J56OWtmUxn112SRTZVhQ"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_es384`
@@ -3633,7 +3397,7 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_es384("""-----BEGIN PUBLIC KEY-----
 MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERoz74/B6SwmLhs8X7CWhnrWyRrB13AuU
 8OYeqy0qHRu9JWNw8NIavqpTmu6XPT4xcFanYjq8FbeuM11eq06C52mNmS4LLwzA
@@ -3641,7 +3405,6 @@ MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERoz74/B6SwmLhs8X7CWhnrWyRrB13AuU
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.H2HBSlrvQBaov2tdreGonbBexxtQB-xzaPL4-tNQZ6TVh7VH8VBcSwcWHYa1lBAHmdsKOFcB2Wk0SB7QWeGT3ptSgr-_EhDMaZ8bA5spgdpq5DsKfaKHrd7DbbQlmxNq"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_es512`
@@ -3659,7 +3422,7 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_es512("""-----BEGIN PUBLIC KEY-----
 MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAkHLdts9P56fFkyhpYQ31M/Stwt3w
 vpaxhlfudxnXgTO1IP4RQRgryRxZ19EUzhvWDcG3GQIckoNMY5PelsnCGnIBT2Xh
@@ -3668,7 +3431,6 @@ UeYyTt05zRRWuD+p5bY=
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.ACrpLuU7TKpAnncDCpN9m85nkL55MJ45NFOBl6-nEXmNT1eIxWjiP4pwWVbFH9et_BgN14119jbL_KqEJInPYc9nAXC6dDLq0aBU-dalvNl4-O5YWpP43-Y-TBGAsWnbMTrchILJ4-AEiICe73Ck5yWPleKg9c3LtkEFWfGs7BoPRguZ"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_hs256`
@@ -3686,11 +3448,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_hs256("""dont-tell-anyone""")
 
 # In:  {"signed":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.YwXOM8v3gHVWcQRRRQc_zDlhmLnM62fwhFYGpiA0J1A"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_hs384`
@@ -3708,11 +3469,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_hs384("""dont-tell-anyone""")
 
 # In:  {"signed":"eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.2Y8rf_ijwN4t8hOGGViON_GrirLkCQVbCOuax6EoZ3nluX0tCGezcJxbctlIfsQ2"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_hs512`
@@ -3730,11 +3490,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_hs512("""dont-tell-anyone""")
 
 # In:  {"signed":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.utRb0urG6LGGyranZJVo5Dk0Fns1QNcSUYPN0TObQ-YzsGGB8jrxHwM5NAJccjJZzKectEUqmmKCaETZvuX4Fg"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_rs256`
@@ -3752,7 +3511,7 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_rs256("""-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs/ibN8r68pLMR6gRzg4S
 8v8l6Q7yi8qURjkEbcNeM1rkokC7xh0I4JVTwxYSVv/JIW8qJdyspl5NIfuAVi32
@@ -3764,7 +3523,6 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.b0lH3jEupZZ4zoaly4Y_GCvu94HH6UKdKY96zfGNsIkPZpQLHIkZ7jMWlLlNOAd8qXlsBGP_i8H2qCKI4zlWJBGyPZgxXDzNRPVrTDfFpn4t4nBcA1WK2-ntXP3ehQxsaHcQU8Z_nsogId7Pme5iJRnoHWEnWtbwz5DLSXL3ZZNnRdrHM9MdI7QSDz9mojKDCaMpGN9sG7Xl-tGdBp1XzXuUOzG8S03mtZ1IgVR1uiBL2N6oohHIAunk8DIAmNWI-zgycTgzUGU7mvPkKH43qO8Ua1-13tCUBKKa8VxcotZ67Mxm1QAvBGoDnTKwWMwghLzs6d6WViXQg6eWlJcpBA"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_rs384`
@@ -3782,7 +3540,7 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_rs384("""-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs/ibN8r68pLMR6gRzg4S
 8v8l6Q7yi8qURjkEbcNeM1rkokC7xh0I4JVTwxYSVv/JIW8qJdyspl5NIfuAVi32
@@ -3794,7 +3552,6 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.orcXYBcjVE5DU7mvq4KKWFfNdXR4nEY_xupzWoETRpYmQZIozlZnM_nHxEk2dySvpXlAzVm7kgOPK2RFtGlOVaNRIa3x-pMMr-bhZTno4L8Hl4sYxOks3bWtjK7wql4uqUbqThSJB12psAXw2-S-I_FMngOPGIn4jDT9b802ottJSvTpXcy0-eKTjrV2PSkRRu-EYJh0CJZW55MNhqlt6kCGhAXfbhNazN3ASX-dmpd_JixyBKphrngr_zRA-FCn_Xf3QQDA-5INopb4Yp5QiJ7UxVqQEKI80X_JvJqz9WE1qiAw8pq5-xTen1t7zTP-HT1NbbD3kltcNa3G8acmNg"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `parse_jwt_rs512`
@@ -3812,7 +3569,7 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.claims = this.signed.parse_jwt_rs512("""-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs/ibN8r68pLMR6gRzg4S
 8v8l6Q7yi8qURjkEbcNeM1rkokC7xh0I4JVTwxYSVv/JIW8qJdyspl5NIfuAVi32
@@ -3824,7 +3581,6 @@ XOInTHs/Gg6DZMkbxjQu6L06EdJ+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO
 -----END PUBLIC KEY-----""")
 
 # In:  {"signed":"eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.rsMp_X5HMrUqKnZJIxo27aAoscovRA6SSQYR9rq7pifIj0YHXxMyNyOBDGnvVALHKTi25VUGHpfNUW0VVMmae0A4t_ObNU6hVZHguWvetKZZq4FZpW1lgWHCMqgPGwT5_uOqwYCH6r8tJuZT3pqXeL0CY4putb1AN2w6CVp620nh3l8d3XWb4jaifycd_4CEVCqHuWDmohfug4VhmoVKlIXZkYoAQowgHlozATDssBSWdYtv107Wd2AzEoiXPu6e3pflsuXULlyqQnS4ELEKPYThFLafh1NqvZDPddqozcPZ-iODBW-xf3A4DYDdivnMYLrh73AZOGHexxu8ay6nDA"}
-# Out: {"claims":{"iat":1516239022,"mood":"Disdainful","sub":"1234567890"}}
 ```
 
 === `sign_jwt_es256`
@@ -3843,13 +3599,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_es256("""-----BEGIN EC PRIVATE KEY-----
 ... signature data ...
 -----END EC PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.-8LrOdkEiv_44ADWW08lpbq41ZmHCel58NMORPq1q4Dyw0zFhqDVLrRoSvCvuyyvgXAFb9IHfR-9MlJ_2ShA9A"}
 ```
 
 === `sign_jwt_es384`
@@ -3867,13 +3622,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_es384("""-----BEGIN EC PRIVATE KEY-----
 ... signature data ...
 -----END EC PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.8FmTKH08dl7dyxrNu0rmvhegiIBCy-O9cddGco2e9lpZtgv5mS5qHgPkgBC5eRw1d7SRJsHwHZeehzdqT5Ba7aZJIhz9ds0sn37YQ60L7jT0j2gxCzccrt4kECHnUnLw"}
 ```
 
 === `sign_jwt_es512`
@@ -3891,13 +3645,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_es512("""-----BEGIN EC PRIVATE KEY-----
 ... signature data ...
 -----END EC PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.AQbEWymoRZxDJEJtKSFFG2k2VbDCTYSuBwAZyMqexCspr3If8aERTVGif8HXG3S7TzMBCCzxkcKr3eIU441l3DlpAMNfQbkcOlBqMvNBn-CX481WyKf3K5rFHQ-6wRonz05aIsWAxCDvAozI_9J0OWllxdQ2MBAuTPbPJ38OqXsYkCQs"}
 ```
 
 === `sign_jwt_hs256`
@@ -3915,11 +3668,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_hs256("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.hUl-nngPMY_3h9vveWJUPsCcO5PeL6k9hWLnMYeFbFQ"}
 ```
 
 === `sign_jwt_hs384`
@@ -3937,11 +3689,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_hs384("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.zGYLr83aToon1efUNq-hw7XgT20lPvZb8sYei8x6S6mpHwb433SJdXJXx0Oio8AZ"}
 ```
 
 === `sign_jwt_hs512`
@@ -3959,11 +3710,10 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_hs512("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.zBNR9o_6EDwXXKkpKLNJhG26j8Dc-mV-YahBwmEdCrmiWt5les8I9rgmNlWIowpq6Yxs4kLNAdFhqoRz3NXT3w"}
 ```
 
 === `sign_jwt_rs256`
@@ -3981,13 +3731,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_rs256("""-----BEGIN RSA PRIVATE KEY-----
 ... signature data ...
 -----END RSA PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.b0lH3jEupZZ4zoaly4Y_GCvu94HH6UKdKY96zfGNsIkPZpQLHIkZ7jMWlLlNOAd8qXlsBGP_i8H2qCKI4zlWJBGyPZgxXDzNRPVrTDfFpn4t4nBcA1WK2-ntXP3ehQxsaHcQU8Z_nsogId7Pme5iJRnoHWEnWtbwz5DLSXL3ZZNnRdrHM9MdI7QSDz9mojKDCaMpGN9sG7Xl-tGdBp1XzXuUOzG8S03mtZ1IgVR1uiBL2N6oohHIAunk8DIAmNWI-zgycTgzUGU7mvPkKH43qO8Ua1-13tCUBKKa8VxcotZ67Mxm1QAvBGoDnTKwWMwghLzs6d6WViXQg6eWlJcpBA"}
 ```
 
 === `sign_jwt_rs384`
@@ -4005,13 +3754,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_rs384("""-----BEGIN RSA PRIVATE KEY-----
 ... signature data ...
 -----END RSA PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.orcXYBcjVE5DU7mvq4KKWFfNdXR4nEY_xupzWoETRpYmQZIozlZnM_nHxEk2dySvpXlAzVm7kgOPK2RFtGlOVaNRIa3x-pMMr-bhZTno4L8Hl4sYxOks3bWtjK7wql4uqUbqThSJB12psAXw2-S-I_FMngOPGIn4jDT9b802ottJSvTpXcy0-eKTjrV2PSkRRu-EYJh0CJZW55MNhqlt6kCGhAXfbhNazN3ASX-dmpd_JixyBKphrngr_zRA-FCn_Xf3QQDA-5INopb4Yp5QiJ7UxVqQEKI80X_JvJqz9WE1qiAw8pq5-xTen1t7zTP-HT1NbbD3kltcNa3G8acmNg"}
 ```
 
 === `sign_jwt_rs512`
@@ -4029,13 +3777,12 @@ endif::[]
 ==== Examples
 
 
-```coffeescript
+```bloblang
 root.signed = this.claims.sign_jwt_rs512("""-----BEGIN RSA PRIVATE KEY-----
 ... signature data ...
 -----END RSA PRIVATE KEY-----""")
 
 # In:  {"claims":{"sub":"user123"}}
-# Out: {"signed":"eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm1vb2QiOiJEaXNkYWluZnVsIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.rsMp_X5HMrUqKnZJIxo27aAoscovRA6SSQYR9rq7pifIj0YHXxMyNyOBDGnvVALHKTi25VUGHpfNUW0VVMmae0A4t_ObNU6hVZHguWvetKZZq4FZpW1lgWHCMqgPGwT5_uOqwYCH6r8tJuZT3pqXeL0CY4putb1AN2w6CVp620nh3l8d3XWb4jaifycd_4CEVCqHuWDmohfug4VhmoVKlIXZkYoAQowgHlozATDssBSWdYtv107Wd2AzEoiXPu6e3pflsuXULlyqQnS4ELEKPYThFLafh1NqvZDPddqozcPZ-iODBW-xf3A4DYDdivnMYLrh73AZOGHexxu8ay6nDA"}
 ```
 
 == GeoIP

--- a/modules/guides/pages/bloblang/walkthrough.adoc
+++ b/modules/guides/pages/bloblang/walkthrough.adoc
@@ -26,9 +26,12 @@ Next, open your browser at `+http://localhost:4195+` and you should see an app w
 
 The primary goal of a Bloblang mapping is to construct a brand new document by using an input document as a reference, which we achieve through a series of assignments. Bloblang is traditionally used to map JSON documents and that's mostly what we'll be doing in this walkthrough. The first mapping you'll see when you open the editor is a single assignment:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
+
+# In:  {"message":"hello world"}
+# Out: {"message":"hello world"}
 ----
 
 On the left-hand side of the assignment is our assignment target, where `root` is a keyword referring to the root of the new document being constructed. On the right-hand side is a query which determines the value to be assigned, where `this` is a keyword that refers to the context of the mapping which begins as the root of the input document.
@@ -46,10 +49,13 @@ This output is a (neatly formatted) replica of the input document. This is the r
 
 Let's create a brand new document by assigning a fresh object to the root:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = {}
 root.foo = this.message
+
+# In:  {"message":"hello world"}
+# Out: {"foo":"hello world"}
 ----
 
 Bloblang supports a bunch of xref:guides:bloblang/about.adoc#literals[literal types], and the first line of this mapping assigns an empty object literal to the root. The second line then creates a new field `foo` on that object by assigning it the value of `message` from the input document. You should see that our output has changed to:
@@ -63,10 +69,13 @@ Bloblang supports a bunch of xref:guides:bloblang/about.adoc#literals[literal ty
 
 In Bloblang, when the path that we assign to contains fields that are themselves unset then they are created as empty objects. This rule also applies to `root` itself, which means the mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo.bar = this.message
 root.foo."buz me".baz = "I like mapping"
+
+# In:  {"message":"hello world"}
+# Out: {"foo":{"bar":"hello world","buz me":{"baz":"I like mapping"}}}
 ----
 
 Will automatically create the objects required to produce the output document:
@@ -89,10 +98,13 @@ Also note that we can use quotes in order to express path segments that contain 
 
 Nothing is ever good enough for you, why should the input document be any different? Usually in our mappings it's necessary to mutate values whilst we map them over, this is almost always done with methods, of which xref:guides:bloblang/methods.adoc[there are many]. To demonstrate we're going to change our mapping to xref:guides:bloblang/methods.adoc#uppercase[uppercase] the field `message` from our input document:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo.bar = this.message.uppercase()
 root.foo."buz me".baz = "I like mapping"
+
+# In:  {"message":"hello world"}
+# Out: {"foo":{"bar":"HELLO WORLD","buz me":{"baz":"I like mapping"}}}
 ----
 
 As you can see the syntax for a method is similar to many languages, simply add a dot on the target value followed by the method name and arguments within brackets. With this method added our output document should look like this:
@@ -111,29 +123,37 @@ As you can see the syntax for a method is similar to many languages, simply add 
 
 Since the result of any Bloblang query is a value you can use methods on anything, including other methods. For example, we could expand our mapping of `message` to also replace `WORLD` with `EARTH` using the xref:guides:bloblang/methods.adoc#replace_all[`replace_all` method]:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo.bar = this.message.uppercase().replace_all("WORLD", "EARTH")
 root.foo."buz me".baz = "I like mapping"
+
+# In:  {"message":"hello world"}
+# Out: {"foo":{"bar":"HELLO EARTH","buz me":{"baz":"I like mapping"}}}
 ----
 
 As you can see this method required some arguments. Methods support both nameless (like above) and named arguments, which are often literal values but can also be queries themselves. For example try out the following mapping using both named style and a dynamic argument:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo.bar = this.message.uppercase().replace_all(old: "WORLD", new: this.message.capitalize())
 root.foo."buz me".baz = "I like mapping"
+
+# In:  {"message":"hello world"}
+# Out: {"foo":{"bar":"HELLO Hello World","buz me":{"baz":"I like mapping"}}}
 ----
 
 Woah, I think that's the plot to Inception, let's move onto functions. Functions are just boring methods that don't have a target, and there are xref:guides:bloblang/functions.adoc[plenty of them as well]. Functions are often used to extract information unrelated to the input document, such as xref:guides:bloblang/functions.adoc#env[environment variables], or to generate data such as xref:guides:bloblang/functions.adoc#now[timestamps] or xref:guides:bloblang/functions.adoc#uuid_v4[UUIDs].
 
 Since we're completionists let's add one to our mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo.bar = this.message.uppercase().replace_all("WORLD", "EARTH")
 root.foo."buz me".baz = "I like mapping"
 root.foo.id = uuid_v4()
+
+# In:  {"message":"hello world"}
 ----
 
 Now I can't tell you what the output looks like since it will be different each time it's mapped, how fun!
@@ -153,10 +173,13 @@ Everything in Bloblang is an expression to be assigned, including deletions, whi
 
 If we wanted a full copy of this document without the field `name` then we can assign `deleted()` to it:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.name = deleted()
+
+# In:  {"name":"fooman barson","age":7,"opinions":["trucks are cool","trains are cool","chores are bad"]}
+# Out: {"age":7,"opinions":["trucks are cool","trains are cool","chores are bad"]}
 ----
 
 And it won't be included in the output:
@@ -179,11 +202,13 @@ An alternative way to delete fields is the xref:guides:bloblang/methods.adoc#wit
 
 Sometimes it's necessary to capture a value for later, but we might not want it to be added to the resulting document. In Bloblang we can achieve this with variables which are created using the `let` keyword, and can be referenced within subsequent queries with a dollar sign prefix:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 let id = uuid_v4()
 root.id_sha1 = $id.hash("sha1").encode("hex")
 root.id_md5 = $id.hash("md5").encode("hex")
+
+# In:  {}
 ----
 
 Variables can be assigned any value type, including objects and arrays.
@@ -196,9 +221,12 @@ You should notice that when a value type is assigned to the root the output is t
 
 Unstructured mapping is not limited to the output. Rather than referencing the input document with `this`, where it must be structured, it is possible to reference it as a binary string with the xref:guides:bloblang/functions.adoc#content[function `content`], try changing your mapping to:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = content().uppercase()
+
+# In:  hello world
+# Out: HELLO WORLD
 ----
 
 When you add content to the input panel, it should be the same in the output panel, but in all uppercase.
@@ -225,12 +253,15 @@ In Bloblang all conditionals are expressions, this is a core principal of Blobla
 
 The simplest conditional is the `if` expression, where the boolean condition does not need to be in parentheses. Let's create a map that modifies the number of treats our pet receives based on a field:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.pet.treats = if this.pet.is_cute {
   this.pet.treats + 10
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":15,"toys":3}}
 ----
 
 Try that mapping out and you should see the number of treats in the output increased to 15. Now try changing the input field `pet.is_cute` to `false` and the output treats count should go back to the original 5.
@@ -239,7 +270,7 @@ When a conditional expression doesn't have a branch to execute then the assignme
 
 We can add an `else` block to our `if` expression to remove treats entirely when the pet is not cute:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.pet.treats = if this.pet.is_cute {
@@ -247,6 +278,9 @@ root.pet.treats = if this.pet.is_cute {
 } else {
   deleted()
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":15,"toys":3}}
 ----
 
 This is possible because field deletions are expressed as assigned values created with the `deleted()` function.
@@ -255,7 +289,7 @@ This is possible because field deletions are expressed as assigned values create
 
 The `if` keyword can also be used as a statement in order to conditionally apply a series of mapping assignments, the previous example can be rewritten as:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 if this.pet.is_cute {
@@ -263,17 +297,23 @@ if this.pet.is_cute {
 } else {
   root.pet.treats = deleted()
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":15,"toys":3}}
 ----
 
 Converting this mapping to use a statement has resulted in a more verbose mapping as we had to specify `root.pet.treats` multiple times as an assignment target. However, using `if` as a statement can be beneficial when multiple assignments rely on the same logic:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 if this.pet.is_cute {
   root.pet.treats = this.pet.treats + 10
   root.pet.toys = this.pet.toys + 10
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":15,"toys":13}}
 ----
 
 More treats _and_ more toys! Lucky Spot!
@@ -282,7 +322,7 @@ More treats _and_ more toys! Lucky Spot!
 
 Another conditional expression is `match` which allows you to list many branches consisting of a condition and a query to execute separated with `+=>+`, where the first condition to pass is the one that is executed:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.pet.toys = match {
@@ -292,11 +332,14 @@ root.pet.toys = match {
   this.pet.type == "horse" => this.pet.toys + 10,
   _ => 0,
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
 ----
 
 Try executing that mapping with different values for `pet.type` and `pet.treats`. Match expressions can also specify a new context for the keyword `this` which can help reduce some of the boilerplate in your boolean conditions. The following mapping is equivalent to the previous:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.pet.toys = match this.pet {
@@ -306,11 +349,14 @@ root.pet.toys = match this.pet {
   this.type == "horse" => this.toys + 10,
   _ => 0,
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
 ----
 
 Your boolean conditions can also be expressed as value types, in which case the context being matched will be compared to the value:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this
 root.pet.toys = match this.pet.type {
@@ -320,6 +366,9 @@ root.pet.toys = match this.pet.type {
   "horse" => 20,
   _ => 0,
 }
+
+# In:  {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
+# Out: {"pet":{"type":"cat","is_cute":true,"treats":5,"toys":3}}
 ----
 
 == Error handling
@@ -338,9 +387,11 @@ First, let's take a look at what happens when errors _aren't_ handled, change yo
 
 And change your mapping to something simple like a number comparison:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.in_trouble = this.angry_peasants > this.palace_guards
+
+# In:  {"palace_guards":10,"angry_peasants":"I couldn't be bothered to ask them"}
 ----
 
 Uh oh! It looks like our canvasser was too lazy and our `angry_peasants` count was incorrectly set for this document. You should see an error in the output window that mentions something like `cannot compare types string (from field this.angry_peasants) and number (from field this.palace_guards)`, which means the mapping was abandoned.
@@ -349,22 +400,28 @@ So what if we want to try and map something, but don't care if it fails? In this
 
 For that we have a special xref:guides:bloblang/methods.adoc#catch[method `catch`], which if we add to any query allows us to specify an argument to be returned when an error occurs. Since methods can be added to any query we can surround our arithmetic with brackets and catch the whole thing:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.in_trouble = (this.angry_peasants > this.palace_guards).catch(true)
+
+# In:  {"palace_guards":10,"angry_peasants":"I couldn't be bothered to ask them"}
+# Out: {"in_trouble":true}
 ----
 
 Now instead of an error we should see an output with `in_trouble` set to `true`. Try changing to value of `angry_peasants` to a few different values, including some numbers.
 
 One of the powerful features of `catch` is that when it is added at the end of a series of expressions and methods it will capture errors at any part of the series, allowing you to capture errors at any granularity. For example, the mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.abort_mission = if this.mission.type == "impossible" {
   !this.user.motives.contains("must clear name")
 } else {
   this.mission.difficulty > 10
 }.catch(false)
+
+# In:  {"mission":{"type":"impossible","difficulty":5},"user":{"motives":["must clear name"]}}
+# Out: {"abort_mission":false}
 ----
 
 Will catch errors caused by:
@@ -390,13 +447,16 @@ But will always return `false` if any of those errors occur. Try it out with thi
 
 Now try out this mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.abort_mission = if (this.mission.type == "impossible").catch(true) {
   !this.user.motives.contains("must clear name").catch(false)
 } else {
   (this.mission.difficulty > 10).catch(true)
 }
+
+# In:  {"mission":{"type":"impossible","difficulty":5},"user":{"motives":["must clear name"]}}
+# Out: {"abort_mission":false}
 ----
 
 This version is more granular and will capture each of the errors individually, with each error given a unique `true` or `false` fallback.
@@ -409,11 +469,14 @@ You can read about common Redpanda Connect error handling patterns for bad data 
 
 There are xref:guides:bloblang/methods.adoc#type-coercion[a few helper methods] that make validating and coercing fields nice and easy, try this mapping out:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foo = this.foo.number()
 root.bar = this.bar.not_null()
 root.baz = this.baz.not_empty()
+
+# In:  {"foo":5,"bar":"hello world","baz":[1,2,3]}
+# Out: {"foo":5,"bar":"hello world","baz":[1,2,3]}
 ----
 
 With some of these sample inputs:
@@ -429,13 +492,15 @@ However, these methods don't cover all use cases. The general purpose error thro
 
 For example, we can check the type of a field with the xref:guides:bloblang/methods.adoc#type[method `type`], and then throw an error if it's not the type we expected:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foos = if this.user.foos.type() == "array" {
   this.user.foos
 } else {
   throw("foos must be an array, but it ain't, what gives?")
 }
+
+# In:  {"user":{"foos":[1,2,3]}}
 ----
 
 Try this mapping out with a few sample inputs:
@@ -452,34 +517,46 @@ In Bloblang, when we refer to the context we're talking about the value returned
 
 However, in Bloblang there are mechanisms whereby the context might change, we've already seen how this can happen within a `match` expression. Another useful way to change the context is by adding a bracketed query expression as a method to a query, which looks like this:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.foo.bar.(this.baz + this.buz)
+
+# In:  {"foo":{"bar":{"baz":1,"buz":2}}}
+# Out: 3
 ----
 
 Within the bracketed query expression the context becomes the result of the query that it's a method of, so within the brackets in the above mapping the value of `this` points to the result of `this.foo.bar`, and the mapping is therefore equivalent to:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.foo.bar.baz + this.foo.bar.buz
+
+# In:  {"foo":{"bar":{"baz":1,"buz":2}}}
+# Out: 3
 ----
 
 With this handy trick the `throw` mapping from the validation section above could be rewritten as:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.foos = this.user.foos.(if this.type() == "array" { this } else {
   throw("foos must be an array, but it ain't, what gives?")
 })
+
+# In:  {"user":{"foos":[1,2,3]}}
+# Out: {"foos":[1,2,3]}
 ----
 
 === Naming the context
 
 Shadowing the keyword `this` with new contexts can look confusing in your mappings, and it also limits you to only being able to reference one context at any given time. As an alternative, Bloblang supports context capture expressions that look similar to lambda functions from other languages, where you can name the new context with the syntax `+<context name> -> <query>+`, which looks like this:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.foo.bar.(thing -> thing.baz + thing.buz)
+
+# In:  {"foo":{"bar":{"baz":1,"buz":2}}}
+# Out: 3
 ----
 
 Within the brackets we now have a new field `thing`, which returns the context that would have otherwise been captured as `this`. This also means the value returned from `this` hasn't changed and will continue to return the root of the input document.
@@ -504,41 +581,56 @@ To illustrate this problem change the input document to the following:
 
 Let's say we wish to flatten this structure with the following mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.contents = this.thing.article.contents
+
+# In:  {"thing":{"article":{"id":"foo","contents":"Some people did some stuff"}}}
+# Out: {"contents":"Some people did some stuff"}
 ----
 
 But articles are only one of many document types we expect to receive, where the field `contents` remains the same but the field `article` could instead be `comment` or `share`. In this case we could expand our map of `contents` to use a `match` expression where we check for the existence of `article`, `comment`, etc in the input document.
 
 However, a much cleaner way of approaching this is with the pipe operator (`|`), which in Bloblang can be used to join multiple queries, where the first to yield a non-null result is selected. Change your mapping to the following:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.contents = this.thing.article.contents | this.thing.comment.contents
+
+# In:  {"thing":{"article":{"id":"foo","contents":"Some people did some stuff"}}}
+# Out: {"contents":"Some people did some stuff"}
 ----
 
 And now try changing the field `article` in your input document to `comment`. You should see that the value of `contents` remains as `Some people did some stuff` in the output document.
 
 Now, rather than write out the full path prefix `this.thing` each time we can use a bracketed query expression to change the context, giving us more space for adding other fields:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.contents = this.thing.(this.article | this.comment | this.share).contents
+
+# In:  {"thing":{"article":{"id":"foo","contents":"Some people did some stuff"}}}
+# Out: {"contents":"Some people did some stuff"}
 ----
 
 And by the way, the keyword `this` within queries can be omitted and made implicit, which allows us to reduce this even further:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.contents = this.thing.(article | comment | share).contents
+
+# In:  {"thing":{"article":{"id":"foo","contents":"Some people did some stuff"}}}
+# Out: {"contents":"Some people did some stuff"}
 ----
 
 Finally, we can also add a pipe operator at the end to fallback to a literal value when none of our candidates exists:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root.contents = this.thing.(article | comment | share).contents | "nothing"
+
+# In:  {"thing":{"article":{"id":"foo","contents":"Some people did some stuff"}}}
+# Out: {"contents":"Some people did some stuff"}
 ----
 
 Neat.
@@ -580,9 +672,12 @@ Bloblang offers a bunch of advanced methods for xref:guides:bloblang/methods.ado
 
 Let's say we wanted to reduce the `things` in our input document to only those that are cool and where we have enough of them to share with our friends. We can do this with a xref:guides:bloblang/methods.adoc#filter[`filter` method]:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.things.filter(thing -> thing.is_cool && thing.quantity > this.num_friends)
+
+# In:  {"num_friends":5,"things":[{"name":"yo-yo","quantity":10,"is_cool":true},{"name":"dish soap","quantity":50,"is_cool":false},{"name":"scooter","quantity":1,"is_cool":true},{"name":"pirate hat","quantity":7,"is_cool":true}]}
+# Out: [{"name":"yo-yo","quantity":10,"is_cool":true},{"name":"pirate hat","quantity":7,"is_cool":true}]
 ----
 
 Try running that mapping and you'll see that the output is reduced. What is happening here is that the `filter` method takes an argument that is a query, and that query will be mapped for each individual element of the array (where the context is changed to the element itself). We have captured the context into a field `thing` which allows us to continue referencing the root of the input with `this`.
@@ -607,12 +702,15 @@ Another such method is xref:guides:bloblang/methods.adoc#map_each[`map_each`], w
 
 Here we have an array of talking heads, where each element is a string containing an identifer, a colon, and a comma separated list of their opinions. We wish to map each string into a structured object, which we can do with the following mapping:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.talking_heads.map_each(raw -> {
   "id": raw.split(":").index(0),
   "opinions": raw.split(":").index(1).split(",")
 })
+
+# In:  {"talking_heads":["1:E.T. is a bad film,Pokemon corrupted an entire generation","2:Digimon ripped off Pokemon,Cats are boring","3:I'm important","4:Science is just made up,The Pokemon films are good,The weather is good"]}
+# Out: [{"id":"1","opinions":["E.T. is a bad film","Pokemon corrupted an entire generation"]},{"id":"2","opinions":["Digimon ripped off Pokemon","Cats are boring"]},{"id":"3","opinions":["I'm important"]},{"id":"4","opinions":["Science is just made up","The Pokemon films are good","The weather is good"]}]
 ----
 
 The argument to `map_each` is a query where the context is the element, which we capture into the field `raw`. The result of the query argument will become the value of the element in the resulting array, and in this case we return an object literal.
@@ -621,12 +719,15 @@ In order to separate the identifier from opinions we perform a `split` by colon 
 
 However, one problem with this mapping is that the split by colon is written out twice and executed twice. A more efficient way of performing the same thing is with the bracketed query expressions we've played with before:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 root = this.talking_heads.map_each(raw -> raw.split(":").(split_string -> {
   "id": split_string.index(0),
   "opinions": split_string.index(1).split(",")
 }))
+
+# In:  {"talking_heads":["1:E.T. is a bad film,Pokemon corrupted an entire generation","2:Digimon ripped off Pokemon,Cats are boring","3:I'm important","4:Science is just made up,The Pokemon films are good,The weather is good"]}
+# Out: [{"id":"1","opinions":["E.T. is a bad film","Pokemon corrupted an entire generation"]},{"id":"2","opinions":["Digimon ripped off Pokemon","Cats are boring"]},{"id":"3","opinions":["I'm important"]},{"id":"4","opinions":["Science is just made up","The Pokemon films are good","The weather is good"]}]
 ----
 
 [NOTE]
@@ -641,7 +742,7 @@ Cool. To find more methods for manipulating structured data types check out the 
 
 Bloblang has cool methods, sure, but there's nothing cooler than methods you've made yourself. When the going gets tough in the mapping world the best solution is often to create a named mapping, which you can do with the keyword `map`:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map parse_talking_head {
   let split_string = this.split(":")
@@ -651,6 +752,9 @@ map parse_talking_head {
 }
 
 root = this.talking_heads.map_each(raw -> raw.apply("parse_talking_head"))
+
+# In:  {"talking_heads":["1:E.T. is a bad film,Pokemon corrupted an entire generation","2:Digimon ripped off Pokemon,Cats are boring","3:I'm important","4:Science is just made up,The Pokemon films are good,The weather is good"]}
+# Out: [{"id":"1","opinions":["E.T. is a bad film","Pokemon corrupted an entire generation"]},{"id":"2","opinions":["Digimon ripped off Pokemon","Cats are boring"]},{"id":"3","opinions":["I'm important"]},{"id":"4","opinions":["Science is just made up","The Pokemon films are good","The weather is good"]}]
 ----
 
 The body of a named map, encapsulated with squiggly brackets, is a totally isolated mapping where `root` now refers to a new value being created for each invocation of the map, and `this` refers to the root of the context provided to the map.
@@ -661,7 +765,7 @@ As you can see in the above example we were able to use a custom map in order to
 
 A cool feature of named mappings is that they can invoke themselves recursively, allowing you to define mappings that walk deeply nested structures. The following mapping will scrub all values from a document that contain the word "Voldemort" (case insensitive):
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map remove_naughty_man {
   root = match {
@@ -674,6 +778,8 @@ map remove_naughty_man {
 }
 
 root = this.apply("remove_naughty_man")
+
+# In:  {"summer_party":{"theme":"the woman in black","guests":["Emma Bunton","the seal I spotted in Trebarwith","Voldemort","The cast of Swiss Army Man","Richard"],"notes":{"lisa":"I don't think voldemort eats fish","monty":"Seals hate dance music"}},"crushes":["Richard is nice but he hates pokemon","Victoria Beckham but I think she's taken","Charlie but they're totally into Voldemort"]}
 ----
 
 Try running that mapping with the following input document:
@@ -707,7 +813,7 @@ Try running that mapping with the following input document:
 
 Redpanda Connect has it's own xref:configuration:unit_testing.adoc[unit testing capabilities] that you can also use for your mappings. To start with save a mapping into a file called something like `naughty_man.blobl`, we can use the example above from the reusable mappings section:
 
-[source,coffeescript]
+[source,bloblang]
 ----
 map remove_naughty_man {
   root = match {


### PR DESCRIPTION
## Description

Upgrades all Bloblang code blocks to use the new dedicated `bloblang` syntax highlighter and interactive features introduced in [docs-ui v2.12.0](https://github.com/redpanda-data/docs-ui/releases/tag/v2.12.0).

**Changes:**
- Switched 39 Bloblang code blocks from `coffeescript` to `bloblang` language
- Added `# In:` comments with sample input data for interactive Try It feature

**Benefits:**
- Proper Bloblang syntax highlighting
- Hover documentation for functions and methods
- Try It mini-playground button for testing examples in-browser

**Files changed:** 9 files (mapping, mutation, metadata, unit_testing, about, advanced, functions, methods, walkthrough)

## Try it

https://deploy-preview-373--redpanda-connect.netlify.app/redpanda-connect/guides/bloblang/walkthrough/

## Limitations

Hover documentation relies on descriptions being available in the Connect source code. Some functions and methods are missing a description. For example `uppercase()`. In this case, the fallback description is 'Bloblang method'. This will be resolved in a separate task: https://redpandadata.atlassian.net/browse/CON-320

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)