### PR TITLE
Move playground to the top level for easy access

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -368,7 +368,7 @@
 ** xref:guides:bloblang/methods.adoc[Methods]
 ** xref:guides:bloblang/arithmetic.adoc[Arithmetic]
 ** xref:guides:bloblang/advanced.adoc[Advanced]
-** xref:guides:bloblang/playground.adoc[Playground]
+* xref:guides:bloblang/playground.adoc[Playground]
 
 * xref:guides:index.adoc[]
 ** xref:guides:monitoring.adoc[]


### PR DESCRIPTION
## Description

This pull request makes a minor change to the navigation structure in `modules/ROOT/nav.adoc`, adjusting the indentation level of the "Playground" link to make it a primary navigation item rather than a sub-item.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)