### PR TITLE
Qualify cookbook xrefs with redpanda-connect component

### DIFF
--- a/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
+++ b/modules/components/pages/inputs/aws_dynamodb_cdc.adoc
@@ -145,5 +145,5 @@ include::redpanda-connect:components:partial$examples/inputs/aws_dynamodb_cdc.ad
 
 == Suggested reading
 
-For common patterns including filtering events, routing to Kafka or S3, and detecting changed fields, see the xref:cookbooks:dynamodb_cdc.adoc[DynamoDB CDC Patterns] cookbook.
+For common patterns including filtering events, routing to Kafka or S3, and detecting changed fields, see the xref:redpanda-connect:cookbooks:dynamodb_cdc.adoc[DynamoDB CDC Patterns] cookbook.
 // end::single-source[]

--- a/modules/components/pages/outputs/drop.adoc
+++ b/modules/components/pages/outputs/drop.adoc
@@ -100,6 +100,6 @@ output:
   drop: {}  # Measure input consumption speed without output overhead
 ----
 
-For more patterns on message routing, filtering, and when to use `drop` vs. other approaches, see the xref:cookbooks:message_routing.adoc[Message Routing Patterns] cookbook.
+For more patterns on message routing, filtering, and when to use `drop` vs. other approaches, see the xref:redpanda-connect:cookbooks:message_routing.adoc[Message Routing Patterns] cookbook.
 
 // end::single-source[]


### PR DESCRIPTION
## Summary

- The `drop` output and `aws_dynamodb_cdc` input pages are single-sourced into cloud-docs via `include::redpanda-connect:...[tag=single-source]`.
- Inside those include regions, the cookbook links were written as `xref:cookbooks:...adoc[]` (two coordinates).
- When rendered as part of the `redpanda-cloud` component, Antora looks for a `cookbooks` module in `redpanda-cloud` (doesn't exist) and fails with `target of xref not found: cookbooks:message_routing.adoc`. Same issue hidden behind `cookbooks:dynamodb_cdc.adoc`.
- Fix: fully qualify both xrefs with the `redpanda-connect:` component prefix so they resolve the same way in both components.

The `snowflake_streaming.adoc` file has a similar cookbook xref, but it's already gated behind `ifndef::env-cloud[]` so it's excluded from cloud builds — left unchanged.

## Preview pages

- [aws_dynamodb_cdc](https://deploy-preview-417--redpanda-connect.netlify.app/redpanda-connect/components/inputs/aws_dynamodb_cdc/) (updated)
- [drop](https://deploy-preview-417--redpanda-connect.netlify.app/redpanda-connect/components/outputs/drop/) (updated)

## Test plan

- [x] `npm run build` in `rp-connect-docs` — clean, no xref errors
- [x] `npm run build` in `cloud-docs` (with playbook temporarily pointed at this branch's content) — clean
- [x] `npm run build` in `docs` (same) — clean
- [ ] Verify on Netlify deploy preview that the `drop` and `aws_dynamodb_cdc` pages link correctly to the cookbook pages in both the `redpanda-connect` and `redpanda-cloud` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)