### PR TITLE
Add quick-access links to Claude plugin and Bloblang playground

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,8 @@ nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    toc-tools-title: Connect Tools
+    toc-tools-links: '[{"text": "Bloblang Playground", "url": "guides:bloblang/playground.adoc", "icon": "terminal"}, {"text": "Claude AI Skills", "url": "https://github.com/redpanda-data/connect/blob/main/.claude-plugin/README.md", "icon": "layers", "external": true}]'
     page-header-data:
       order: 3
       color: '#54478C'


### PR DESCRIPTION
## Description

Adds quick links to playground and Claude skills

<img width="396" height="662" alt="2026-02-05_11-20-47" src="https://github.com/user-attachments/assets/55d69fb8-7764-4f61-b58b-2cf230f3a5b5" />


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)