### PR TITLE
fix: add GITHUB_TOKEN to connector docs automation

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -194,6 +194,8 @@ jobs:
 
       - name: Generate RPCN Connector docs
         id: generate
+        env:
+          GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
         run: |
           set -e
 


### PR DESCRIPTION
## Problem

Binary analysis in connector docs automation fails with `401 Unauthorized` because GITHUB_TOKEN is not provided:

```
Warning: Binary analysis failed: Failed to fetch latest version: Bad credentials
```

This causes the fallback stripping logic to activate, which removes CGO/cloud metadata from comparisons.

## Solution

Add `GITHUB_TOKEN` environment variable to the connector docs generation step:

```yaml
env:
  GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
```

## Why This Fixes It

Binary analysis needs GITHUB_TOKEN to:
1. Detect latest cloud version from GitHub releases API
2. Download OSS/CGO/cloud binaries from GitHub
3. Compare binaries to find CGO-only and cloud-only connectors

With token: Full analysis succeeds, accurate platform metadata ✅
Without token: Fallback stripping prevents false removals, but loses platform info ⚠️

## Testing

Local test with token (4.85.0 → 4.86.0):
```
✓ Binary analysis: OSS 4.86.0, Cloud 4.86.0
✓ Augmented 301 connectors  
✓ Added 4 CGO-only + 1 cloud-only connectors
✓ 0 removed connectors (no false positives!)
```

## Related

- Depends on: https://github.com/redpanda-data/docs-extensions-and-macros/pull/185
- Fixes false "removed connectors" issue in automated doc updates