### PR TITLE
Improve drop output docs and add message routing cookbook

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -397,6 +397,7 @@
 ** xref:cookbooks:oracledb_cdc.adoc[]
 ** xref:cookbooks:enrichments.adoc[]
 ** xref:cookbooks:filtering.adoc[]
+** xref:cookbooks:message_routing.adoc[]
 ** xref:cookbooks:jira.adoc[]
 ** xref:cookbooks:joining_streams.adoc[]
 ** xref:cookbooks:snowflake_ingestion.adoc[]

--- a/modules/components/pages/outputs/drop.adoc
+++ b/modules/components/pages/outputs/drop.adoc
@@ -1,8 +1,14 @@
 = drop
 // tag::single-source[]
+:description: Drop output reference for silently discarding messages in Redpanda Connect pipelines.
 :type: output
 :status: stable
 :categories: ["Utility"]
+:page-topic-type: reference
+:personas: streaming_developer, app_developer
+:learning-objective-1: Look up drop output syntax and configuration
+:learning-objective-2: Find examples of drop in conditional routing
+:learning-objective-3: Identify use cases for drop output in pipelines
 
 // © 2024 Redpanda Data Inc.
 
@@ -10,10 +16,90 @@
 component_type_dropdown::[]
 
 
-Drops all messages.
+Silently discards all messages without error or side effects.
 
-```yml
+The `drop` output is a utility component that drops messages from the glossterm:pipeline[]. Unlike filtering or conditional processors that modify or route messages, `drop` consumes messages and does nothing with them. This is useful for:
+
+- *Testing and debugging*: Measure input throughput without output bottlenecks
+- *Conditional workflows*: Discard messages that don't meet certain criteria
+- *Dead letter queue patterns*: Provide a final fallback when all other outputs fail
+- *Development*: Temporarily disable output while testing pipeline logic
+
+Use this reference to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
+
+[,yaml]
+----
 include::components:example$common/outputs/drop.yaml[]
-```
+----
+
+== Performance
+
+The `drop` output has minimal overhead and immediately acknowledges messages. This makes it ideal for performance testing, as it removes output processing time from measurements.
+
+== Examples
+
+=== Conditional filtering
+
+Use `drop` with the xref:components:outputs/switch.adoc[`switch`] output to conditionally discard messages:
+
+[,yaml]
+----
+output:
+  switch:
+    cases:
+      - check: this.type == "error"
+        output:
+          label: error_sink
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: errors
+      - check: this.type == "debug"
+        output:
+          label: drop_debug
+          drop: {}  # Don't process debug messages in production
+      - output:
+          label: main_sink
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: events
+----
+
+=== Dead letter queue pattern
+
+Use `drop` as a last resort in a xref:components:outputs/fallback.adoc[`fallback`] chain:
+
+[,yaml]
+----
+output:
+  fallback:
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: primary_topic
+        max_in_flight: 1
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: dlq_topic
+    - drop: {}  # Last resort: drop if both outputs fail
+----
+
+=== Testing input throughput
+
+Measure how fast your input can consume data without output bottlenecks:
+
+[,yaml]
+----
+input:
+  kafka:
+    addresses: ["kafka:9092"]
+    topics: ["test"]
+output:
+  drop: {}  # Measure input consumption speed without output overhead
+----
+
+For more patterns on message routing, filtering, and when to use `drop` vs. other approaches, see the xref:cookbooks:message_routing.adoc[Message Routing Patterns] cookbook.
 
 // end::single-source[]

--- a/modules/cookbooks/pages/message_routing.adoc
+++ b/modules/cookbooks/pages/message_routing.adoc
@@ -1,10 +1,11 @@
 = Message Routing Patterns
+// tag::single-source[]
 :description: Learn how to route, filter, and discard messages in Redpanda Connect pipelines.
 :page-topic-type: cookbook
 :personas: streaming_developer, app_developer
-:learning-objective-1: Find reusable patterns for message routing and filtering
-:learning-objective-2: Look up conditional routing patterns using switch and broker outputs
-:learning-objective-3: Identify dead letter queue patterns with fallback outputs
+:learning-objective-1: Implement message routing and filtering patterns in pipelines
+:learning-objective-2: Configure conditional routing using switch and broker outputs
+:learning-objective-3: Build dead letter queue patterns with fallback outputs
 
 This cookbook demonstrates common patterns for routing and filtering messages in Redpanda Connect glossterm:pipeline[,pipelines].
 
@@ -16,7 +17,7 @@ Use this cookbook to:
 
 == Discarding messages
 
-There are two primary ways to discard messages in Redpanda Connect: using the xref:components:outputs/drop.adoc[`drop` output] or the xref:guides:bloblang/walkthrough.adoc#deleting-messages[`deleted()`] function in a xref:components:processors/mapping.adoc[`mapping` processor].
+There are two primary ways to discard messages in Redpanda Connect: using the xref:components:outputs/drop.adoc[`drop` output] or the xref:guides:bloblang/walkthrough.adoc#deletions[`deleted()`] function in a xref:components:processors/mapping.adoc[`mapping` processor].
 
 === Using `deleted()` in mapping
 
@@ -112,7 +113,7 @@ output:
           drop: {}  # Don't store debug logs in production
 ----
 
-Each output can be labeled for monitoring and observability.
+You can label each output for monitoring and observability.
 
 == Error handling with fallback
 
@@ -193,10 +194,11 @@ output:
 ----
 
 This configuration:
-1. Tries to write to Kafka with batching
-2. Falls back to an HTTP service with retries
-3. Falls back to a DLQ topic
-4. Ultimately drops messages if all else fails
+
+. Tries to write to Kafka with batching
+. Falls back to an HTTP service with retries
+. Falls back to a DLQ topic
+. Ultimately drops messages if all else fails
 
 == Routing with broker
 
@@ -326,7 +328,7 @@ output:
 - **`broker`**: Sends to multiple outputs in parallel
 - **`fallback`**: Tries outputs sequentially until one succeeds
 
-Choose based on your delivery requirements and performance needs.
+Choose between these output types based on whether you need single-destination routing (`switch`), multi-destination fan-out (`broker`), or fallback behavior (`fallback`).
 
 == Testing and debugging
 
@@ -354,3 +356,4 @@ This reveals the maximum speed your input can consume data, isolated from output
 - xref:components:outputs/broker.adoc[broker output] - Fan-out patterns reference
 - xref:components:outputs/drop.adoc[drop output] - Drop output reference
 - xref:components:processors/mapping.adoc[mapping processor] - Bloblang mapping reference
+// end::single-source[]

--- a/modules/cookbooks/pages/message_routing.adoc
+++ b/modules/cookbooks/pages/message_routing.adoc
@@ -324,11 +324,11 @@ output:
 
 === Output parallelism
 
+Choose between these output types based on whether you need single-destination routing, multi-destination fan-out, or fallback behavior:
+
 - **`switch`**: Sends to one output (sequential evaluation)
 - **`broker`**: Sends to multiple outputs in parallel
 - **`fallback`**: Tries outputs sequentially until one succeeds
-
-Choose between these output types based on whether you need single-destination routing (`switch`), multi-destination fan-out (`broker`), or fallback behavior (`fallback`).
 
 == Testing and debugging
 

--- a/modules/cookbooks/pages/message_routing.adoc
+++ b/modules/cookbooks/pages/message_routing.adoc
@@ -289,7 +289,7 @@ pipeline:
   processors:
     - mapping: |
         root = if this.debug { deleted() }
-    - other_processor: {}  # Doesn't process debug messages
+    - log: {}  # Doesn't process debug messages
 
 output:
   kafka:
@@ -306,7 +306,7 @@ pipeline:
   processors:
     - mapping: |
         root.enriched = true
-    - other_processor: {}  # Processes all messages
+    - log: {}  # Processes all messages
 
 output:
   switch:

--- a/modules/cookbooks/pages/message_routing.adoc
+++ b/modules/cookbooks/pages/message_routing.adoc
@@ -212,10 +212,11 @@ output:
           addresses: ["kafka:9092"]
           topic: events
 
-      - elasticsearch:
+      - elasticsearch_v8:
           urls: ["http://localhost:9200"]
           index: events
           id: ${!json("id")}
+          action: index
 
       - http_client:
           url: https://metrics.example.com/ingest

--- a/modules/cookbooks/pages/message_routing.adoc
+++ b/modules/cookbooks/pages/message_routing.adoc
@@ -1,0 +1,355 @@
+= Message Routing Patterns
+:description: Learn how to route, filter, and discard messages in Redpanda Connect pipelines.
+:page-topic-type: cookbook
+:personas: streaming_developer, app_developer
+:learning-objective-1: Find reusable patterns for message routing and filtering
+:learning-objective-2: Look up conditional routing patterns using switch and broker outputs
+:learning-objective-3: Identify dead letter queue patterns with fallback outputs
+
+This cookbook demonstrates common patterns for routing and filtering messages in Redpanda Connect glossterm:pipeline[,pipelines].
+
+Use this cookbook to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
+
+== Discarding messages
+
+There are two primary ways to discard messages in Redpanda Connect: using the xref:components:outputs/drop.adoc[`drop` output] or the xref:guides:bloblang/walkthrough.adoc#deleting-messages[`deleted()`] function in a xref:components:processors/mapping.adoc[`mapping` processor].
+
+=== Using `deleted()` in mapping
+
+Use `deleted()` to filter messages early in the pipeline, before they reach the output stage. This is more efficient when you don't need conditional output routing:
+
+[,yaml]
+----
+input:
+  kafka:
+    addresses: ["kafka:9092"]
+    topics: ["events"]
+
+pipeline:
+  processors:
+    - mapping: |
+        # Delete debug messages early in the pipeline
+        root = if this.type == "debug" { deleted() }
+
+output:
+  kafka:
+    addresses: ["kafka:9092"]
+    topic: production_events
+----
+
+For more filtering patterns with `deleted()`, see the xref:cookbooks:filtering.adoc[Filtering and Sampling] cookbook.
+
+=== Using `drop` output
+
+Use the xref:components:outputs/drop.adoc[`drop` output] to discard messages at the output stage, typically in conditional routing or as a fallback. This is useful when you're routing different message types to different destinations:
+
+[,yaml]
+----
+output:
+  switch:
+    cases:
+      - check: this.type == "error"
+        output:
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: errors
+      - check: this.type == "debug"
+        output:
+          drop: {}  # Discard debug messages
+      - output:
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: events
+----
+
+The `drop` output has minimal overhead and immediately acknowledges messages, making it ideal for this use case.
+
+== Conditional routing with switch
+
+The xref:components:outputs/switch.adoc[`switch` output] routes messages to different outputs based on conditions. Each case is evaluated in order until a match is found:
+
+[,yaml]
+----
+output:
+  switch:
+    cases:
+      - check: this.severity == "critical"
+        output:
+          label: pagerduty_alerts
+          http_client:
+            url: https://events.pagerduty.com/v2/enqueue
+            verb: POST
+
+      - check: this.severity == "error"
+        output:
+          label: error_topic
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: errors
+            max_in_flight: 1
+
+      - check: this.severity == "warn"
+        output:
+          label: warning_topic
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: warnings
+
+      - check: this.severity == "info"
+        output:
+          label: info_topic
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: info
+
+      - check: this.severity == "debug"
+        output:
+          label: drop_debug
+          drop: {}  # Don't store debug logs in production
+----
+
+Each output can be labeled for monitoring and observability.
+
+== Error handling with fallback
+
+The xref:components:outputs/fallback.adoc[`fallback` output] tries outputs in sequence. If an output fails, it moves to the next one. This is useful for implementing dead letter queue (DLQ) patterns:
+
+=== Basic DLQ pattern
+
+[,yaml]
+----
+output:
+  fallback:
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: primary_topic
+        max_in_flight: 1
+
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: dlq_topic
+----
+
+If writing to `primary_topic` fails, the message is sent to `dlq_topic` instead.
+
+=== DLQ with ultimate fallback
+
+Add a xref:components:outputs/drop.adoc[`drop` output] as the final fallback to prevent pipeline failures:
+
+[,yaml]
+----
+output:
+  fallback:
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: primary_topic
+        max_in_flight: 1
+
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: dlq_topic
+
+    - drop: {}  # Last resort: drop if both outputs fail
+----
+
+This ensures messages don't cause the pipeline to block, even if both Kafka outputs fail.
+
+=== Multi-tier fallback with retries
+
+Combine fallback with retry configuration for more sophisticated error handling:
+
+[,yaml]
+----
+output:
+  fallback:
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: primary_topic
+        max_in_flight: 10
+        batching:
+          count: 100
+          period: 1s
+
+    - retry:
+        max_retries: 3
+        backoff:
+          initial_interval: 1s
+          max_interval: 10s
+        output:
+          http_client:
+            url: https://backup-service.example.com/events
+            verb: POST
+            max_in_flight: 5
+
+    - kafka:
+        addresses: ["kafka:9092"]
+        topic: dlq_topic
+
+    - drop: {}
+----
+
+This configuration:
+1. Tries to write to Kafka with batching
+2. Falls back to an HTTP service with retries
+3. Falls back to a DLQ topic
+4. Ultimately drops messages if all else fails
+
+== Routing with broker
+
+The xref:components:outputs/broker.adoc[`broker` output] sends messages to multiple outputs simultaneously. Unlike `switch`, all outputs receive every message:
+
+[,yaml]
+----
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - kafka:
+          addresses: ["kafka:9092"]
+          topic: events
+
+      - elasticsearch:
+          urls: ["http://localhost:9200"]
+          index: events
+          id: ${!json("id")}
+
+      - http_client:
+          url: https://metrics.example.com/ingest
+          verb: POST
+----
+
+This sends each message to Kafka, Elasticsearch, and an HTTP endpoint in parallel.
+
+== Combining patterns
+
+You can combine these patterns for sophisticated routing logic:
+
+[,yaml]
+----
+output:
+  switch:
+    cases:
+      # Critical events: send to multiple destinations
+      - check: this.severity == "critical"
+        output:
+          broker:
+            pattern: fan_out
+            outputs:
+              - kafka:
+                  addresses: ["kafka:9092"]
+                  topic: critical_events
+              - http_client:
+                  url: https://pagerduty.example.com/alert
+                  verb: POST
+
+      # Errors: send to Kafka with DLQ fallback
+      - check: this.severity == "error"
+        output:
+          fallback:
+            - kafka:
+                addresses: ["kafka:9092"]
+                topic: errors
+            - kafka:
+                addresses: ["kafka:9092"]
+                topic: dlq
+
+      # Info: send to Kafka only
+      - check: this.severity == "info"
+        output:
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: info
+
+      # Debug: drop in production
+      - check: this.severity == "debug"
+        output:
+          drop: {}
+----
+
+== Performance considerations
+
+When choosing between routing approaches, consider:
+
+=== Filtering with `deleted()` vs. `drop` output
+
+- **`deleted()` in mapping**: Filters messages earlier in the pipeline, reducing downstream processing
+- **`drop` output**: Filters at output stage, useful for conditional routing but messages still flow through processors
+
+For pure filtering without routing, use `deleted()`:
+
+[,yaml]
+----
+# More efficient - filters early
+pipeline:
+  processors:
+    - mapping: |
+        root = if this.debug { deleted() }
+    - other_processor: {}  # Doesn't process debug messages
+
+output:
+  kafka:
+    addresses: ["kafka:9092"]
+    topic: events
+----
+
+For conditional routing, use `drop` output:
+
+[,yaml]
+----
+# Better for routing - processes all messages, routes selectively
+pipeline:
+  processors:
+    - mapping: |
+        root.enriched = true
+    - other_processor: {}  # Processes all messages
+
+output:
+  switch:
+    cases:
+      - check: this.important
+        output:
+          kafka:
+            addresses: ["kafka:9092"]
+            topic: important
+      - output:
+          drop: {}  # Discard non-important messages
+----
+
+=== Output parallelism
+
+- **`switch`**: Sends to one output (sequential evaluation)
+- **`broker`**: Sends to multiple outputs in parallel
+- **`fallback`**: Tries outputs sequentially until one succeeds
+
+Choose based on your delivery requirements and performance needs.
+
+== Testing and debugging
+
+Use xref:components:outputs/drop.adoc[`drop`] to test input throughput without output bottlenecks:
+
+[,yaml]
+----
+input:
+  kafka:
+    addresses: ["kafka:9092"]
+    topics: ["test"]
+    consumer_group: throughput_test
+
+output:
+  drop: {}  # Measure input consumption speed
+----
+
+This reveals the maximum speed your input can consume data, isolated from output performance.
+
+== Next steps
+
+- xref:cookbooks:filtering.adoc[Filtering and Sampling] - More patterns for using `deleted()`
+- xref:components:outputs/switch.adoc[switch output] - Conditional routing reference
+- xref:components:outputs/fallback.adoc[fallback output] - Error handling reference
+- xref:components:outputs/broker.adoc[broker output] - Fan-out patterns reference
+- xref:components:outputs/drop.adoc[drop output] - Drop output reference
+- xref:components:processors/mapping.adoc[mapping processor] - Bloblang mapping reference


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/DOC-2078

## Problem

The drop output reference page was getting negative feedback from users. It only had a one-line description and a basic config example. Users couldn't figure out when to use drop vs other filtering approaches, and there were no practical examples showing real-world patterns.

## What changed

### Enhanced drop output reference
- Added clear description of what drop does and when to use it
- Added three practical examples: conditional filtering with switch, DLQ patterns with fallback, and performance testing
- Added proper metadata (learning objectives, personas, topic type)
- Fixed code block formatting to use AsciiDoc style
- Linked to new message routing cookbook for deeper patterns

### New message routing patterns cookbook
Created a comprehensive cookbook covering:
- When to use drop output vs deleted() in mapping
- Conditional routing with switch output
- Error handling and DLQ patterns with fallback
- Fan-out patterns with broker output
- Performance considerations for different approaches
- Testing and debugging techniques

## Why a cookbook?

Rather than cramming all the routing patterns into the drop reference, I created a dedicated cookbook that can be linked from drop, switch, fallback, and other related pages. This gives users a single place to learn about routing patterns and makes the reference docs cleaner.

## Testing

- [x] Builds locally without errors
- [x] Learning objectives display correctly
- [x] All xrefs resolve properly
- [x] Code examples are complete and valid
- [x] Follows docs team standards (metadata, formatting, glossary terms)