### PR TITLE
add missing brackets to prometheus common

### DIFF
--- a/modules/components/examples/common/metrics/prometheus.yaml
+++ b/modules/components/examples/common/metrics/prometheus.yaml
@@ -1,2 +1,2 @@
 metrics:
-  prometheus:
+  prometheus: {}


### PR DESCRIPTION
## Description

Small fix to add missing brackets to prometheus common example

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)