### PR TITLE
chore: Add clean and build:clean scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "The Antora playbook project for Redpanda documentation.",
   "license": "ISC",
   "scripts": {
+    "clean": "rm -rf docs .cache",
     "build": "antora --to-dir docs --fetch local-antora-playbook.yml --stacktrace",
+    "build:clean": "npm run clean && npm run build",
     "start": "cross-env-shell LIVERELOAD=true npx gulp",
     "serve": "wds --node-resolve --open / --watch --root-dir docs",
     "test-mcp-examples": "cd modules/ai-agents/examples && ./test-all.sh",


### PR DESCRIPTION
## Summary

- Add `npm run clean` script to remove `docs/` and `.cache/` directories
- Add `npm run build:clean` script that cleans then builds in one command

This prevents the glob-stream stack overflow error that occurs when the `docs/` directory accumulates too many files from previous builds.

## Usage

When you encounter the stack overflow error during build:

```bash
npm run build:clean
```

Or manually clean first:

```bash
npm run clean
npm run build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)